### PR TITLE
Fix k8spsphostfilesystem path matching

### DIFF
--- a/library/pod-security-policy/host-filesystem/template.yaml
+++ b/library/pod-security-policy/host-filesystem/template.yaml
@@ -78,10 +78,18 @@ spec:
         # This allows "/foo", "/foo/", "/foo/bar" etc., but
         # disallows "/fool", "/etc/foo" etc.
         path_matches(prefix, path) {
-            a := split(trim(prefix, "/"), "/")
-            b := split(trim(path, "/"), "/")
+            a := path_array(prefix)
+            b := path_array(path)
             prefix_matches(a, b)
         }
+        path_array(p) = out {
+            p != "/"
+            out := split(trim(p, "/"), "/")
+        }
+        # This handles the special case for "/", since
+        # split(trim("/", "/"), "/") == [""]
+        path_array("/") = []
+
         prefix_matches(a, b) {
             count(a) <= count(b)
             not any_not_equal_upto(a, b, count(a))

--- a/src/pod-security-policy/host-filesystem/src.rego
+++ b/src/pod-security-policy/host-filesystem/src.rego
@@ -50,10 +50,18 @@ writeable_input_volume_mounts(volume_name) {
 # This allows "/foo", "/foo/", "/foo/bar" etc., but
 # disallows "/fool", "/etc/foo" etc.
 path_matches(prefix, path) {
-    a := split(trim(prefix, "/"), "/")
-    b := split(trim(path, "/"), "/")
+    a := path_array(prefix)
+    b := path_array(path)
     prefix_matches(a, b)
 }
+path_array(p) = out {
+    p != "/"
+    out := split(trim(p, "/"), "/")
+}
+# This handles the special case for "/", since
+# split(trim("/", "/"), "/") == [""]
+path_array("/") = []
+
 prefix_matches(a, b) {
     count(a) <= count(b)
     not any_not_equal_upto(a, b, count(a))

--- a/src/pod-security-policy/host-filesystem/src_test.rego
+++ b/src/pod-security-policy/host-filesystem/src_test.rego
@@ -129,6 +129,18 @@ test_input_hostpath_many_not_allowed_readonly_init_containers {
     count(results) == 2
 }
 
+
+# Unit Tests
+test_path_matches {
+    path_matches("/foo", "/foo/")
+    path_matches("/foo", "/foo/r")
+    path_matches("/", "/foo")
+    not path_matches("/foo", "/fool")
+    not path_matches("/foo", "/etc/foo")
+    not path_matches("/foo", "/")
+}
+
+
 input_review = {
     "object": {
         "metadata": {


### PR DESCRIPTION
This change updates the path matching logic to correctly handle "/",
which should match all paths.

Fixes https://github.com/open-policy-agent/gatekeeper-library/issues/96