### PR TITLE
exclude kube-system namespace in K8sPSPPrivilegedContainer example

### DIFF
--- a/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/constraint.yaml
+++ b/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/constraint.yaml
@@ -7,3 +7,4 @@ spec:
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
+    excludedNamespaces: ["kube-system"]


### PR DESCRIPTION
This is to allow system pods to be created on new nodes during node upgrade, repair, or auto-scaling.