### PR TITLE
add mutation pod security policies

### DIFF
--- a/library/experimental/mutation/pod-security-policy/allow-privilege-escalation/samples/default-allow-privilege-escalation/example.yaml
+++ b/library/experimental/mutation/pod-security-policy/allow-privilege-escalation/samples/default-allow-privilege-escalation/example.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-default-privilege-escalation
+  labels:
+    app: nginx-default-privilege-escalation
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/library/experimental/mutation/pod-security-policy/allow-privilege-escalation/samples/mutation.yaml
+++ b/library/experimental/mutation/pod-security-policy/allow-privilege-escalation/samples/mutation.yaml
@@ -1,0 +1,16 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: Assign
+metadata:
+  name: k8spspdefaultallowprivilegeescalation
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.containers[name:*].securityContext.allowPrivilegeEscalation"
+  parameters:
+    pathTests:
+    - subPath: "spec.containers[name:*].securityContext.allowPrivilegeEscalation"
+      condition: MustNotExist
+    assign:
+      value: false

--- a/library/experimental/mutation/pod-security-policy/apparmor/samples/default-apparmor/example.yaml
+++ b/library/experimental/mutation/pod-security-policy/apparmor/samples/default-apparmor/example.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-default-apparmor
+  labels:
+    app: nginx-default-apparmor
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/library/experimental/mutation/pod-security-policy/apparmor/samples/mutation.yaml
+++ b/library/experimental/mutation/pod-security-policy/apparmor/samples/mutation.yaml
@@ -1,0 +1,14 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: AssignMetadata
+metadata:
+  name: k8spspapparmor
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+    - apiGroups: [""]
+      kinds: ["Pod"]
+  location: metadata.annotations."apparmor.security.beta.kubernetes.io/pod"
+  parameters:
+    assign:
+      value: runtime/default

--- a/library/experimental/mutation/pod-security-policy/capabilities/samples/default-add-capabilities/example.yaml
+++ b/library/experimental/mutation/pod-security-policy/capabilities/samples/default-add-capabilities/example.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-default-add-capabilities
+  labels:
+    app: nginx-default-add-capabilities
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/library/experimental/mutation/pod-security-policy/capabilities/samples/mutation.yaml
+++ b/library/experimental/mutation/pod-security-policy/capabilities/samples/mutation.yaml
@@ -1,0 +1,13 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: Assign
+metadata:
+  name: k8spspcapabilities
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.containers[name:*].securityContext.capabilities.add"
+  parameters:
+    assign:
+      value: ["NEW_CAPABILITY"] # default add capability

--- a/library/experimental/mutation/pod-security-policy/read-only-root-filesystem/samples/mutation.yaml
+++ b/library/experimental/mutation/pod-security-policy/read-only-root-filesystem/samples/mutation.yaml
@@ -1,0 +1,16 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: Assign
+metadata:
+  name: k8spspreadonlyrootfs
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.containers[name:*].securityContext.readOnlyRootFilesystem"
+  parameters:
+    pathTests:
+    - subPath: "spec.containers[name:*].securityContext.readOnlyRootFilesystem"
+      condition: MustNotExist
+    assign:
+      value: true

--- a/library/experimental/mutation/pod-security-policy/read-only-root-filesystem/samples/read-only-root-filesystem/example.yaml
+++ b/library/experimental/mutation/pod-security-policy/read-only-root-filesystem/samples/read-only-root-filesystem/example.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-readonlyrootfs
+  labels:
+    app: nginx-readonlyrootfs
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/library/experimental/mutation/pod-security-policy/seccomp/samples/default-seccomp/example.yaml
+++ b/library/experimental/mutation/pod-security-policy/seccomp/samples/default-seccomp/example.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-default-seccomp
+  labels:
+    app: nginx-default-seccomp
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/library/experimental/mutation/pod-security-policy/seccomp/samples/mutation.yaml
+++ b/library/experimental/mutation/pod-security-policy/seccomp/samples/mutation.yaml
@@ -1,0 +1,17 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: AssignMetadata
+metadata:
+  name: k8spspseccomp
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+    - apiGroups: [""]
+      kinds: ["Pod"]
+  location: metadata.annotations."seccomp.security.alpha.kubernetes.io/pod"
+  parameters:
+    pathTests:
+    - subPath: metadata.annotations."seccomp.security.alpha.kubernetes.io/pod"
+      condition: MustNotExist
+    assign:
+      value: runtime/default

--- a/library/experimental/mutation/pod-security-policy/selinux/samples/default-selinux/example.yaml
+++ b/library/experimental/mutation/pod-security-policy/selinux/samples/default-selinux/example.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-default-selinux
+  labels:
+    app: nginx-default-selinux
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/library/experimental/mutation/pod-security-policy/selinux/samples/mutation.yaml
+++ b/library/experimental/mutation/pod-security-policy/selinux/samples/mutation.yaml
@@ -1,0 +1,20 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: Assign
+metadata:
+  name: k8spspselinux
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: spec.containers[name:*].securityContext.seLinuxOptions
+  parameters:
+    pathTests:
+    - subPath: spec.containers[name:*].securityContext.seLinuxOptions
+      condition: MustNotExist
+    assign:
+      value:
+        level: s1:c234,c567
+        user: sysadm_u
+        role: sysadm_r
+        type: svirt_lxc_net_t

--- a/library/experimental/mutation/pod-security-policy/users/samples/mutation-fsGroup.yaml
+++ b/library/experimental/mutation/pod-security-policy/users/samples/mutation-fsGroup.yaml
@@ -1,0 +1,16 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: Assign
+metadata:
+  name: k8spspfsGroup
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.securityContext.fsGroup"
+  parameters:
+    pathTests:
+    - subPath: "spec.securityContext.fsGroup"
+      condition: MustNotExist
+    assign:
+      value: 3000

--- a/library/experimental/mutation/pod-security-policy/users/samples/mutation-mustRunAsNonRoot.yaml
+++ b/library/experimental/mutation/pod-security-policy/users/samples/mutation-mustRunAsNonRoot.yaml
@@ -1,0 +1,16 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: Assign
+metadata:
+  name: k8spsprunasnonroot
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.containers[name:*].securityContext.runAsNonRoot"
+  parameters:
+    pathTests:
+      - subPath: "spec.containers[name:*].securityContext.runAsNonRoot"
+        condition: MustNotExist
+    assign:
+      value: true

--- a/library/experimental/mutation/pod-security-policy/users/samples/mutation-runAsGroup.yaml
+++ b/library/experimental/mutation/pod-security-policy/users/samples/mutation-runAsGroup.yaml
@@ -1,0 +1,16 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: Assign
+metadata:
+  name: k8spsprunasgroup
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.containers[name:*].securityContext.runAsGroup"
+  parameters:
+    pathTests:
+    - subPath: "spec.containers[name:*].securityContext.runAsGroup"
+      condition: MustNotExist
+    assign:
+      value: 2000

--- a/library/experimental/mutation/pod-security-policy/users/samples/mutation-runAsUser.yaml
+++ b/library/experimental/mutation/pod-security-policy/users/samples/mutation-runAsUser.yaml
@@ -1,0 +1,16 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: Assign
+metadata:
+  name: k8spsprunasuser
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.containers[name:*].securityContext.runAsUser"
+  parameters:
+    pathTests:
+    - subPath: "spec.containers[name:*].securityContext.runAsUser"
+      condition: MustNotExist
+    assign:
+      value: 1000

--- a/library/experimental/mutation/pod-security-policy/users/samples/mutation-supplementalGroups.yaml
+++ b/library/experimental/mutation/pod-security-policy/users/samples/mutation-supplementalGroups.yaml
@@ -1,0 +1,16 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: Assign
+metadata:
+  name: k8spspsupplementalgroups
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.securityContext.supplementalGroups"
+  parameters:
+    pathTests:
+    - subPath: "spec.securityContext.supplementalGroups"
+      condition: MustNotExist
+    assign:
+      value: [3000]

--- a/library/experimental/mutation/pod-security-policy/users/samples/users/example-nomutation.yaml
+++ b/library/experimental/mutation/pod-security-policy/users/samples/users/example-nomutation.yaml
@@ -1,0 +1,16 @@
+# Pods which have specified neither runAsNonRoot nor runAsUser settings will be mutated to set runAsNonRoot=true
+# thus requiring a defined non-zero numeric USER directive in the container.
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-run-as-root
+  labels:
+    app: nginx-run-as-root
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      runAsUser: 0
+      runAsNonRoot: false

--- a/library/experimental/mutation/pod-security-policy/users/samples/users/example.yaml
+++ b/library/experimental/mutation/pod-security-policy/users/samples/users/example.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-users
+  labels:
+    app: nginx-users
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -65,6 +65,9 @@ setup() {
     if [ -d "$policy" ]; then
       local policy_group=$(basename "$(dirname "$policy")")
       local template_name=$(basename "$policy")
+      if [[ $policy_group == "experimental"  ]]; then
+        continue
+      fi
       echo "running integration test against policy group: $policy_group, constraint template: $template_name"
       # apply template
       wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl apply -k $policy"


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

Re-opening since I can't change target branch of #62 

As discussed on the community call, policies are moved to `library/experimental/mutation/pod-security-policy/`