### PR TITLE
Document steps for installing via kustomize in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A community-owned library of policies for the [OPA Gatekeeper project](https://open-policy-agent.github.io/gatekeeper/website/docs/).
 
-## Usage - kustomize
+## Usage
+
+### kustomize
 
 You can use [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) to install some or all of the templates alongside your own contraints.
 
@@ -25,7 +27,7 @@ You can install everything with `kustomize build . | kubectl apply -f -`.
 More information can be found in the [kustomization documentation](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/).
 
 
-## Usage - kubectl
+### kubectl
 
 Instead of using kustomize, you can directly apply the `template.yaml` and `constraint.yaml` provided in each directory under `library/`
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,33 @@
 # OPA Gatekeeper Library
 
-A community-owned library of policies for the OPA Gatekeeper project.
+A community-owned library of policies for the [OPA Gatekeeper project](https://open-policy-agent.github.io/gatekeeper/website/docs/).
 
-## Usage
+## Usage - kustomize
 
-Apply the `template.yaml` and `constraint.yaml` provided in each directory under `library/`
+You can use [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) to install some or all of the templates alongside your own contraints.
+
+First, create a `kustomization.yaml` file:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- github.com/open-policy-agent/gatekeeper-library/library
+# You can optionally install a subset by specifying a subfolder, or specify a commit SHA
+# - github.com/open-policy-agent/gatekeeper-library/library/pod-security-policy?ref=0c82f402fb3594097a90d15215ae223267f5b955
+- constraints.yaml
+```
+
+Then define your constraints in a file called `constraints.yaml` in the same directory. Example constraints can be found in the "samples" folders.
+
+You can install everything with `kustomize build . | kubectl apply -f -`.
+
+More information can be found in the [kustomization documentation](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/).
+
+
+## Usage - kubectl
+
+Instead of using kustomize, you can directly apply the `template.yaml` and `constraint.yaml` provided in each directory under `library/`
 
 For example
 


### PR DESCRIPTION
I've always found the official kustomize documentation to be frustratingly organized and not in-depth enough. Especially for edge cases like ours where users will probably want to use the remote templates, but define their constraints in a local file. As a result, I think we should provide the exact steps for installing with kustomize in the readme.

Here's another repo that provides similarly detailed installation steps: https://metallb.org/installation/