### PR TITLE
Update template.yaml

### DIFF
--- a/library/general/containerresourceratios/template.yaml
+++ b/library/general/containerresourceratios/template.yaml
@@ -11,7 +11,7 @@ spec:
         openAPIV3Schema:
           properties:
             ratio:
-              type: string
+              type: integer
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |


### PR DESCRIPTION
Fix type of ratio: from string to integer

fix error:
`The K8sContainerRatios "container-must-meet-ratio" is invalid: spec.parameters.ratio: Invalid value: "integer": spec.parameters.ratio in body must be of type string: "integer"`