### PR TITLE
Add min/max constraint examples for Deployments

### DIFF
--- a/library/general/replicalimits/kustomization.yaml
+++ b/library/general/replicalimits/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/replicalimits/samples/replicalimits/constraint.yaml
+++ b/library/general/replicalimits/samples/replicalimits/constraint.yaml
@@ -1,0 +1,13 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sReplicaLimits
+metadata:
+  name: replica-limits
+spec:
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment"]
+  parameters:
+    ranges:
+    - min_replicas: 3
+      max_replicas: 50

--- a/library/general/replicalimits/samples/replicalimits/example_allowed.yaml
+++ b/library/general/replicalimits/samples/replicalimits/example_allowed.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: allowed-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/library/general/replicalimits/samples/replicalimits/example_disallowed.yaml
+++ b/library/general/replicalimits/samples/replicalimits/example_disallowed.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: disallowed-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 100
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/library/general/replicalimits/template.yaml
+++ b/library/general/replicalimits/template.yaml
@@ -2,7 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8sreplicalimits
-  description: Requires a number of replicas to be set for a deployment between a min and max value.
+  annotations:
+    description: Requires a number of replicas to be set for a deployment between a min and max value.
 spec:
   crd:
     spec:

--- a/library/general/replicalimits/template.yaml
+++ b/library/general/replicalimits/template.yaml
@@ -1,0 +1,47 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sreplicalimits
+  description: Requires a number of replicas to be set for a deployment between a min and max value.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sReplicaLimits
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            ranges:
+              type: array
+              items:
+                type: object
+                properties:
+                  min_replicas:
+                    type: integer
+                  max_replicas:
+                    type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sreplicalimits
+
+        deployment_name = input.review.object.metadata.name
+
+        violation[{"msg": msg}] {
+          spec := input.review.object.spec
+          not input_replica_limit(spec)
+          msg := sprintf("The provided number of replicas is not allowed for deployment: %v. Allowed ranges: %v", [deployment_name, input.parameters])
+        }
+
+        input_replica_limit(spec) {
+          provided := input.review.object.spec.replicas
+          count(input.parameters.ranges) > 0
+          range := input.parameters.ranges[_]
+          value_within_range(range, provided)
+        }
+
+        value_within_range(range, value) {
+          range.min_replicas <= value
+          range.max_replicas >= value
+        }

--- a/src/general/replicalimits/src.rego
+++ b/src/general/replicalimits/src.rego
@@ -1,0 +1,22 @@
+package k8sreplicalimits
+
+deployment_name = input.review.object.metadata.name
+
+violation[{"msg": msg}] {
+    spec := input.review.object.spec
+    not input_replica_limit(spec)
+    msg := sprintf("The provided number of replicas is not allowed for deployment: %v. Allowed ranges: %v", [deployment_name, input.parameters])
+}
+
+input_replica_limit(spec) {
+    provided := input.review.object.spec.replicas
+    count(input.parameters.ranges) > 0
+    range := input.parameters.ranges[_]
+    value_within_range(range, provided)
+}
+
+value_within_range(range, value) {
+    range.min_replicas <= value
+    range.max_replicas >= value
+}
+

--- a/src/general/replicalimits/src_test.rego
+++ b/src/general/replicalimits/src_test.rego
@@ -1,0 +1,81 @@
+package k8sreplicalimits
+
+test_input_empty {
+    input := { "review": empty, "parameters": {}}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_within_required_replicas {
+    input := { "review": review(6), "parameters": input_parameters_valid_range}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_exact_required_replicas_min {
+    input := { "review": review(5), "parameters": input_parameters_valid_range}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_exact_required_replicas_max {
+    input := { "review": review(35), "parameters": input_parameters_valid_range}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_not_enough_required_replicas {
+    input := { "review": review(1), "parameters": input_parameters_valid_range}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_too_many_replicas {
+    input := { "review": review(100), "parameters": input_parameters_valid_range}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_zero_replicas {
+    input := { "review": review(0), "parameters": input_parameters_zero_range}
+    results := violation with input as input
+    count(results) == 0
+}
+
+empty = {
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+  }
+}
+
+review(replicas) = output {
+  output = {
+    "object": {
+    "metadata": {
+        "name": "nginx"
+    },
+      "spec": {
+        "replicas": replicas,
+      },
+    }
+  }
+} 
+
+input_parameters_valid_range = {
+    "ranges": [
+    {
+        "min_replicas": 5,
+        "max_replicas": 35
+    }]
+}
+
+input_parameters_zero_range = {
+    "ranges": [
+    {
+        "min_replicas": 0,
+        "max_replicas": 0
+    }]
+}
+


### PR DESCRIPTION
This adds a  new constraint templates and constraints:

- replicalimits

As it says the constraint is aimed at limiting how many replicas can be deployed and making sure a sufficient amount of replicas are deployed in a cluster.

I think this helps with #7 , but i'm not 100% sure.

First time PR'er here so let me know if there's a format I need to follow for PR's etc. (I couldn't see anything)