### PR TITLE
Update usage instructions to new directory layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This repository is a community-owned library of policies for the OPA Gatekeeper 
 
 ## How to use the library
 
-The easiest way to apply a policy from this library is to download and apply the `constraint.yaml` and `template.yaml` provided in each directory
+The easiest way to apply a policy from this library is to download and apply the `template.yaml` and a sample `constraint.yaml` provided in each policy directory
 
 For example
 
     cd library/general/httpsonly/
-    kubectl apply -f constraint.yaml
     kubectl apply -f template.yaml
+    kubectl apply -f samples/ingress-https-only/constraint.yaml
 
 ## How to contribute to the library
 


### PR DESCRIPTION
Recent directory layout changes by @ctab broken end-user instructions. 

Would be nice if there are always working instructions on how to use stuff...

The library repo so far doesn't seem to have people in mind that actually might want to use it. I know this is maybe a harsh critic, I'm still speaking out, because I find the work here really really useful and wish for everyone to use it.

