### PR TITLE
add testing

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,22 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        opa: ["v0.24.0"]
+    name: ${{ matrix.os }} opa ${{ matrix.opa }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+        binary=$([[ "$OSTYPE" == "darwin"* ]] && echo "opa_darwin_amd64" || echo "opa_linux_amd64")
+        sudo curl -L -o /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/download/${{ matrix.opa }}/$binary
+        sudo chmod +x /usr/local/bin/opa
+        sh test.sh
+

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -15,8 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-        binary=$([[ "$OSTYPE" == "darwin"* ]] && echo "opa_darwin_amd64" || echo "opa_linux_amd64")
-        sudo curl -L -o /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/download/${{ matrix.opa }}/$binary
-        sudo chmod +x /usr/local/bin/opa
-        sh test.sh
-
+          binary=$([[ "$OSTYPE" == "darwin"* ]] && echo "opa_darwin_amd64" || echo "opa_linux_amd64")
+          sudo curl -L -o /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/download/${{ matrix.opa }}/$binary
+          sudo chmod +x /usr/local/bin/opa
+          sh test.sh

--- a/README.md
+++ b/README.md
@@ -14,7 +14,17 @@ For example
 
 ## How to contribute to the library
 
-If you have a policy you would like to contribute to the library, please feel free to submit a pull request. Each new policy contribution should contain the following:
+### New policy
+
+If you have a policy you would like to contribute, please submit a pull request.
+Each new policy should contain:
 * A constraint template with a `description` annotation and the parameter structure, if any, defined in `spec.crd.spec.validation.openAPIV3Schema`
 * One or more sample constraints, each with an example of an allowed (`example_allowed.yaml`) and disallowed (`example_disallowed.yaml`) resource.
 * The rego source, as `src.rego` and unit tests as `src_test.rego` in the corresponding subdirectory under `src/`
+
+### Development
+
+* policy code and tests are maintained in `src/` folder and then manually copied into `library/`
+* run all tests with `./test.sh`
+* run single test with `opa test src/<folder>/src.rego src/<folder>/src_test.rego --verbose`
+* print results with `trace(sprintf("%v", [thing]))`

--- a/library/general/httpsonly/template.yaml
+++ b/library/general/httpsonly/template.yaml
@@ -16,8 +16,8 @@ spec:
         package k8shttpsonly
 
         violation[{"msg": msg}] {
-          input.review.kind.kind == "Ingress"
-          re_match("^(extensions|networking.k8s.io)$", input.review.kind.group)
+          input.review.object.kind == "Ingress"
+          re_match("^(extensions|networking.k8s.io)/", input.review.object.apiVersion)
           ingress := input.review.object
           not https_complete(ingress)
           msg := sprintf("Ingress should be https. tls configuration and allow-http=false annotation are required for %v", [ingress.metadata.name])

--- a/src/general/httpsonly/src.rego
+++ b/src/general/httpsonly/src.rego
@@ -1,8 +1,8 @@
 package k8shttpsonly
 
 violation[{"msg": msg}] {
-  input.review.kind.kind == "Ingress"
-  re_match("^(extensions|networking.k8s.io)$", input.review.kind.group)
+  input.review.object.kind == "Ingress"
+  re_match("^(extensions|networking.k8s.io)/", input.review.object.apiVersion)
   ingress := input.review.object
   not https_complete(ingress)
   msg := sprintf("Ingress should be https. tls configuration and allow-http=false annotation are required for %v", [ingress.metadata.name])

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+for folder in src/*/*
+do
+  src=$folder/src.rego
+  test=$folder/src_test.rego
+  # TODO: enforce coverage
+  # needs https://github.com/open-policy-agent/opa/issues/2562 to see what was not covered
+  # needs https://github.com/open-policy-agent/opa/issues/2139 to see verbose output when using coverage
+  echo "opa test $src $test"
+  opa test $src $test
+done


### PR DESCRIPTION
replaces https://github.com/open-policy-agent/gatekeeper/pull/821

needs https://github.com/open-policy-agent/opa/issues/2562 + https://github.com/open-policy-agent/opa/issues/2139 for nice coverage enforcement (or we can hack it ... I got the code already, but it's in ruby)