### PR TITLE
add reorder parameter to example kustomize command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ resources:
 
 Then define your constraints in a file called `constraints.yaml` in the same directory. Example constraints can be found in the "samples" folders.
 
-You can install everything with `kustomize build . | kubectl apply -f -`.
+You can install everything with `kustomize --reorder none build . | kubectl apply -f -`.
 
 More information can be found in the [kustomization documentation](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/).
 


### PR DESCRIPTION
If you run the example kustomize build and apply command, the constrainttemplate is created after the constraint. The first time this is run, it results in the error below: 

```
constrainttemplate.templates.gatekeeper.sh/k8sreplicalimits created
Error from server (NotFound): error when creating "STDIN": the server could not find the requested resource
```

Using the --reorder none parameter resolves this issue