### PR TITLE
Add library policy for HostProcess containers

### DIFF
--- a/library/pod-security-policy/hostprocess-containers/kustomization.yaml
+++ b/library/pod-security-policy/hostprocess-containers/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/hostprocess-containers/samples/constraint.yaml
+++ b/library/pod-security-policy/hostprocess-containers/samples/constraint.yaml
@@ -1,0 +1,10 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostProcessContainer
+metadata:
+  name: psp-hostprocess-containers
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces: ["kube-system"]

--- a/library/pod-security-policy/hostprocess-containers/samples/example_allowed.yaml
+++ b/library/pod-security-policy/hostprocess-containers/samples/example_allowed.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nanoserver-ping-loop
+spec:
+  containers:
+  - name: ping-loop
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+  nodeSelector:
+    "kubernetes.io/os": windows

--- a/library/pod-security-policy/hostprocess-containers/samples/example_disallowed_container.yaml
+++ b/library/pod-security-policy/hostprocess-containers/samples/example_disallowed_container.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nanoserver-ping-loop-hostprocess-container
+spec:
+  hostNetwork: true
+  containers:
+  - name: ping-test
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+        runAsUserName: "NT AUTHORITY\\SYSTEM"
+  nodeSelector:
+    "kubernetes.io/os": windows

--- a/library/pod-security-policy/hostprocess-containers/samples/example_disallowed_pod.yaml
+++ b/library/pod-security-policy/hostprocess-containers/samples/example_disallowed_pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nanoserver-ping-loop-hostprocess-pod
+spec:
+  securityContext:
+    windowsOptions:
+      hostProcess: true
+      runAsUserName: "NT AUTHORITY\\SYSTEM"
+  hostNetwork: true
+  containers:
+  - name: ping-test
+    image: mcr.microsoft.com/windows/nanoserver:1809
+    command:
+      - "ping"
+      - "-t"
+      - "127.0.0.1"
+  nodeSelector:
+    "kubernetes.io/os": windows

--- a/library/pod-security-policy/hostprocess-containers/template.yaml
+++ b/library/pod-security-policy/hostprocess-containers/template.yaml
@@ -1,0 +1,44 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+  name: k8spsphostprocess
+  annotations:
+    description: Prohibits running of HostProcess containers. https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/ for more information.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPHostProcessContainer
+  targets:
+  - target: admission.k8s.gatekeeper.sh
+    rego: |
+      package k8spsphostprocess
+
+      violation[{"msg": msg}] {
+          c := input_containers[_]
+          is_hostprocess(c)
+          msg := sprintf("HostProcess container is not allowed: %v", [c.name])
+      }
+
+      # returns true if hostProcess is set to true for container
+      is_hostprocess(c) = true {
+          c.securityContext.windowsOptions.hostProcess == true
+      }
+
+      # returns true if hostProcess is not specified for container AND is set to true on pod
+      is_hostprocess(c) = true {
+          not sets_hostprocess(c)
+          input.review.object.spec.securityContext.windowsOptions.hostProcess == true
+      }
+
+      # returns true if hostProcess is set for container
+      sets_hostprocess(c) {
+          c.securityContext.windowsOptions.hostProcess != null
+      }
+
+      input_containers[c] {
+          c := input.review.object.spec.containers[_]
+      }
+
+      input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+      }

--- a/library/pod-security-policy/kustomization.yaml
+++ b/library/pod-security-policy/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - host-filesystem
   - host-namespaces
   - host-network-ports
+  - hostprocess-containers
   - privileged-containers
   - proc-mount
   - read-only-root-filesystem

--- a/src/pod-security-policy/hostprocess-containers/src.rego
+++ b/src/pod-security-policy/hostprocess-containers/src.rego
@@ -1,0 +1,31 @@
+package k8spsphostprocess
+
+violation[{"msg": msg}] {
+    c := input_containers[_]
+    is_hostprocess(c)
+    msg := sprintf("HostProcess container is not allowed: %v", [c.name])
+}
+
+# returns true if hostProcess is set to true for container
+is_hostprocess(c) = true {
+    c.securityContext.windowsOptions.hostProcess == true
+}
+
+# returns true if hostProcess is not specified for container AND is set to true on pod
+is_hostprocess(c) = true {
+    not sets_hostprocess(c)
+    input.review.object.spec.securityContext.windowsOptions.hostProcess == true
+}
+
+# returns true if hostProcess is set for container
+sets_hostprocess(c) {
+    c.securityContext.windowsOptions.hostProcess != null
+}
+
+input_containers[c] {
+    c := input.review.object.spec.containers[_]
+}
+
+input_containers[c] {
+    c := input.review.object.spec.initContainers[_]
+}

--- a/src/pod-security-policy/hostprocess-containers/src_test.rego
+++ b/src/pod-security-policy/hostprocess-containers/src_test.rego
@@ -1,0 +1,97 @@
+package k8spsphostprocess
+
+test_empty_spec {
+    input := { "review": make_review(null, null, null) }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_pod_hostprocess_null_no_hostprocess_containers {
+    input := { "review": make_review(null, [ctr("ctr1", null), ctr("ctr2", false)], [ctr("init1", null), ctr("init2", false)]) }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_pod_hostprocess_false_no_hostprocess_containers {
+    input := { "review": make_review(false, [ctr("ctr1", null), ctr("ctr2", false)], [ctr("init1", null), ctr("init2", false)]) }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_pod_hostprocess_null_some_hostprocess_containers {
+    input := { "review": make_review(null, [ctr("ctr1", null), ctr("ctr2", false), ctr("ctr3", true)], [ctr("init1", null), ctr("init2", false), ctr("init3", true)]) }
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_pod_hostprocess_false_some_hostprocess_containers {
+    input := { "review": make_review(false, [ctr("ctr1", null), ctr("ctr2", false), ctr("ctr3", true)], [ctr("init1", null), ctr("init2", false), ctr("init3", true)]) }
+    results := violation with input as input
+    count(results) == 2
+}
+
+
+test_pod_hostprocess_true_no_containers_set_hostprocess { input := { "review": make_review(true, [ctr("ctr1", null)], [ctr("init1", null)]) }
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_pod_hostprocess_true_containers_set_hostprocess_false {
+    input := { "review": make_review(true, [ctr("ctr1", false)], [ctr("init1", false)]) }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_pod_hostprocess_true_containers_set_hostprocess_true {
+    input := { "review": make_review(true, [ctr("ctr1", true)], [ctr("init1", true)]) }
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_pod_hostprocess_true_some_containers_set_hostprocess_true {
+    input := { "review": make_review(true, [ctr("ctr1", null), ctr("ctr2", false), ctr("ctr3", true)], [ctr("init1", null), ctr("init2", false), ctr("init3", true)]) }
+    results := violation with input as input
+    count(results) == 4
+}
+
+make_review(pod_is_hostprocess, containers, init_containers) = out {
+
+    pod_security_context_obj := obj_if_exists("securityContext", windows_options_with_hostprocess(pod_is_hostprocess))
+    container_obj := obj_if_exists("containers", containers)
+    init_containers_obj := obj_if_exists("initContainers", init_containers)
+    out = {
+        "object": {
+            "spec": object.union(object.union(pod_security_context_obj, container_obj), init_containers_obj)
+        }
+    }
+}
+
+windows_options_with_hostprocess(is_hostprocess) = out {
+    not is_null(is_hostprocess)
+    out = {
+        "windowsOptions": {
+            "hostProcess": is_hostprocess
+        }
+    }
+}
+
+windows_options_with_hostprocess(is_hostprocess) = out {
+    is_null(is_hostprocess)
+    out = null
+}
+
+ctr(name, is_hostprocess) = out {
+    name_obj = { "name": name }
+    security_context_obj := obj_if_exists("securityContext", windows_options_with_hostprocess(is_hostprocess))
+    out = object.union(name_obj, security_context_obj)
+}
+
+obj_if_exists(key, val) = out {
+    not is_null(val)
+    out := { key: val }
+}
+
+obj_if_exists(key, val) = out {
+    is_null(val)
+    out := {}
+}


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

This PR adds a library policy to deny pods if either
- Any container specifies securityContext.windowsOptions.hostProcess
- The pod specifies securityContext.windowsOptions.hostProcess

HostProcess containers on Windows are similar to privileged containers on Linux and have access to most of the node resources.
HostProcess containers feature is going beta Kubernetes v1.23 and are also blocked under both baseline and restricted policies under the Pod Security Standards.

https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline