### PR TITLE
kustomize : YAML -> JSON conversion issue

### DIFF
--- a/library/general/containerresourceratios/template.yaml
+++ b/library/general/containerresourceratios/template.yaml
@@ -13,7 +13,8 @@ spec:
             ratio:
               type: string
   targets:
-    - rego: |
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
         package k8scontainerratios
 
         missing(obj, field) = true {
@@ -244,5 +245,4 @@ spec:
           mem_ratio := input.parameters.ratio
           to_number(mem_limits) > to_number(mem_ratio) * to_number(mem_requests)
           msg := sprintf("container <%v> memory limit <%v> is higher than the maximum allowed ratio of <%v>", [container.name, mem_limits_orig, mem_ratio])
-    }
-  target: admission.k8s.gatekeeper.sh
+        }


### PR DESCRIPTION
**Line 246 - misaligned `}`**

```
resources: accumulateFile \\\"accumulating resources from 'template.yaml': YAML file [template.yaml] encounters a format error.\\\\nerror converting YAML to JSON: yaml: line 246:
```

**Formatting issue**
```
Error from server (failed to validate targets for template k8scontainerratios: target  not recognized): error when creating "STDIN": admission webhook "validation.gatekeeper.sh" denied the request: failed to validate targets for template k8scontainerratios: target  not recognized
```

**What this PR does / why we need it**:
 - Fixes the parsing issue

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes # 
- Fixed the misaligned `}`

**Special notes for your reviewer**: