### PR TITLE
Minor: Typo in name s/disallowed/allowed/

### DIFF
--- a/library/general/containerlimits/samples/container-must-have-limits/example_allowed.yaml
+++ b/library/general/containerlimits/samples/container-must-have-limits/example_allowed.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: opa-disallowed
+  name: opa-allowed
   labels:
     owner: me.agilebank.demo
 spec:

--- a/library/general/externalip/samples/allowed-ip/example_disallowed.yaml
+++ b/library/general/externalip/samples/allowed-ip/example_disallowed.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: allowed-external-ip
+  name: disallowed-external-ip
 spec:
   selector:
     app: MyApp


### PR DESCRIPTION
Typos in sample resources do not match the allowed/disallowed property.
