### PR TITLE
Adding GatewayClass namespaces validation

### DIFF
--- a/library/general/gatewayclassnamespaces/constraint.yaml
+++ b/library/general/gatewayclassnamespaces/constraint.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GatewayClassNamespaces
+metadata:
+  name: gatewayclassnamespaces
+spec:
+  match:
+    kinds:
+      - apiGroups: ["networking.x-k8s.io"]
+        kinds: ["Gateway"]
+  parameters:
+    gatewayClasses:
+      - name: external-lb
+        namespaces:
+        - prod

--- a/library/general/gatewayclassnamespaces/example.yaml
+++ b/library/general/gatewayclassnamespaces/example.yaml
@@ -1,0 +1,16 @@
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: prod-gateway
+spec:
+  gatewayClassName: prod-lb
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        selector:
+          matchLabels:
+            env: prod
+        namespaces:
+          from: "All"

--- a/library/general/gatewayclassnamespaces/kustomization.yaml
+++ b/library/general/gatewayclassnamespaces/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/gatewayclassnamespaces/src.rego
+++ b/library/general/gatewayclassnamespaces/src.rego
@@ -1,0 +1,24 @@
+package gatewayclassnamespaces
+
+has_key(x, k) {
+  _ = x[k]
+}
+
+list_has(namespaces, namespace) {
+  namespaces[_] = namespace
+}
+
+ns_allowed(params, gatewayClassName, namespace) {
+  params.gatewayClasses[i].name == gatewayClassName
+  list_has(params.gatewayClasses[i].namespaces, namespace)
+}
+
+violation[{"msg": msg}] {
+  input.review.kind.kind == "Gateway"
+  input.review.kind.group == "networking.x-k8s.io"
+  ns := input.review.namespace
+  gcName := input.review.object.spec.gatewayClassName
+  satisfied := [good | has_key(input.parameters, "gatewayClasses") ; good = ns_allowed(input.parameters, gcName, ns)]
+  not any(satisfied)  
+  msg := sprintf("Can not use %v GatewayClass in %v", [gcName, ns])
+}

--- a/library/general/gatewayclassnamespaces/src_test.rego
+++ b/library/general/gatewayclassnamespaces/src_test.rego
@@ -1,0 +1,54 @@
+package gatewayclassnamespaces
+
+test_no_data {
+    input := {"review": review(gateway("my-gateway", "prod", "external-lb"))}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_valid {
+    input := {
+      "review": review(gateway("my-gateway", "prod", "external-lb")), 
+      "parameters": {"gatewayClasses": [{"name": "external-lb", "namespaces": ["prod"]}]}
+    }
+    trace(sprintf("Test: %v", [json.marshal(input)]))
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_no_allowed_namespaces {
+    input := {
+      "review": review(gateway("my-gateway", "prod", "external-lb")), 
+      "parameters": {"gatewayClasses": [{"name": "external-lb", "namespaces": []}]}
+    }
+    results := violation with input as input
+    count(results) == 1
+}
+
+
+review(gw) = output {
+  output = {
+    "kind": {
+      "kind": "Gateway",
+      "version": "v1alpha1",
+      "group": "networking.x-k8s.io",
+    },
+    "namespace": gw.metadata.namespace,
+    "name": gw.metadata.name,
+    "object": gw,
+  }
+}
+
+gateway(name, ns, gcName) = out {
+  out = {
+    "kind": "Gateway",
+    "apiVersion": "networking.x-k8s.io/v1alpha1",
+    "metadata": {
+      "name": name,
+      "namespace": ns,
+    },
+    "spec": {
+      "gatewayClassName": gcName,
+    },
+  }
+}

--- a/library/general/gatewayclassnamespaces/template.yaml
+++ b/library/general/gatewayclassnamespaces/template.yaml
@@ -1,0 +1,56 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: gatewayclassnamespaces
+spec:
+  crd:
+    spec:
+      names:
+        kind: GatewayClassNamespaces
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            gatewayClasses:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    maxLength: 253
+                    minLength: 1
+                  namespaces:
+                    type: array
+                    items:
+                      type: string
+                required:
+                - value
+                - namespaces
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package gatewayclassnamespaces
+
+        has_key(x, k) {
+          _ = x[k]
+        }
+
+        list_has(namespaces, namespace) {
+          namespaces[_] = namespace
+        }
+
+        ns_allowed(params, gatewayClassName, namespace) {
+          has_key(params.gatewayClassNamespaces, gatewayClassName)
+          list_has(params.gatewayClassNamespaces[gatewayClassName], namespace)
+        }
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Gateway"
+          input.review.kind.group == "networking.x-k8s.io"
+          ns := input.review.namespace
+          gcName := input.review.object.spec.gatewayClassName
+          satisfied := [good | has_key(input.parameters, "gatewayClassNamespaces") ; good = ns_allowed(input.parameters, gcName, ns)]
+          not any(satisfied)  
+          msg := sprintf("Can not use %v GatewayClass in %v", [gcName, ns])
+        }


### PR DESCRIPTION
We're working on the [next generation of Kubernetes Service APIs](https://github.com/kubernetes-sigs/service-apis) as part of Kubernetes sig-network. We wanted to provide a way for admins to restrict where certain classes of Gateways can be used (ie an external LB should only be created in prod namespaces). We [evaluated a lot of different options here](https://docs.google.com/document/d/1OmtEiT97i2_rwayiw0G2tW9GX9-BYhiwhVruicWertQ/edit), but we've settled on using policy agents like OPA + Gatekeeper for our initial alpha release. 

I'm not actually sure if you're open to community contributions yet, but wanted to start a conversation here. This example could certainly live in our repo, I just wanted to check in with maintainers here to see if it would also make sense in this library. Do you have any plans for something like the experimental directory that existed in helm/charts?