### PR TITLE
Adding some library policies for Windows workloads

### DIFF
--- a/OS-specific-policies.md
+++ b/OS-specific-policies.md
@@ -1,0 +1,47 @@
+# OS Specific Policies
+
+Kubernetes allows for pods/containers targeting different operating systems to be scheduled into the same cluster and different operating systems and can behave differently depending on what OS the pods/containers are targeting.
+
+This guide will help you configure policies that are meant only to specific operating systems.
+
+## Usage
+
+### Determine how your cluster will identify target OS
+
+Unfortunately there is no definitive way identify which OS a pod is targeted for.
+If you would like to enforce OS-specific policies in your cluster you should first determine how your cluster will identify the target OS for pods.
+
+Policies in this repository will use [nodeSelectors](https://v1-18.docs.kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) against the well-known [kubernetes.io\os](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-os) label for pods. This is the simplest way to identifying the target OS for a pod but other mechanisms like [Runtime Classes](https://kubernetes.io/docs/concepts/containers/runtime-class/) exist as well and will follow the same procedure for enabling policy enforcement.
+
+### Add a policy requiring all pods to identify an OS
+
+After you have selected how you would like your cluster to identify the target OS for pods create a policy to ensure **every** pod admitted into your cluster specifies an OS.
+
+Example:
+
+```bash
+cd library/general/requirednodeselectors
+kubectl apply -f template.yaml
+kubectl apply -f samples/require-os-node-selector/constraint.yaml
+```
+
+### Add OS specific policies
+
+1. Include a check for your targeted OS in the rego for your policy. This check should skip policy enforcement if the OS does not match and enforce policy enforcement if the OS does match.
+
+    Example: The function `isWindowsPod` in the [windows-runasusername](./library/pod-security-policy/windows-runasusername/template.yaml) template.
+
+1. Add OS specific policies to your cluster.
+
+    Example:
+
+    ```bash
+    cd library/general/windows-container-resources
+    kubectl apply -f template.yaml
+    kubectl apply -f samples/constraint.yaml
+    ```
+
+Some examples of OS specific policies include:
+
+- [windows-container-resources](./library/general/windows-container-resources)
+- [windows-runasusername](./library/pod-security-policy/windows-runasusername)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ kubectl apply -f samples/ingress-https-only/constraint.yaml
 kubectl apply -f library/general/httpsonly/sync.yaml # optional: when GK is running with OPA cache
 ```
 
+Note: Some policies should only be enforced for pods targeting a specific OS.
+Refer to the [OS specific policies](./OS-specific-policies.md) page for more information.
+
 ## How to contribute to the library
 
 ### New policy

--- a/library/general/kustomization.yaml
+++ b/library/general/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - httpsonly
   - imagedigests
   - requiredlabels
+  - requirednodeselectors
   - requiredprobes
   - uniqueingresshost
   - uniqueserviceselector

--- a/library/general/requirednodeselectors/kustomization.yaml
+++ b/library/general/requirednodeselectors/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/requirednodeselectors/samples/require-os-node-selector/constraint.yaml
+++ b/library/general/requirednodeselectors/samples/require-os-node-selector/constraint.yaml
@@ -1,0 +1,11 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredNodeSelectors
+metadata:
+  name: must-have-os
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    nodeSelectors: ["kubernetes.io/os"]

--- a/library/general/requirednodeselectors/samples/require-os-node-selector/example_allowed.yaml
+++ b/library/general/requirednodeselectors/samples/require-os-node-selector/example_allowed.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-allowed
+spec:
+  containers:
+    - name: nginx
+      image: nginx
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"
+  nodeSelector:
+    "kubernetes.io/os": "windows"

--- a/library/general/requirednodeselectors/samples/require-os-node-selector/example_disallowed.yaml
+++ b/library/general/requirednodeselectors/samples/require-os-node-selector/example_disallowed.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-disallowed
+spec:
+  containers:
+    - name: nginx
+      image: nginx
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"

--- a/library/general/requirednodeselectors/template.yaml
+++ b/library/general/requirednodeselectors/template.yaml
@@ -1,0 +1,28 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequirednodeselectors
+  annotations:
+    description: Requires Pods to have node selectors.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredNodeSelectors
+      validation:
+        openAPIV3Schema:
+          properties:
+            nodeSelectors:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequirednodeselectors
+
+        violation[{"msg": msg}] {
+          required := input.parameters.nodeSelectors[_]
+          not input.review.object.spec.nodeSelector[required]
+          msg := sprintf("Pod spec must specify the following node selectors: %v", [input.parameters.nodeSelectors])
+        }

--- a/library/general/windows-container-resources/kustomization.yaml
+++ b/library/general/windows-container-resources/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/windows-container-resources/samples/constraint.yaml
+++ b/library/general/windows-container-resources/samples/constraint.yaml
@@ -1,0 +1,11 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sWindowsContainerResources
+metadata:
+  name: windows-containers-must-set-resource-limits
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaces:
+      - "default"

--- a/library/general/windows-container-resources/samples/example_allowed.yaml
+++ b/library/general/windows-container-resources/samples/example_allowed.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windows-containers-resources-allowed
+spec:
+  containers:
+  - name: ping-loop-limits
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+    resources:
+      limits:
+        cpu: .25
+        memory: 250m
+  - name: ping-loop-limits-and-requests
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+    resources:
+      limits:
+        cpu: .25
+        memory: 250m
+      requests:
+        cpu: .25
+        memory: 250m
+  nodeSelector:
+    "kubernetes.io/os": windows

--- a/library/general/windows-container-resources/samples/example_disallowed.yaml
+++ b/library/general/windows-container-resources/samples/example_disallowed.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windows-containers-resources-disallowed
+spec:
+  containers:
+  - name: ping-loop-no-limits
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+  - name: ping-loop-partial-limits
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+    resources:
+      limits:
+        memory: 250m
+  - name: ping-loop-mismatched-requests
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+    resources:
+      limits:
+        cpu: 0.5
+        memory: 500m
+      requests:
+        cpu: 0.25
+        memory: 250m
+  nodeSelector:
+    "kubernetes.io/os": windows

--- a/library/general/windows-container-resources/template.yaml
+++ b/library/general/windows-container-resources/template.yaml
@@ -1,0 +1,85 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8swindowscontainerresources
+  annotations:
+    description: |
+      This constraint template enforces the following for Windows pods:
+        - Ensure that all containers set resources limits
+        - Ensure that that for all containers, if resource requests are set then they match limits
+      Resource management and eviction for Windows containers works much different than Linux containers and
+      these policies will help to ensure Windows workloads will remain responsive during operation.
+      For more information please refer to https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#resource-reservations
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sWindowsContainerResources
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8swindowscontainerresources
+
+        violation[{"msg":msg}] {
+            is_windows_pod
+            container := input_containers[_]
+            not has_limits(container)
+            msg := sprintf("Container <%v> has missing resource limits", [container.name])
+        }
+
+        violation[{"msg":msg}] {
+            is_windows_pod
+            container := input_containers[v]
+            requests_do_not_match_limits(container)
+            msg := sprintf("Container <%v> sets reource requests that do not match limits", [container.name])
+        }
+
+        is_windows_pod {
+            ns := input.review.object.spec.nodeSelector
+            ns["kubernetes.io/os"] == "windows"
+        }
+
+        has_limits(c) {
+            get_cpu_limit(c)
+            get_mem_limit(c)
+        }
+
+        requests_do_not_match_limits(c) {
+            # Tests that cpu requests match limits if specified
+            r := get_cpu_request(c)
+            l := get_cpu_limit(c)
+            r != null
+            l != null
+            r != l
+        }
+        requests_do_not_match_limits(c) {
+            # Tests that mem requests match limits if specified
+            r := get_mem_request(c)
+            l := get_mem_limit(c)
+            r != null
+            l != null
+            r != l
+        }
+
+        get_cpu_limit(c) = out {
+            out := c.resources.limits.cpu
+        }
+
+        get_cpu_request(c) = out {
+            out := c.resources.requests.cpu
+        }
+
+        get_mem_limit(c) = out {
+            out := c.resources.limits.memory
+        }
+
+        get_mem_request(c) = out {
+            out := c.resources.requests.memory
+        }
+
+        input_containers[c] {
+            c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+            c := input.review.object.spec.initContainers[_]
+        }

--- a/library/pod-security-policy/windows-runasusername/kustomization.yaml
+++ b/library/pod-security-policy/windows-runasusername/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/windows-runasusername/samples/psps-windows-runasusername/constraint.yaml
+++ b/library/pod-security-policy/windows-runasusername/samples/psps-windows-runasusername/constraint.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDisallowedRunAsUserNames
+metadata:
+  name: runasusername-is-not-containeradmin
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaces:
+      - "default"
+  parameters:
+    disallowedUserNames:
+      - "ContainerAdmin"

--- a/library/pod-security-policy/windows-runasusername/samples/psps-windows-runasusername/example_allowed.yaml
+++ b/library/pod-security-policy/windows-runasusername/samples/psps-windows-runasusername/example_allowed.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nanoserver-as-containeruser
+spec:
+  containers:
+  - name: ping-loop
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+    securityContext:
+      windowsOptions:
+        runAsUserName: "ContainerUser"
+  nodeSelector:
+    "kubernetes.io/os": windows

--- a/library/pod-security-policy/windows-runasusername/samples/psps-windows-runasusername/example_disallowed_container.yaml
+++ b/library/pod-security-policy/windows-runasusername/samples/psps-windows-runasusername/example_disallowed_container.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nanoserver-as-containeradmin
+spec:
+  containers:
+  - name: ping-loop
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+    securityContext:
+      windowsOptions:
+        runAsUserName: "ContainerAdmin"
+  nodeSelector:
+    "kubernetes.io/os": windows

--- a/library/pod-security-policy/windows-runasusername/samples/psps-windows-runasusername/example_disallowed_pod.yaml
+++ b/library/pod-security-policy/windows-runasusername/samples/psps-windows-runasusername/example_disallowed_pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nanoserver-as-containeradmin
+spec:
+  securityContext:
+    windowsOptions:
+      runAsUserName: "ContainerAdmin"
+  containers:
+  - name: ping-loop
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+  nodeSelector:
+    "kubernetes.io/os": windows

--- a/library/pod-security-policy/windows-runasusername/template.yaml
+++ b/library/pod-security-policy/windows-runasusername/template.yaml
@@ -1,0 +1,64 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdisallowedrunasusernames
+  annotations:
+    description: Forbids Windows containers from running as specified users.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDisallowedRunAsUserNames
+    validation:
+      openAPIV3Schema:
+        properties:
+          disallowedUserNames:
+            type: array
+            items:
+              type: string
+  targets:
+  - target: admission.k8s.gatekeeper.sh
+    rego: |
+      package windowsrunasusername
+
+      violation[{"msg": msg}] {
+          isWindowsPod
+          container := input_containers[_]
+          has_disallowed_username(container)
+          msg := sprintf("Container <%v> has disallowed runAsUsername. Disallowed users are %v", [container.name, input.parameters.disallowedUserNames])
+      }
+
+      has_disallowed_username(c) {
+          un := get_username(c)
+          input.parameters.disallowedUserNames[_] == un
+      }
+
+      # returns runAsUserName if set for container
+      get_username(c) = out {
+          un := c.securityContext.windowsOptions.runAsUserName
+          out = un
+      }
+
+      # returns runAsUserName if NOT set for container but IS set for pod
+      get_username(c) = out {
+          not has_username_set_for_container(c)
+          un := input.review.object.spec.securityContext.windowsOptions.runAsUserName
+          out = un
+      }
+
+      has_username_set_for_container(c) {
+          c.securityContext.windowsOptions.runAsUserName
+      }
+
+      isWindowsPod {
+          ns := input.review.object.spec.nodeSelector
+          ns["kubernetes.io/os"] == "windows"
+      }
+
+      input_containers[c] {
+          c := input.review.object.spec.containers[_]
+      }
+
+      input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+      }

--- a/src/general/requirednodeselectors/src.rego
+++ b/src/general/requirednodeselectors/src.rego
@@ -1,0 +1,7 @@
+package k8srequirednodeselectors
+
+violation[{"msg": msg}] {
+    required := input.parameters.nodeSelectors[_]
+    not input.review.object.spec.nodeSelector[required]
+    msg := sprintf("Pod spec must specify the following node selectors: %v", [input.parameters.nodeSelectors])
+}

--- a/src/general/requirednodeselectors/src_test.rego
+++ b/src/general/requirednodeselectors/src_test.rego
@@ -1,0 +1,48 @@
+package k8srequirednodeselectors
+
+test_no_required_node_selectors {
+    input := { "review": review({}), "parameters" : {}}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_no_required_node_selectors {
+    input := { "review": review({"kubernetes.io/arch": "amd64", "kubernetes.io/os": "linux"}), "parameters" : {}}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_has_required_node_selectors {
+    input := { "review": review({"kubernetes.io/os": "windows"}), "parameters": {"nodeSelectors": ["kubernetes.io/os"]}}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_has_requried_node_selectors {
+    input := { "review": review({"1": "a", "2": "b", "3": "c"}), "parameters": {"nodeSelectors": ["1", "2", "3"]}}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_missing_required_node_selectors {
+    input := { "review": review({}), "parameters": {"nodeSelectors": ["kubernetes.io/os"]}}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_some_requried_node_selectors {
+    input := { "review": review({"1": "a"}), "parameters": {"nodeSelectors": ["1", "2", "3"]}}
+    results := violation with input as input
+    count(results) == 1
+}
+
+review(nodeSelectors) = out {
+    out = {
+        "object": {
+            "kind": "Pod",
+            "spec" : {
+                "nodeSelector": nodeSelectors
+            }
+        }
+    }
+}

--- a/src/general/windows-container-resources/src.rego
+++ b/src/general/windows-container-resources/src.rego
@@ -1,0 +1,65 @@
+package k8swindowscontainerresources
+
+violation[{"msg":msg}] {
+    is_windows_pod
+    container := input_containers[_]
+    not has_limits(container)
+    msg := sprintf("Container <%v> has missing resource limits", [container.name])
+}
+
+violation[{"msg":msg}] {
+    is_windows_pod
+    container := input_containers[v]
+    requests_do_not_match_limits(container)
+    msg := sprintf("Container <%v> sets reource requests that do not match limits", [container.name])
+}
+
+is_windows_pod {
+    ns := input.review.object.spec.nodeSelector
+    ns["kubernetes.io/os"] == "windows"
+}
+
+has_limits(c) {
+    get_cpu_limit(c)
+    get_mem_limit(c)
+}
+
+requests_do_not_match_limits(c) {
+    # Tests that cpu requests match limits if specified
+    r := get_cpu_request(c)
+    l := get_cpu_limit(c)
+    r != null
+    l != null
+    r != l
+}
+requests_do_not_match_limits(c) {
+    # Tests that mem requests match limits if specified
+    r := get_mem_request(c)
+    l := get_mem_limit(c)
+    r != null
+    l != null
+    r != l
+}
+
+get_cpu_limit(c) = out {
+    out := c.resources.limits.cpu
+}
+
+get_cpu_request(c) = out {
+    out := c.resources.requests.cpu
+}
+
+get_mem_limit(c) = out {
+    out := c.resources.limits.memory
+}
+
+get_mem_request(c) = out {
+    out := c.resources.requests.memory
+}
+
+input_containers[c] {
+    c := input.review.object.spec.containers[_]
+}
+input_containers[c] {
+    c := input.review.object.spec.initContainers[_]
+}

--- a/src/general/windows-container-resources/src_test.rego
+++ b/src/general/windows-container-resources/src_test.rego
@@ -1,0 +1,112 @@
+package k8swindowscontainerresources
+
+test_input_no_resources_no_node_selector {
+    input := {"review": review([ctr("ctr1", null, null)], null, null)}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_no_resources {
+    input := {"review": review([ctr("ctr1", null, null)], null, windowsNodeSelector)}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_no_cpu_limit {
+    input := {"review": review([ctr("ctr1", limits(null, "500m"), null)], null, windowsNodeSelector)}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_no_mem_limit {
+    input := {"review": review([ctr("ctr1", limits(0.5, null), null)], null, windowsNodeSelector)}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_with_limits {
+    input := {"review": review([ctr("ctr1", limits(0.5, "500m"), null)],null, windowsNodeSelector)}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_no_limits_with_requests {
+    input := {"review": review([ctr("ctr1", null, requests(0.5, "500m"))], null, windowsNodeSelector)}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_limits_match_requests {
+    input := {"review": review([ctr("ctr1", limits(0.5, "500m"), requests(0.5, "500m"))], null, windowsNodeSelector)}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_limits_do_not_match_requests1 {
+    input := {"review": review([ctr("ctr1", limits(0.5, "500m"), requests(0.25, "500m"))], null, windowsNodeSelector)}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_limits_do_not_match_requests2 {
+    input := {"review": review([ctr("ctr1", limits(0.5, "500m"), requests(0.5, "250m"))], null, windowsNodeSelector)}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_multiple_containers {
+    input := {"review": review(
+        [
+            ctr("ctr1", null, null),                                    # bad
+            ctr("ctr2", limits(0.5, "500m"), null),                      # good
+            ctr("ctr3", null, requests(0.5, "500m"))                     # bad
+        ],[ 
+            ctr("init_1", null, null),                                  # bad
+            ctr("init_2", limits(0.5, "500m"), requests(0.25, "250m")),   # bad
+            ctr("init_3", limits(0.5, "500m"), requests(0.5, "500m")),    # good
+            ctr("init_4", limits(0.5, "500m"), null)                     # good
+        ], windowsNodeSelector)}
+    results := violation with input as input
+    count(results) == 4
+}
+
+review(containers, init_containers, node_selector) = out {
+    containers_obj := obj_if_exists("containers", containers)
+    init_containers_obj := obj_if_exists("initContainers", init_containers)
+    node_selector_obj := obj_if_exists("nodeSelector", node_selector)
+    out = {
+        "object": {
+            "spec": object.union(object.union(containers_obj, init_containers_obj), node_selector_obj)
+        }
+    }
+}
+
+windowsNodeSelector = out {
+    out = {
+        "kubernetes.io/os": "windows"
+    }
+}
+
+ctr(name, limits, requests) = out {
+    out = {
+        "name": name,
+        "resources": object.union(obj_if_exists("limits", limits), obj_if_exists("requests", requests))
+    }
+}
+
+limits(cpu, mem) = out {
+    out =  object.union(obj_if_exists("cpu", cpu), obj_if_exists("memory", mem))
+}
+
+requests(cpu, mem) = out {
+    out = object.union(obj_if_exists("cpu", cpu), obj_if_exists("memory", mem))
+}
+
+obj_if_exists(key, val) = out {
+    not is_null(val)
+    out := {key: val}
+}
+obj_if_exists(key, val) = out {
+    is_null(val)
+    out := {}
+}

--- a/src/pod-security-policy/windows-runasusername/src.rego
+++ b/src/pod-security-policy/windows-runasusername/src.rego
@@ -1,0 +1,43 @@
+package windowsrunasusername
+
+violation[{"msg": msg}] {
+    isWindowsPod
+    container := input_containers[_]
+    has_disallowed_username(container)
+    msg := sprintf("Container <%v> has disallowed runAsUsername. Disallowed users are %v", [container.name, input.parameters.disallowedUserNames])
+}
+
+has_disallowed_username(c) {
+    un := get_username(c)
+    input.parameters.disallowedUserNames[_] == un
+}
+
+# returns runAsUserName if set for container
+get_username(c) = out {
+    un := c.securityContext.windowsOptions.runAsUserName
+    out = un
+}
+
+# returns runAsUserName if NOT set for container but IS set for pod
+get_username(c) = out {
+    not has_username_set_for_container(c)
+    un := input.review.object.spec.securityContext.windowsOptions.runAsUserName
+    out = un
+}
+
+has_username_set_for_container(c) {
+    c.securityContext.windowsOptions.runAsUserName
+}
+
+isWindowsPod {
+    ns := input.review.object.spec.nodeSelector
+    ns["kubernetes.io/os"] == "windows"
+}
+
+input_containers[c] {
+    c := input.review.object.spec.containers[_]
+}
+
+input_containers[c] {
+    c := input.review.object.spec.initContainers[_]
+}

--- a/src/pod-security-policy/windows-runasusername/src_test.rego
+++ b/src/pod-security-policy/windows-runasusername/src_test.rego
@@ -1,0 +1,163 @@
+package windowsrunasusername
+
+test_no_usernames_no_node_selector {
+    input := {
+        "review": make_review(null, [ctr("ctr1", null)], null, null),
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_no_usernames_windows_node_selector {
+    input := {
+        "review": make_review(null, [ctr("ctr1", null)], null, windowsNodeSelector),
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_disallowed_pod_username_but_no_node_selector {
+    input := {
+        "review": make_review("admin", [ctr("ctr1", null)], null, null), 
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_disallowed_pod_username1 {
+    input := {
+        "review": make_review("admin", [ctr("ctr1", null)], null, windowsNodeSelector), 
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_disallowed_pod_username2 {
+    input := {
+        "review": make_review("SYSTEM", [ctr("ctr1", null)], null, windowsNodeSelector), 
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_disallowed_pod_username_but_allowed_container_username {
+    input := {
+        "review": make_review("SYSTEM", [ctr("ctr1", "user")], null, windowsNodeSelector), 
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_disallowed_container_username_no_pod_username {
+    input := {
+        "review": make_review(null, [ctr("ctr1", "user")], null, windowsNodeSelector), 
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_disallowed_container_username_allowed_pod_username {
+    input := {
+        "review": make_review("user", [ctr("ctr1", "SYSTEM")], null, windowsNodeSelector), 
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_multiple_disallowed_container_usernames1 {
+    input := {
+        "review": make_review("user", [ctr("ctr1", "SYSTEM"), ctr("ctr2", "admin"), ctr("ctr3", null)], null, windowsNodeSelector), 
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_multiple_disallowed_container_usernames2 {
+    input := {
+        "review": make_review(null, [ctr("ctr1", "SYSTEM"), ctr("ctr2", "admin"), ctr("ctr3", null)], null, windowsNodeSelector), 
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_multiple_disallowed_container_usernames2 {
+    input := {
+        "review": make_review("admin", [ctr("ctr1", "SYSTEM"), ctr("ctr2", "admin"), ctr("ctr3", null)], null, windowsNodeSelector), 
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 3
+}
+
+test_disallowed_initcontainer_usernames {
+    input := {
+        "review": make_review("admin", [ctr("ctr1", "user")], [ctr("initCtr1", null), ctr("initCtr2", "SYSTEM")], windowsNodeSelector), 
+        "parameters": {"disallowedUserNames": ["admin", "SYSTEM"]}
+    }
+    results := violation with input as input
+    count(results) == 2
+}
+
+# make_review is a helper function to make pod specs for unit testing.
+
+make_review(podRunAsUserName, containers, initContainers, nodeSelector) = out {
+    pod_sercurity_context_obj := obj_if_exists("securityContext", windows_options_with_runasusername(podRunAsUserName))
+    containers_obj := obj_if_exists("containers", containers)
+    init_containers_obj := obj_if_exists("initContainers", initContainers)
+    node_selector_obj := obj_if_exists("nodeSelector", nodeSelector)
+    out = {
+        "kind": {
+            "kind": "Pod"
+        },
+        "metadata": {
+            "name": "test-pod"
+        },
+        "object": {
+            "spec": object.union(object.union(object.union(pod_sercurity_context_obj, containers_obj), init_containers_obj), node_selector_obj)
+        }
+    }
+}
+
+windowsNodeSelector = out {
+    out = {
+        "kubernetes.io/os": "windows"
+    }
+}
+
+windows_options_with_runasusername(name) = out {
+    not is_null(name)
+    out = {
+            "windowsOptions": {
+                "runAsUserName": name
+            }
+        }
+}
+windows_options_with_runasusername(name) = out {
+    is_null(name)
+    out = null
+}
+
+ctr(name, runAsUserName) = out {
+    name_obj := { "name": name }
+    security_context_obj := obj_if_exists("securityContext", windows_options_with_runasusername(runAsUserName))
+    out = object.union(name_obj, security_context_obj)
+}
+
+obj_if_exists(key, val) = out {
+    not is_null(val)
+    out := { key: val }
+}
+obj_if_exists(key, val) = out {
+    is_null(val)
+    out := {}
+}


### PR DESCRIPTION
Fixes #4 

This PR adds the following new policies
- A policy to enforce that all pods have specified node selectors set
- A policy to disallow pods that use specified RunAsUserNames in their securityContext options
- A policy that enforces best practices around resource requests/limits for Windows pods 
- Add docs for recommendations on using OS specific policies in a cluster

These library policies will use `kubernetes.io/os` node selectors to determine if a pod is a Windows pod.
Once PSP v2 settles on a way to identify the OS for a pod I can update these library polices to use the same mechanism in a future PR.

Documentation will be added to describe usages patterns following https://github.com/open-policy-agent/gatekeeper-library/pull/70#issuecomment-824460250

Signed-off-by: Mark Rossetti <marosset@microsoft.com>