### PR TITLE
Treat "ALL" capability as special

### DIFF
--- a/library/pod-security-policy/capabilities/template.yaml
+++ b/library/pod-security-policy/capabilities/template.yaml
@@ -36,7 +36,7 @@ spec:
         violation[{"msg": msg}] {
           container := input.review.object.spec.containers[_]
           missing_drop_capabilities(container)
-          msg := sprintf("container <%v> is not dropping all required capabilities. Container must drop all of %v", [container.name, input.parameters.requiredDropCapabilities])
+          msg := sprintf("container <%v> is not dropping all required capabilities. Container must drop all of %v or \"ALL\"", [container.name, input.parameters.requiredDropCapabilities])
         }
 
 
@@ -50,7 +50,7 @@ spec:
         violation[{"msg": msg}] {
           container := input.review.object.spec.initContainers[_]
           missing_drop_capabilities(container)
-          msg := sprintf("init container <%v> is not dropping all required capabilities. Container must drop all of %v", [container.name, input.parameters.requiredDropCapabilities])
+          msg := sprintf("init container <%v> is not dropping all required capabilities. Container must drop all of %v or \"ALL\"", [container.name, input.parameters.requiredDropCapabilities])
         }
 
 
@@ -63,8 +63,10 @@ spec:
 
         missing_drop_capabilities(container) {
           must_drop := {c | c := input.parameters.requiredDropCapabilities[_]}
-          dropped := {c | c := container.securityContext.capabilities.drop[_]}
+          all := {"all"}
+          dropped := {c | c := lower(container.securityContext.capabilities.drop[_])}
           count(must_drop - dropped) > 0
+          count(all - dropped) > 0
         }
 
         get_default(obj, param, _default) = out {

--- a/library/pod-security-policy/capabilities/template.yaml
+++ b/library/pod-security-policy/capabilities/template.yaml
@@ -55,16 +55,18 @@ spec:
 
 
         has_disallowed_capabilities(container) {
-          allowed := {c | c := input.parameters.allowedCapabilities[_]}
+          allowed := {c | c := lower(input.parameters.allowedCapabilities[_])}
           not allowed["*"]
-          capabilities := {c | c := container.securityContext.capabilities.add[_]}
+          capabilities := {c | c := lower(container.securityContext.capabilities.add[_])}
+
           count(capabilities - allowed) > 0
         }
 
         missing_drop_capabilities(container) {
-          must_drop := {c | c := input.parameters.requiredDropCapabilities[_]}
+          must_drop := {c | c := lower(input.parameters.requiredDropCapabilities[_])}
           all := {"all"}
           dropped := {c | c := lower(container.securityContext.capabilities.drop[_])}
+
           count(must_drop - dropped) > 0
           count(all - dropped) > 0
         }

--- a/src/pod-security-policy/capabilities/src.rego
+++ b/src/pod-security-policy/capabilities/src.rego
@@ -36,8 +36,8 @@ has_disallowed_capabilities(container) {
 
 missing_drop_capabilities(container) {
   must_drop := {c | c := input.parameters.requiredDropCapabilities[_]}
-  all := {"ALL"}
-  dropped := {c | c := container.securityContext.capabilities.drop[_]}
+  all := {"all"}
+  dropped := {c | c := lower(container.securityContext.capabilities.drop[_])}
   count(must_drop - dropped) > 0
   count(all - dropped) > 0
 }

--- a/src/pod-security-policy/capabilities/src.rego
+++ b/src/pod-security-policy/capabilities/src.rego
@@ -9,7 +9,7 @@ violation[{"msg": msg}] {
 violation[{"msg": msg}] {
   container := input.review.object.spec.containers[_]
   missing_drop_capabilities(container)
-  msg := sprintf("container <%v> is not dropping all required capabilities. Container must drop all of %v", [container.name, input.parameters.requiredDropCapabilities])
+  msg := sprintf("container <%v> is not dropping all required capabilities. Container must drop all of %v or \"ALL\"", [container.name, input.parameters.requiredDropCapabilities])
 }
 
 
@@ -23,7 +23,7 @@ violation[{"msg": msg}] {
 violation[{"msg": msg}] {
   container := input.review.object.spec.initContainers[_]
   missing_drop_capabilities(container)
-  msg := sprintf("init container <%v> is not dropping all required capabilities. Container must drop all of %v", [container.name, input.parameters.requiredDropCapabilities])
+  msg := sprintf("init container <%v> is not dropping all required capabilities. Container must drop all of %v or \"ALL\"", [container.name, input.parameters.requiredDropCapabilities])
 }
 
 
@@ -36,8 +36,10 @@ has_disallowed_capabilities(container) {
 
 missing_drop_capabilities(container) {
   must_drop := {c | c := input.parameters.requiredDropCapabilities[_]}
+  all := {"ALL"}
   dropped := {c | c := container.securityContext.capabilities.drop[_]}
   count(must_drop - dropped) > 0
+  count(all - dropped) > 0
 }
 
 get_default(obj, param, _default) = out {

--- a/src/pod-security-policy/capabilities/src.rego
+++ b/src/pod-security-policy/capabilities/src.rego
@@ -28,16 +28,18 @@ violation[{"msg": msg}] {
 
 
 has_disallowed_capabilities(container) {
-  allowed := {c | c := input.parameters.allowedCapabilities[_]}
+  allowed := {c | c := lower(input.parameters.allowedCapabilities[_])}
   not allowed["*"]
-  capabilities := {c | c := container.securityContext.capabilities.add[_]}
+  capabilities := {c | c := lower(container.securityContext.capabilities.add[_])}
+
   count(capabilities - allowed) > 0
 }
 
 missing_drop_capabilities(container) {
-  must_drop := {c | c := input.parameters.requiredDropCapabilities[_]}
+  must_drop := {c | c := lower(input.parameters.requiredDropCapabilities[_])}
   all := {"all"}
   dropped := {c | c := lower(container.securityContext.capabilities.drop[_])}
+
   count(must_drop - dropped) > 0
   count(all - dropped) > 0
 }

--- a/src/pod-security-policy/capabilities/src_test.rego
+++ b/src/pod-security-policy/capabilities/src_test.rego
@@ -242,6 +242,11 @@ test_input_drop_literal_all_with_all_param {
    results := violation with input as input
    count(results) == 0
 }
+test_input_drop_literal_with_all_param {
+   input := { "review": input_init_review([cdrop(["one"])]), "parameters": {"requiredDropCapabilities": ["one", "ALL"]}}
+   results := violation with input as input
+   count(results) == 1
+}
 test_input_drop_literal_all_x2 {
    input := { "review": input_init_review([cdrop(["ALL", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
    results := violation with input as input

--- a/src/pod-security-policy/capabilities/src_test.rego
+++ b/src/pod-security-policy/capabilities/src_test.rego
@@ -104,19 +104,24 @@ test_input_drop_undefined_x2 {
    count(results) == 2
 }
 test_input_drop_literal_all {
+   input := { "review": input_review([cdrop(["ALL"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+   results := violation with input as input
+   count(results) == 0
+}
+test_input_drop_literal_all_lower {
    input := { "review": input_review([cdrop(["all"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
    results := violation with input as input
-   count(results) == 1
+   count(results) == 0
 }
 test_input_drop_literal_all_with_all_param {
-   input := { "review": input_review([cdrop(["all"])]), "parameters": {"requiredDropCapabilities": ["one", "all"]}}
+   input := { "review": input_review([cdrop(["ALL"])]), "parameters": {"requiredDropCapabilities": ["one", "ALL"]}}
    results := violation with input as input
-   count(results) == 1
+   count(results) == 0
 }
 test_input_drop_literal_all_x2 {
-   input := { "review": input_review([cdrop(["all", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+   input := { "review": input_review([cdrop(["ALL", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
    results := violation with input as input
-   count(results) == 1
+   count(results) == 0
 }
 
 # init containers
@@ -223,19 +228,24 @@ test_input_drop_undefined_x2 {
    count(results) == 2
 }
 test_input_drop_literal_all {
+   input := { "review": input_init_review([cdrop(["ALL"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+   results := violation with input as input
+   count(results) == 0
+}
+test_input_drop_literal_all_lower {
    input := { "review": input_init_review([cdrop(["all"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
    results := violation with input as input
-   count(results) == 1
+   count(results) == 0
 }
 test_input_drop_literal_all_with_all_param {
-   input := { "review": input_init_review([cdrop(["all"])]), "parameters": {"requiredDropCapabilities": ["one", "all"]}}
+   input := { "review": input_init_review([cdrop(["ALL"])]), "parameters": {"requiredDropCapabilities": ["one", "ALL"]}}
    results := violation with input as input
-   count(results) == 1
+   count(results) == 0
 }
 test_input_drop_literal_all_x2 {
-   input := { "review": input_init_review([cdrop(["all", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+   input := { "review": input_init_review([cdrop(["ALL", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
    results := violation with input as input
-   count(results) == 1
+   count(results) == 0
 }
 
 

--- a/src/pod-security-policy/capabilities/src_test.rego
+++ b/src/pod-security-policy/capabilities/src_test.rego
@@ -103,6 +103,21 @@ test_input_drop_undefined_x2 {
    results := violation with input as input
    count(results) == 2
 }
+test_input_drop_literal_all {
+   input := { "review": input_review([cdrop(["all"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+   results := violation with input as input
+   count(results) == 1
+}
+test_input_drop_literal_all_with_all_param {
+   input := { "review": input_review([cdrop(["all"])]), "parameters": {"requiredDropCapabilities": ["one", "all"]}}
+   results := violation with input as input
+   count(results) == 1
+}
+test_input_drop_literal_all_x2 {
+   input := { "review": input_review([cdrop(["all", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+   results := violation with input as input
+   count(results) == 1
+}
 
 # init containers
 test_input_all_allowed {
@@ -207,6 +222,22 @@ test_input_drop_undefined_x2 {
    results := violation with input as input
    count(results) == 2
 }
+test_input_drop_literal_all {
+   input := { "review": input_init_review([cdrop(["all"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+   results := violation with input as input
+   count(results) == 1
+}
+test_input_drop_literal_all_with_all_param {
+   input := { "review": input_init_review([cdrop(["all"])]), "parameters": {"requiredDropCapabilities": ["one", "all"]}}
+   results := violation with input as input
+   count(results) == 1
+}
+test_input_drop_literal_all_x2 {
+   input := { "review": input_init_review([cdrop(["all", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+   results := violation with input as input
+   count(results) == 1
+}
+
 
 input_review(containers) = output {
     cs := [o | c := containers[i]; o := inject_name(i, c)]


### PR DESCRIPTION
When checking required drop capabilities, if the container drops "ALL" that should not trigger a violation even if other specifc capabilites are in the requiredDropCapabilities parameter.