### PR TITLE
Create block-wildcard-ingress constraint

### DIFF
--- a/library/general/block-wildcard-ingress/kustomization.yaml
+++ b/library/general/block-wildcard-ingress/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/constraint.yaml
+++ b/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/constraint.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sBlockWildcardIngress
+metadata:
+  name: block-wildcard-ingress
+spec:
+  match:
+    kinds:
+      - apiGroups: ["extensions", "networking.k8s.io"]
+        kinds: ["Ingress"]

--- a/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/disallowed/blank_host.yaml
+++ b/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/disallowed/blank_host.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wildcard-ingress
+spec:
+  rules:
+  - host: ''
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: example
+            port:
+              number: 80

--- a/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/disallowed/host_omitted.yaml
+++ b/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/disallowed/host_omitted.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wildcard-ingress
+spec:
+  rules:
+  # Omitted host field counts as a wildcard too
+  - http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: example
+            port:
+              number: 80

--- a/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/disallowed/wildcard_host.yaml
+++ b/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/disallowed/wildcard_host.yaml
@@ -14,18 +14,9 @@ spec:
             name: example
             port:
               number: 80
-  - host: ''
+  # Extra test to ensure the rule still detects invalid hosts in files containing valid hosts
+  - host: 'valid.example.com'
     http:
-      paths:
-      - pathType: Prefix
-        path: "/"
-        backend:
-          service:
-            name: example
-            port:
-              number: 80
-  # Omitted host field counts as a wildcard too
-  - http:
       paths:
       - pathType: Prefix
         path: "/"

--- a/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/example_allowed.yaml
+++ b/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/example_allowed.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: non-wildcard-ingress
+spec:
+  rules:
+  - host: 'myservice.example.com'
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: example
+            port:
+              number: 80

--- a/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/example_disallowed.yaml
+++ b/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/example_disallowed.yaml
@@ -24,17 +24,6 @@ spec:
             name: example
             port:
               number: 80
-  # Some clients display the host as '_' when it's blank, but I don't think this is a valid hostname anyway
-  - host: '_'
-    http:
-      paths:
-      - pathType: Prefix
-        path: "/"
-        backend:
-          service:
-            name: example
-            port:
-              number: 80
   # Omitted host field counts as a wildcard too
   - http:
       paths:

--- a/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/example_disallowed.yaml
+++ b/library/general/block-wildcard-ingress/samples/block-wildcard-ingress/example_disallowed.yaml
@@ -1,0 +1,47 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wildcard-ingress
+spec:
+  rules:
+  - host: '*.example.com'
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: example
+            port:
+              number: 80
+  - host: ''
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: example
+            port:
+              number: 80
+  # Some clients display the host as '_' when it's blank, but I don't think this is a valid hostname anyway
+  - host: '_'
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: example
+            port:
+              number: 80
+  # Omitted host field counts as a wildcard too
+  - http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: example
+            port:
+              number: 80

--- a/library/general/block-wildcard-ingress/suite.yaml
+++ b/library/general/block-wildcard-ingress/suite.yaml
@@ -11,7 +11,15 @@ tests:
     object: samples/block-wildcard-ingress/example_allowed.yaml
     assertions:
     - violations: 0
-  - name: example-disallowed
-    object: samples/block-wildcard-ingress/example_disallowed.yaml
+  - name: blank-host
+    object: samples/block-wildcard-ingress/disallowed/blank_host.yaml
     assertions:
-    - violations: 3
+    - violations: 1
+  - name: host-omitted
+    object: samples/block-wildcard-ingress/disallowed/host_omitted.yaml
+    assertions:
+    - violations: 1
+  - name: wildcard-host
+    object: samples/block-wildcard-ingress/disallowed/wildcard_host.yaml
+    assertions:
+    - violations: 1

--- a/library/general/block-wildcard-ingress/suite.yaml
+++ b/library/general/block-wildcard-ingress/suite.yaml
@@ -14,4 +14,4 @@ tests:
   - name: example-disallowed
     object: samples/block-wildcard-ingress/example_disallowed.yaml
     assertions:
-    - violations: 4
+    - violations: 3

--- a/library/general/block-wildcard-ingress/suite.yaml
+++ b/library/general/block-wildcard-ingress/suite.yaml
@@ -1,0 +1,17 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: block-wildcard-ingress
+tests:
+- name: block-wildcard-ingress
+  template: template.yaml
+  constraint: samples/block-wildcard-ingress/constraint.yaml
+  cases:
+  - name: example-allowed
+    object: samples/block-wildcard-ingress/example_allowed.yaml
+    assertions:
+    - violations: 0
+  - name: example-disallowed
+    object: samples/block-wildcard-ingress/example_disallowed.yaml
+    assertions:
+    - violations: 4

--- a/library/general/block-wildcard-ingress/template.yaml
+++ b/library/general/block-wildcard-ingress/template.yaml
@@ -1,0 +1,36 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblockwildcardingress
+  annotations:
+    description: >-
+      Users should not be able to create Ingresses with a blank or wildcard (*) hostname since that would enabled them to intercept traffic for other services in the cluster, even if they don't have access to those services.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockWildcardIngress
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      # Try it out: https://play.openpolicyagent.org/p/Cfw0Ycx7OB
+      rego: |
+        package K8sBlockWildcardIngress
+
+        # This is how you express logical OR: https://www.openpolicyagent.org/docs/latest/#logical-or
+        is_wildcard = true {
+          object.get(input.review.object.spec.rules[_], "host", "") == ""
+        }
+        is_wildcard = true {
+          object.get(input.review.object.spec.rules[_], "host", "") == "_"
+        }
+        is_wildcard = true {
+          contains(object.get(input.review.object.spec.rules[_], "host", ""), "*")
+        }
+
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Ingress"
+          hostname := object.get(input.review.object.spec.rules[_], "host", null)
+          is_wildcard
+          msg := sprintf("Hostname '%v' is not allowed since it counts as a wildcard, which can be used to intercept traffic from other applications.", [hostname])
+        }

--- a/library/general/block-wildcard-ingress/template.yaml
+++ b/library/general/block-wildcard-ingress/template.yaml
@@ -21,9 +21,6 @@ spec:
           object.get(input.review.object.spec.rules[_], "host", "") == ""
         }
         is_wildcard = true {
-          object.get(input.review.object.spec.rules[_], "host", "") == "_"
-        }
-        is_wildcard = true {
           contains(object.get(input.review.object.spec.rules[_], "host", ""), "*")
         }
 

--- a/library/general/block-wildcard-ingress/template.yaml
+++ b/library/general/block-wildcard-ingress/template.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k8sblockwildcardingress
   annotations:
     description: >-
-      Users should not be able to create Ingresses with a blank or wildcard (*) hostname since that would enabled them to intercept traffic for other services in the cluster, even if they don't have access to those services.
+      Users should not be able to create Ingresses with a blank or wildcard (*) hostname since that would enable them to intercept traffic for other services in the cluster, even if they don't have access to those services.
 spec:
   crd:
     spec:

--- a/library/general/block-wildcard-ingress/template.yaml
+++ b/library/general/block-wildcard-ingress/template.yaml
@@ -12,22 +12,22 @@ spec:
         kind: K8sBlockWildcardIngress
   targets:
     - target: admission.k8s.gatekeeper.sh
-      # Try it out: https://play.openpolicyagent.org/p/Cfw0Ycx7OB
+      # Try it out: https://play.openpolicyagent.org/p/IMrH4CFosB
       rego: |
         package K8sBlockWildcardIngress
 
         # This is how you express logical OR: https://www.openpolicyagent.org/docs/latest/#logical-or
-        is_wildcard = true {
-          object.get(input.review.object.spec.rules[_], "host", "") == ""
+        contains_wildcard(hostname) = true {
+          hostname == ""
         }
-        is_wildcard = true {
-          contains(object.get(input.review.object.spec.rules[_], "host", ""), "*")
+        contains_wildcard(hostname) = true {
+          contains(hostname, "*")
         }
-
 
         violation[{"msg": msg}] {
           input.review.kind.kind == "Ingress"
-          hostname := object.get(input.review.object.spec.rules[_], "host", null)
-          is_wildcard
+          # object.get is required to detect omitted host fields
+          hostname := object.get(input.review.object.spec.rules[_], "host", "")
+          contains_wildcard(hostname)
           msg := sprintf("Hostname '%v' is not allowed since it counts as a wildcard, which can be used to intercept traffic from other applications.", [hostname])
         }


### PR DESCRIPTION
Mentioned the reasoning here: https://github.com/kubernetes-sigs/multi-tenancy/issues/1524 , which I've copied below:

> Users can put wildcards (*) in their Ingresses, but I think this can lead to security issues in a multi-tenant environment: https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards

> Wildcards in hostnames mean that one tenant could create an ingress for "myservice.example.com" and another tenant could create an ingress for "\*.example.com" or just "\*" and wait. As long as the "myservice.example.com" ingress exists, there's no issue. But if that Ingress is ever removed, even for a second, the traffic will be sent to the other tenant's wildcard Ingress instead, where they can intercept credentials/secrets/etc.

> Additionally, if users leave the "host" field blank in their Ingress, it will automatically be converted into the wildcard "*", which means this situation may even happen by accident.

> Gatekeeper has an example policy which enforces unique Ingress hosts amongst tenants, but it doesn't handle wildcards: https://github.com/open-policy-agent/gatekeeper-library/blob/master/library/general/uniqueingresshost/template.yaml Maybe adding a benchmark here can help raise awareness of this risk.

> Additional reference: https://youtu.be/Bxnu3llBN20?t=538

This PR adds a constraint to check for wildcards in Ingress hostnames.

CAVEAT: If you create an Ingress with multiple hostnames where one of them is invalid but the others are valid, the error message will say ALL the hostnames are invalid. Any Rego experts know of a way around that? If not, It's probably rare and harmless enough to be fine IMO.

Also PS: `gator` is extremely cool! I had already written the ConstraintTemplate, but the total time it took for me to create the test case having ZERO knowledge of `gator` was like 20 minutes, which is so nice!