### PR TITLE
improvement: enhance selinux policy to account for context rules

### DIFF
--- a/library/pod-security-policy/selinux/samples/psp-selinux-v2/constraint.yaml
+++ b/library/pod-security-policy/selinux/samples/psp-selinux-v2/constraint.yaml
@@ -8,6 +8,7 @@ spec:
       - apiGroups: [""]
         kinds: ["Pod"]
   parameters:
+    seLinuxContext: MustRunAs
     allowedSELinuxOptions:
       - level: s0:c123,c456
         role: object_r

--- a/library/pod-security-policy/selinux/template.yaml
+++ b/library/pod-security-policy/selinux/template.yaml
@@ -73,7 +73,7 @@ spec:
             object[field]
         }
 
-        accept_context(rule, context) = true {
+        accept_context(rule, context) = false {
           rule == "RunAsAny"
         }
 

--- a/library/pod-security-policy/selinux/template.yaml
+++ b/library/pod-security-policy/selinux/template.yaml
@@ -11,6 +11,9 @@ spec:
         # Schema for the `parameters` field
         openAPIV3Schema:
           properties:
+            seLinuxContext:
+              type: string
+              enum: [RunAsAny, MustRunAs]
             allowedSELinuxOptions:
               type: array
               items:
@@ -31,15 +34,13 @@ spec:
 
         # Disallow top level custom SELinux options
         violation[{"msg": msg, "details": {}}] {
-            has_field(input.review.object.spec.securityContext, "seLinuxOptions")
-            not input_seLinuxOptions_allowed(input.review.object.spec.securityContext.seLinuxOptions)
+            accept_context(input.parameters.seLinuxContext, input.review.object.spec.securityContext)
             msg := sprintf("SELinux options is not allowed, pod: %v. Allowed options: %v", [input.review.object.metadata.name, input.parameters.allowedSELinuxOptions])
         }
         # Disallow container level custom SELinux options
         violation[{"msg": msg, "details": {}}] {
             c := input_security_context[_]
-            has_field(c.securityContext, "seLinuxOptions")
-            not input_seLinuxOptions_allowed(c.securityContext.seLinuxOptions)
+            accept_context(input.parameters.seLinuxContext, c.securityContext)
             msg := sprintf("SELinux options is not allowed, pod: %v, container %v. Allowed options: %v", [input.review.object.metadata.name, c.name, input.parameters.allowedSELinuxOptions])
         }
 
@@ -70,4 +71,14 @@ spec:
         # has_field returns whether an object has a field
         has_field(object, field) = true {
             object[field]
+        }
+
+        accept_context(rule, context) = true {
+          rule == "RunAsAny"
+        }
+
+        accept_context(rule, context) = true {
+          rule == "MustRunAs"
+          has_field(context, "seLinuxOptions")
+          not input_seLinuxOptions_allowed(context.seLinuxOptions)
         }

--- a/src/pod-security-policy/selinux/src.rego
+++ b/src/pod-security-policy/selinux/src.rego
@@ -2,17 +2,13 @@ package k8spspselinux
 
 # Disallow top level custom SELinux options
 violation[{"msg": msg, "details": {}}] {
-    # has_field(input.review.object.spec.securityContext, "seLinuxOptions")
     accept_context(input.parameters.seLinuxContext, input.review.object.spec.securityContext)
-    # not input_seLinuxOptions_allowed(input.review.object.spec.securityContext.seLinuxOptions)
     msg := sprintf("SELinux options is not allowed, pod: %v. Allowed options: %v", [input.review.object.metadata.name, input.parameters.allowedSELinuxOptions])
 }
 # Disallow container level custom SELinux options
 violation[{"msg": msg, "details": {}}] {
     c := input_security_context[_]
-    # has_field(c.securityContext, "seLinuxOptions")
     accept_context(input.parameters.seLinuxContext, c.securityContext)
-    # not input_seLinuxOptions_allowed(c.securityContext.seLinuxOptions)
     msg := sprintf("SELinux options is not allowed, pod: %v, container %v. Allowed options: %v", [input.review.object.metadata.name, c.name, input.parameters.allowedSELinuxOptions])
 }
 
@@ -45,7 +41,7 @@ has_field(object, field) = true {
     object[field]
 }
 
-accept_context(rule, context) = true {
+accept_context(rule, context) = false {
   rule == "RunAsAny"
 }
 

--- a/src/pod-security-policy/selinux/src_test.rego
+++ b/src/pod-security-policy/selinux/src_test.rego
@@ -246,6 +246,7 @@ input_seLinuxOptions_subset = {
 }
 
 input_parameters_in_list = {
+    "seLinuxContext": "MustRunAs",
     "allowedSELinuxOptions": [{
         "level": "s0:c123,c456",
         "role": "object_r",
@@ -255,6 +256,7 @@ input_parameters_in_list = {
 }
 
 input_parameters_in_list_split_two = {
+    "seLinuxContext": "MustRunAs",
     "allowedSELinuxOptions": [{
         "level": "s0:c123,c456",
         "role": "object_r",
@@ -269,6 +271,7 @@ input_parameters_in_list_split_two = {
 }
 
 input_parameters_in_list_split_subset = {
+    "seLinuxContext": "MustRunAs",
     "allowedSELinuxOptions": [{
         "level": "s0:c123,c456",
         "role": "object_r"
@@ -279,6 +282,7 @@ input_parameters_in_list_split_subset = {
 }
 
 input_parameters_in_list_subset = {
+    "seLinuxContext": "MustRunAs",
     "allowedSELinuxOptions": [{
         "level": "s0:c123,c456",
         "role": "object_r"
@@ -286,6 +290,7 @@ input_parameters_in_list_subset = {
 }
 
 input_parameters_not_in_list = {
+    "seLinuxContext": "MustRunAs",
     "allowedSELinuxOptions": [{
         "level": "s1:c234,c567",
         "role": "sysadm_r",
@@ -296,6 +301,7 @@ input_parameters_not_in_list = {
 
 
 input_parameters_not_in_list_two = {
+    "seLinuxContext": "MustRunAs",
     "allowedSELinuxOptions": [{
         "level": "s1:c234,c567"
     }, {
@@ -304,5 +310,6 @@ input_parameters_not_in_list_two = {
 }
 
 input_parameters_empty = {
+    "seLinuxContext": "MustRunAs",
     "allowedSELinuxOptions": []
 }


### PR DESCRIPTION
This PR addresses the changes proposed in Issue #35. 

The specification on pod-security-policy for securityContext allows for multiple contexts under `SELinux`, such as `MustRunAs` and `RunAsAny` which should introduce different validation checks for this policy.

```
SELinux 
MustRunAs - Requires seLinuxOptions to be configured. Uses seLinuxOptions as the default. Validates against seLinuxOptions.
RunAsAny - No default provided. Allows any seLinuxOptions to be specified.
```
[Referenced here](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#selinux)

I have changed most of the files and the test suite as well but am still thinking of various test scenarios.
If anyone (@sozercan, @EmandM) has any improvements in mind and has just a bit of time to review, I would be grateful.

