### PR TITLE
Add descriptions to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,7 @@ For example
 
 ## How to contribute to the library
 
-TODO.
+If you have a policy you would like to contribute to the library, please feel free to submit a pull request. Each new policy contribution should contain the following:
+* A constraint template with a `description` annotation and the parameter structure, if any, defined in `spec.crd.spec.validation.openAPIV3Schema`
+* One or more sample constraints, each with an example of an allowed (`example_allowed.yaml`) and disallowed (`example_disallowed.yaml`) resource.
+* The rego source, as `src.rego` and unit tests as `src_test.rego` in the corresponding subdirectory under `src/`

--- a/library/general/allowedrepos/template.yaml
+++ b/library/general/allowedrepos/template.yaml
@@ -2,6 +2,9 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8sallowedrepos
+  annotations:
+    description: Requires container images to begin with a repo string from a specified
+      list.
 spec:
   crd:
     spec:

--- a/library/general/block-nodeport-services/template.yaml
+++ b/library/general/block-nodeport-services/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8sblocknodeport
+  annotations:
+    description: Disallows all Services with type NodePort.
 spec:
   crd:
     spec:

--- a/library/general/containerlimits/template.yaml
+++ b/library/general/containerlimits/template.yaml
@@ -2,6 +2,9 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8scontainerlimits
+  annotations:
+    description: Requires containers to have memory and CPU limits set and within
+      a specified maximum amount.
 spec:
   crd:
     spec:

--- a/library/general/containerresourceratios/template.yaml
+++ b/library/general/containerresourceratios/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8scontainerratios
+  annotations:
+    description: Sets a maximum ratio for container resource limits to requests.
 spec:
   crd:
     spec:

--- a/library/general/externalip/template.yaml
+++ b/library/general/externalip/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8sexternalips
+  annotation:
+    description: "Restricts Services from containing externalIPs except those in a provided allowlist."
 spec:
   crd:
     spec:

--- a/library/general/httpsonly/template.yaml
+++ b/library/general/httpsonly/template.yaml
@@ -2,6 +2,9 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8shttpsonly
+  annotations:
+    description: Requires Ingress resources to be HTTPS only; TLS configuration should
+      be set and `kubernetes.io/ingress.allow-http` annotation equals false.
 spec:
   crd:
     spec:

--- a/library/general/imagedigests/template.yaml
+++ b/library/general/imagedigests/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8simagedigests
+  annotations:
+    description: Requires container images to contain a digest.
 spec:
   crd:
     spec:

--- a/library/general/requiredlabels/template.yaml
+++ b/library/general/requiredlabels/template.yaml
@@ -2,6 +2,9 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8srequiredlabels
+  annotations:
+    description: Requires all resources to contain a specified label with a value
+      matching a provided regular expression.
 spec:
   crd:
     spec:

--- a/library/general/requiredprobes/template.yaml
+++ b/library/general/requiredprobes/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8srequiredprobes
+  annotations:
+    description: Requires Pods to have readiness and/or liveness probes.
 spec:
   crd:
     spec:

--- a/library/general/uniqueingresshost/template.yaml
+++ b/library/general/uniqueingresshost/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8suniqueingresshost
+  annotations:
+    description: Requires all Ingress hosts to be unique.
 spec:
   crd:
     spec:

--- a/library/general/uniqueserviceselector/template.yaml
+++ b/library/general/uniqueserviceselector/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8suniqueserviceselector
+  annotations:
+    description: Requires Services to have unique selectors within a namespace.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/allow-privilege-escalation/template.yaml
+++ b/library/pod-security-policy/allow-privilege-escalation/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspallowprivilegeescalationcontainer
+  annotations:
+    description: Controls restricting escalation to root privileges.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/apparmor/template.yaml
+++ b/library/pod-security-policy/apparmor/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspapparmor
+  annotations:
+    description: Controls the AppArmor profile used by containers.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/capabilities/template.yaml
+++ b/library/pod-security-policy/capabilities/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspcapabilities
+  annotations:
+    description: Controls Linux capabilities.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/flexvolume-drivers/template.yaml
+++ b/library/pod-security-policy/flexvolume-drivers/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspflexvolumes
+  annotations:
+    description: Controls the allowlist of Flexvolume drivers.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/forbidden-sysctls/template.yaml
+++ b/library/pod-security-policy/forbidden-sysctls/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspforbiddensysctls
+  annotations:
+    description: Controls the `sysctl` profile used by containers.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/fsgroup/template.yaml
+++ b/library/pod-security-policy/fsgroup/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspfsgroup
+  annotations:
+    description: Controls allocating an FSGroup that owns the Pod's volumes.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/host-filesystem/template.yaml
+++ b/library/pod-security-policy/host-filesystem/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spsphostfilesystem
+  annotations:
+    description: Controls usage of the host filesystem.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/host-namespaces/template.yaml
+++ b/library/pod-security-policy/host-namespaces/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spsphostnamespace
+  annotations:
+    description: Controls usage of host namespaces.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/host-network-ports/template.yaml
+++ b/library/pod-security-policy/host-network-ports/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spsphostnetworkingports
+  annotations:
+    description: Controls usage of host networking and ports.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/privileged-containers/template.yaml
+++ b/library/pod-security-policy/privileged-containers/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspprivilegedcontainer
+  annotations:
+    description: Controls running of privileged containers.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/proc-mount/template.yaml
+++ b/library/pod-security-policy/proc-mount/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspprocmount
+  annotations:
+    description: Controls the allowed `procMount` types for the container.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/read-only-root-filesystem/template.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspreadonlyrootfilesystem
+  annotations:
+    description: Requires the use of a read only root file system.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspseccomp
+  annotations:
+    description: Controls the seccomp profile used by containers.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/selinux/template.yaml
+++ b/library/pod-security-policy/selinux/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspselinuxv2
+  annotations:
+    description: Controls the SELinux context of the container.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/users/template.yaml
+++ b/library/pod-security-policy/users/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspallowedusers
+  annotations:
+    description: Controls the user and group IDs of the container.
 spec:
   crd:
     spec:

--- a/library/pod-security-policy/volumes/template.yaml
+++ b/library/pod-security-policy/volumes/template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8spspvolumetypes
+  annotations:
+    description: Controls usage of volume types.
 spec:
   crd:
     spec:


### PR DESCRIPTION
Adding description annotations to the templates; these will be used to generate documentation of the available templates (with descriptions, parameters, and sample constraints).

https://github.com/open-policy-agent/gatekeeper-library/issues/28

Signed-off-by: Craig Tabita <ctab@google.com>