### PR TITLE
Add runAsNonRoot securityContext check

### DIFF
--- a/library/pod-security-policy/users/template.yaml
+++ b/library/pod-security-policy/users/template.yaml
@@ -102,14 +102,12 @@ spec:
 
         get_user_violation(params, container) = msg {
           not get_field_value("runAsUser", container, input.review)
-          not get_field_value("runAsNonRoot", container, input.review)
-          params.rule != "RunAsAny"
-          params.rule != "runAsNonRoot"
-          msg := sprintf("Container %v is attempting to run without a required securityContext/%v", [container.name, params.rule])
+          params.rule = "MustRunAs"
+          msg := sprintf("Container %v is attempting to run without a required securityContext/runAsUser", [container.name])
         }
 
         get_user_violation(params, container) = msg {
-          params.rule = "runAsNonRoot"
+          params.rule = "MustRunAsNonRoot"
           not get_field_value("runAsUser", container, input.review)
           not get_field_value("runAsNonRoot", container, input.review)
           msg := sprintf("Container %v is attempting to run without a required securityContext/runAsNonRoot or securityContext/runAsUser != 0", [container.name])

--- a/library/pod-security-policy/users/template.yaml
+++ b/library/pod-security-policy/users/template.yaml
@@ -102,8 +102,17 @@ spec:
 
         get_user_violation(params, container) = msg {
           not get_field_value("runAsUser", container, input.review)
+          not get_field_value("runAsNonRoot", container, input.review)
           params.rule != "RunAsAny"
-          msg := sprintf("Container %v is attempting to run without a required securityContext/runAsUser. Allowed runAsUser: %v", [container.name, params])
+          params.rule != "runAsNonRoot"
+          msg := sprintf("Container %v is attempting to run without a required securityContext/%v", [container.name, params.rule])
+        }
+
+        get_user_violation(params, container) = msg {
+          params.rule = "runAsNonRoot"
+          not get_field_value("runAsUser", container, input.review)
+          not get_field_value("runAsNonRoot", container, input.review)
+          msg := sprintf("Container %v is attempting to run without a required securityContext/runAsNonRoot or securityContext/runAsUser != 0", [container.name])
         }
 
         accept_users("RunAsAny", provided_user) {true}

--- a/src/pod-security-policy/users/src.rego
+++ b/src/pod-security-policy/users/src.rego
@@ -30,7 +30,7 @@ get_user_violation(params, container) = msg {
 get_user_violation(params, container) = msg {
   not get_field_value("runAsUser", container, input.review)
   params.rule = "MustRunAs"
-  msg := sprintf("Container %v is attempting to run without a required securityContext/%v", [container.name, params.rule])
+  msg := sprintf("Container %v is attempting to run without a required securityContext/runAsUser", [container.name])
 }
 
 get_user_violation(params, container) = msg {

--- a/src/pod-security-policy/users/src.rego
+++ b/src/pod-security-policy/users/src.rego
@@ -29,14 +29,12 @@ get_user_violation(params, container) = msg {
 
 get_user_violation(params, container) = msg {
   not get_field_value("runAsUser", container, input.review)
-  not get_field_value("runAsNonRoot", container, input.review)
-  params.rule != "RunAsAny"
-  params.rule != "runAsNonRoot"
+  params.rule = "MustRunAs"
   msg := sprintf("Container %v is attempting to run without a required securityContext/%v", [container.name, params.rule])
 }
 
 get_user_violation(params, container) = msg {
-  params.rule = "runAsNonRoot"
+  params.rule = "MustRunAsNonRoot"
   not get_field_value("runAsUser", container, input.review)
   not get_field_value("runAsNonRoot", container, input.review)
   msg := sprintf("Container %v is attempting to run without a required securityContext/runAsNonRoot or securityContext/runAsUser != 0", [container.name])

--- a/src/pod-security-policy/users/src.rego
+++ b/src/pod-security-policy/users/src.rego
@@ -29,8 +29,17 @@ get_user_violation(params, container) = msg {
 
 get_user_violation(params, container) = msg {
   not get_field_value("runAsUser", container, input.review)
+  not get_field_value("runAsNonRoot", container, input.review)
   params.rule != "RunAsAny"
-  msg := sprintf("Container %v is attempting to run without a required securityContext/runAsUser. Allowed runAsUser: %v", [container.name, params])
+  params.rule != "runAsNonRoot"
+  msg := sprintf("Container %v is attempting to run without a required securityContext/%v", [container.name, params.rule])
+}
+
+get_user_violation(params, container) = msg {
+  params.rule = "runAsNonRoot"
+  not get_field_value("runAsUser", container, input.review)
+  not get_field_value("runAsNonRoot", container, input.review)
+  msg := sprintf("Container %v is attempting to run without a required securityContext/runAsNonRoot or securityContext/runAsUser != 0", [container.name])
 }
 
 accept_users("RunAsAny", provided_user) {true}

--- a/src/pod-security-policy/users/src_test.rego
+++ b/src/pod-security-policy/users/src_test.rego
@@ -213,7 +213,22 @@ test_user_input_container_run_as_rule_non_root_ignore_ranges {
   results := violation with input as input
   count(results) == 0
 }
-
+test_user_input_container_run_as_rule_non_root_runasnonroot_true {
+  input := {
+    "review": review(runAsNonRoot(true), [ctr("cont1", null)], null),
+    "parameters": runAsUser(rule("MustRunAsNonRoot", null))
+  }
+  results := violation with input as input
+  count(results) == 0
+}
+test_user_input_container_run_as_rule_non_root_runasnonroot_false {
+  input := {
+    "review": review(runAsNonRoot(false), [ctr("cont1", null)], null),
+    "parameters": runAsUser(rule("MustRunAsNonRoot", null))
+  }
+  results := violation with input as input
+  count(results) == 1
+}
 
 
 ## runAsGroup ##
@@ -777,6 +792,9 @@ ctr(name, context) = out {
 
 runAsUser(user) = out {
 	out = run_as_rule(user, null, null, null)
+}
+runAsNonRoot(bool) = out {
+  out = {"runAsNonRoot": bool}
 }
 runAsGroup(group) = out {
 	out = run_as_rule(null, group, null, null)

--- a/src/pod-security-policy/users/src_test.rego
+++ b/src/pod-security-policy/users/src_test.rego
@@ -103,6 +103,11 @@ test_user_one_container_run_in_range_user_upper_edge_of_range {
   results := violation with input as input
   count(results) == 0
 }
+test_user_one_container_run_in_range_seccont_runasnonroot {
+  input := { "review": review(null, [ctr("cont1", runAsNonRoot(true))], null), "parameters": user_mustrunas_100_200 }
+  results := violation with input as input
+  count(results) == 1
+}
 test_user_one_container_run_in_range_user_between_ranges {
   input := { "review": review(null, [ctr("cont1", runAsUser(200))], null), "parameters": user_mustrunas_two_ranges }
   results := violation with input as input

--- a/src/pod-security-policy/users/src_test.rego
+++ b/src/pod-security-policy/users/src_test.rego
@@ -58,6 +58,31 @@ test_user_one_container_run_as_rule_non_root_user_is_root {
   results := violation with input as input
   count(results) == 1
 }
+test_user_one_container_run_as_rule_non_root_seccont_runasnonroot_user_is_not_defined {
+  input := { "review": review(null, [ctr("cont1", runAsNonRoot(true))], null), "parameters": user_mustrunasnonroot }
+  results := violation with input as input
+  count(results) == 0
+}
+test_user_one_container_run_as_rule_non_root_seccont_runasnonroot_user_is_root {
+  input := { "review": review(null, [ctr("cont1", object.union(runAsNonRoot(true),runAsUser(0)))], null), "parameters": user_mustrunasnonroot }
+  results := violation with input as input
+  count(results) == 1
+}
+test_user_one_container_run_as_rule_non_root_seccont_runasnonroot_user_is_not_root {
+  input := { "review": review(null, [ctr("cont1", object.union(runAsNonRoot(true),runAsUser(10)))], null), "parameters": user_mustrunasnonroot }
+  results := violation with input as input
+  count(results) == 0
+}
+test_user_one_container_run_as_rule_non_root_seccont_runasnonroot_is_false_user_is_not_defined {
+  input := { "review": review(null, [ctr("cont1", runAsNonRoot(false))], null), "parameters": user_mustrunasnonroot }
+  results := violation with input as input
+  count(results) == 1
+}
+test_user_one_container_run_as_rule_non_root_seccont_runasnonroot_is_false_user_is_not_root {
+  input := { "review": review(null, [ctr("cont1", object.union(runAsNonRoot(false),runAsUser(10)))], null), "parameters": user_mustrunasnonroot }
+  results := violation with input as input
+  count(results) == 0
+}
 test_user_one_container_run_in_range_user_in_range {
   input := { "review": review(null, [ctr("cont1", runAsUser(150))], null), "parameters": user_mustrunas_100_200 }
   results := violation with input as input
@@ -83,6 +108,7 @@ test_user_one_container_run_in_range_user_between_ranges {
   results := violation with input as input
   count(results) == 1
 }
+
 test_user_two_containers_run_as_rule_any {
   input := {
     "review": review(null, [ctr("cont1", runAsUser(1)), ctr("cont2", runAsUser(100))], null),
@@ -102,6 +128,22 @@ test_user_two_containers_run_as_rule_non_root_users_are_not_root {
 test_user_two_containers_run_as_rule_non_root_one_is_root {
   input := {
     "review": review(null, [ctr("cont1", runAsUser(1)), ctr("cont2", runAsUser(0))], null),
+    "parameters": user_mustrunasnonroot
+  }
+  results := violation with input as input
+  count(results) == 1
+}
+test_user_two_containers_run_as_rule_non_root_one_seccont_runasnonroot {
+  input := {
+    "review": review(null, [ctr("cont1", runAsUser(1)), ctr("cont2", runAsNonRoot(true))], null),
+    "parameters": user_mustrunasnonroot
+  }
+  results := violation with input as input
+  count(results) == 0
+}
+test_user_two_containers_run_as_rule_non_root_one_root_other_has_seccont_runasnonroot {
+  input := {
+    "review": review(null, [ctr("cont1", runAsUser(0)), ctr("cont2", runAsNonRoot(true))], null),
     "parameters": user_mustrunasnonroot
   }
   results := violation with input as input
@@ -213,21 +255,13 @@ test_user_input_container_run_as_rule_non_root_ignore_ranges {
   results := violation with input as input
   count(results) == 0
 }
-test_user_input_container_run_as_rule_non_root_runasnonroot_true {
+test_user_input_container_run_as_rule_non_root_seccont_runasnonroot_ignore_ranges {
   input := {
-    "review": review(runAsNonRoot(true), [ctr("cont1", null)], null),
-    "parameters": runAsUser(rule("MustRunAsNonRoot", null))
+    "review": review(null, [ctr("cont1", runAsNonRoot(true))], null),
+    "parameters": runAsUser(rule("MustRunAsNonRoot", [range(100, 200)]))
   }
   results := violation with input as input
   count(results) == 0
-}
-test_user_input_container_run_as_rule_non_root_runasnonroot_false {
-  input := {
-    "review": review(runAsNonRoot(false), [ctr("cont1", null)], null),
-    "parameters": runAsUser(rule("MustRunAsNonRoot", null))
-  }
-  results := violation with input as input
-  count(results) == 1
 }
 
 


### PR DESCRIPTION
This PR solves [Issue 49](https://github.com/open-policy-agent/gatekeeper-library/issues/49)

- It adds a check for the `runAsNonRoot` securityContext field.
- It adds tests to validate the rule is functioning.

 