### PR TITLE
ClusterRole system:aggregate-to-edit should not allow endpoints permissions

### DIFF
--- a/library/general/block-endpoint-edit-default-role/kustomization.yaml
+++ b/library/general/block-endpoint-edit-default-role/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/block-endpoint-edit-default-role/samples/block-endpoint-edit-default-role/constraint.yaml
+++ b/library/general/block-endpoint-edit-default-role/samples/block-endpoint-edit-default-role/constraint.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sBlockEndpointEditDefaultRole
+metadata:
+  name: block-endpoint-edit-default-role
+spec:
+  match:
+    kinds:
+      - apiGroups: ["rbac.authorization.k8s.io"]
+        kinds: ["ClusterRole"]

--- a/library/general/block-endpoint-edit-default-role/samples/block-endpoint-edit-default-role/example_allowed.yaml
+++ b/library/general/block-endpoint-edit-default-role/samples/block-endpoint-edit-default-role/example_allowed.yaml
@@ -1,0 +1,138 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: null
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: system:aggregate-to-edit
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  - secrets
+  - services/proxy
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - persistentvolumeclaims
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - secrets
+  - serviceaccounts
+  - services
+  - services/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - ingresses
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicationcontrollers/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/library/general/block-endpoint-edit-default-role/samples/block-endpoint-edit-default-role/example_disallowed.yaml
+++ b/library/general/block-endpoint-edit-default-role/samples/block-endpoint-edit-default-role/example_disallowed.yaml
@@ -1,0 +1,79 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: null
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: system:aggregate-to-edit
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  - secrets
+  - services/proxy
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - persistentvolumeclaims
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - secrets
+  - serviceaccounts
+  - services
+  - services/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - endpoints
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/library/general/block-endpoint-edit-default-role/template.yaml
+++ b/library/general/block-endpoint-edit-default-role/template.yaml
@@ -1,0 +1,36 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblockendpointeditdefaultrole
+  annotations:
+    description: "ClusterRole/system:aggregate-to-edit should not allow endpoint edit permissions due to CVE-2021-25740, Endpoint & EndpointSlice permissions allow cross-Namespace forwarding, https://github.com/kubernetes/kubernetes/issues/103675"
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockEndpointEditDefaultRole
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sblockendpointeditdefaultrole
+
+        violation[{"msg": msg}] {
+          input.review.object.metadata.name == "system:aggregate-to-edit"
+          endpointRule(input.review.object.rules[_])
+          msg := "ClusterRole system:aggregate-to-edit should not allow endpoint edit permissions. For k8s version < 1.22, the Cluster Role should be annotated with rbac.authorization.kubernetes.io/autoupdate=false to prevent autoreconciliation back to default permissions for this role."
+        }
+
+        endpointRule(rule) {
+          "endpoints" == rule.resources[_]
+          hasEditVerb(rule.verbs)
+        }
+
+        hasEditVerb(verbs) {
+          "create" == verbs[_]
+        }
+        hasEditVerb(verbs) {
+          "patch" == verbs[_]
+        }
+        hasEditVerb(verbs) {
+          "update" == verbs[_]
+        }

--- a/src/general/block-endpoint-edit-role/src.rego
+++ b/src/general/block-endpoint-edit-role/src.rego
@@ -1,0 +1,24 @@
+package k8sblockendpointeditdefaultrole
+
+violation[{"msg": msg}] {
+    input.review.object.metadata.name == "system:aggregate-to-edit"
+    endpointRule(input.review.object.rules[_])
+    msg := "ClusterRole system:aggregate-to-edit should not allow endpoint edit permissions. For k8s version < 1.22, the Cluster Role should be annotated with rbac.authorization.kubernetes.io/autoupdate=false to prevent autoreconciliation back to default permissions for this role."
+}
+
+endpointRule(rule) {
+    "endpoints" == rule.resources[_]
+    hasEditVerb(rule.verbs)
+}
+
+hasEditVerb(verbs) {
+    "create" == verbs[_]
+}
+
+hasEditVerb(verbs) {
+    "patch" == verbs[_]
+}
+
+hasEditVerb(verbs) {
+    "update" == verbs[_]
+}

--- a/src/general/block-endpoint-edit-role/src_test.rego
+++ b/src/general/block-endpoint-edit-role/src_test.rego
@@ -1,0 +1,112 @@
+package k8sblockendpointeditdefaultrole
+
+test_input_no_endpoints_edit_role_allow {
+    input := { "review": input_review_withoutendpoints }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_endpoints_create_role_not_allow {
+    input := { "review": input_review_with_endpoints_create }
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_endpoints_update_role_not_allow {
+    input := { "review": input_review_with_endpoints_update }
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_endpoints_patch_role_not_allow {
+    input := { "review": input_review_with_endpoints_patch }
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_endpoints_delete_role_allow {
+    input := { "review": input_review_with_endpoints_delete }
+    results := violation with input as input
+    count(results) == 0
+}
+
+input_review_withoutendpoints() = {
+    "object": {
+        "metadata":{
+            "annotations":{
+                "rbac.authorization.kubernetes.io/autoupdate": "false"
+            },
+            "name": "system:aggregate-to-edit"
+        },
+        "rules": [
+            input_rule(["pods"], ["create"]),
+            input_rule(["services"], ["delete"])
+        ]
+    }
+}
+
+input_review_with_endpoints_create() = {
+    "object": {
+        "metadata":{
+            "annotations":{
+                "rbac.authorization.kubernetes.io/autoupdate": "false"
+            },
+            "name": "system:aggregate-to-edit"
+        },
+        "rules": [
+            input_rule(["pods", "endpoints"], ["create"]),
+            input_rule(["services"], ["delete"])
+        ]
+    }
+}
+
+input_review_with_endpoints_update() = {
+    "object": {
+        "metadata":{
+            "annotations":{
+                "rbac.authorization.kubernetes.io/autoupdate": "false"
+            },
+            "name": "system:aggregate-to-edit"
+        },
+        "rules": [
+            input_rule(["pods", "endpoints"], ["update"]),
+            input_rule(["services"], ["delete"])
+        ]
+    }
+}
+
+input_review_with_endpoints_patch() = {
+    "object": {
+        "metadata":{
+            "annotations":{
+                "rbac.authorization.kubernetes.io/autoupdate": "false"
+            },
+            "name": "system:aggregate-to-edit"
+        },
+        "rules": [
+            input_rule(["pods", "endpoints"], ["patch"]),
+            input_rule(["services"], ["delete"])
+        ]
+    }
+}
+
+input_review_with_endpoints_delete() = {
+    "object": {
+        "metadata":{
+            "annotations":{
+                "rbac.authorization.kubernetes.io/autoupdate": "false"
+            },
+            "name": "system:aggregate-to-edit"
+        },
+        "rules": [
+            input_rule(["pods"], ["create"]),
+            input_rule(["services", "endpoints"], ["delete"])
+        ]
+    }
+}
+
+input_rule(resources,verbs) = {
+    "apiGroups": [""],
+    "resources": resources,
+    "verbs": verbs
+}


### PR DESCRIPTION
One policy for issue:
CVE-2021-25740: Endpoint & EndpointSlice permissions allow cross-Namespace forwarding · Issue #103675 · kubernetes/kubernetes
https://github.com/kubernetes/kubernetes/issues/103675

Considering violated system:aggregate-to-edit is automatically created for cluster under v1.22, this Azure Policy will only allow audit/disable (no deny)