### PR TITLE
Rework PSP seccomp policy to support the securityContext configuration option

### DIFF
--- a/library/pod-security-policy/seccomp/suite.yaml
+++ b/library/pod-security-policy/seccomp/suite.yaml
@@ -8,15 +8,15 @@ tests:
   constraint: samples/psp-seccomp/constraint.yaml
   cases:
   - name: example-disallowed-global
-    object: samples/psp-seccomp/example_disallowed.yaml
+    object: samples/psp-seccomp/example_disallowed2.yaml
     assertions:
     - violations: 1
-      message: "Seccomp profile is not allowed"
+      message: "Seccomp profile 'unconfined' is not allowed for container 'nginx'. Found at: annotation seccomp.security.alpha.kubernetes.io/pod"
   - name: example-disallowed-container
     object: samples/psp-seccomp/example_disallowed.yaml
     assertions:
     - violations: 1
-      message: "Seccomp profile is not allowed"
+      message: "Seccomp profile 'unconfined' is not allowed for container 'nginx'. Found at: annotation container.seccomp.security.alpha.kubernetes.io/nginx"
   - name: example-allowed-container
     object: samples/psp-seccomp/example_allowed.yaml
     assertions:

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -206,7 +206,6 @@ spec:
         # Container profile as defined in pods securityContext
         get_profile(container) = {"profile": profile, "file": file, "location": location} {
         	not has_securitycontext_container(container)
-        	not has_annotation(get_container_annotation_key(container.name))
         	profile := input.review.object.spec.securityContext.seccompProfile.type
         	file := object.get(input.review.object.spec.securityContext.seccompProfile, "localhostProfile", "")
         	location := "pod securityContext"

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -73,182 +73,182 @@ spec:
         pod_annotation_key = "seccomp.security.alpha.kubernetes.io/pod"
 
         naming_translation = {
-        	# securityContext -> annotation
-        	"RuntimeDefault": ["runtime/default", "docker/default"],
-        	"Unconfined": ["unconfined"],
-        	"Localhost": ["localhost"],
-        	# annotation -> securityContext
-        	"runtime/default": ["RuntimeDefault"],
-        	"docker/default": ["RuntimeDefault"],
-        	"unconfined": ["Unconfined"],
-        	"localhost": ["Localhost"],
+            # securityContext -> annotation
+            "RuntimeDefault": ["runtime/default", "docker/default"],
+            "Unconfined": ["unconfined"],
+            "Localhost": ["localhost"],
+            # annotation -> securityContext
+            "runtime/default": ["RuntimeDefault"],
+            "docker/default": ["RuntimeDefault"],
+            "unconfined": ["Unconfined"],
+            "localhost": ["Localhost"],
         }
 
         violation[{"msg": msg}] {
-        	not input_wildcard_allowed_profiles
-        	allowed_profiles := get_allowed_profiles
-        	container := input_containers[name]
-        	not is_exempt(container)
-        	result := get_profile(container)
-        	not allowed_profile(result.profile, result.file, allowed_profiles)
-        	msg := get_message(result.profile, result.file, name, result.location, allowed_profiles)
+            not input_wildcard_allowed_profiles
+            allowed_profiles := get_allowed_profiles
+            container := input_containers[name]
+            not is_exempt(container)
+            result := get_profile(container)
+            not allowed_profile(result.profile, result.file, allowed_profiles)
+            msg := get_message(result.profile, result.file, name, result.location, allowed_profiles)
         }
 
         get_message(profile, file, name, location, allowed_profiles) = message {
-        	not profile == "Localhost"
-        	message := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, name, location, allowed_profiles])
+            not profile == "Localhost"
+            message := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, name, location, allowed_profiles])
         }
 
         get_message(profile, file, name, location, allowed_profiles) = message {
-        	profile == "Localhost"
-        	message := sprintf("Seccomp profile '%v' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, file, name, location, allowed_profiles])
+            profile == "Localhost"
+            message := sprintf("Seccomp profile '%v' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, file, name, location, allowed_profiles])
         }
 
         input_wildcard_allowed_profiles {
-        	input.parameters.allowedProfiles[_] == "*"
+            input.parameters.allowedProfiles[_] == "*"
         }
 
         input_wildcard_allowed_files {
-        	input.parameters.allowedLocalhostFiles[_] == "*"
+            input.parameters.allowedLocalhostFiles[_] == "*"
         }
 
         input_wildcard_allowed_files {
-        	"localhost/*" == input.parameters.allowedProfiles[_]
+            "localhost/*" == input.parameters.allowedProfiles[_]
         }
 
         # Simple allowed Profiles
         allowed_profile(profile, file, allowed) {
-        	not startswith(lower(profile), "localhost")
-        	profile == allowed[_]
+            not startswith(lower(profile), "localhost")
+            profile == allowed[_]
         }
 
         # seccomp Localhost without wildcard
         allowed_profile(profile, file, allowed) {
-        	profile == "Localhost"
-        	not input_wildcard_allowed_files
-        	profile == allowed[_]
-        	allowed_files := {x | x := object.get(input.parameters, "allowedLocalhostFiles", [])[_]} | get_annotation_localhost_files
-        	file == allowed_files[_]
+            profile == "Localhost"
+            not input_wildcard_allowed_files
+            profile == allowed[_]
+            allowed_files := {x | x := object.get(input.parameters, "allowedLocalhostFiles", [])[_]} | get_annotation_localhost_files
+            file == allowed_files[_]
         }
 
         # seccomp Localhost with wildcard
         allowed_profile(profile, file, allowed) {
-        	profile == "Localhost"
-        	input_wildcard_allowed_files
-        	profile == allowed[_]
+            profile == "Localhost"
+            input_wildcard_allowed_files
+            profile == allowed[_]
         }
 
         # annotation localhost with wildcard
         allowed_profile(profile, file, allowed) {
-        	"localhost/*" == allowed[_]
-        	startswith(profile, "localhost/")
+            "localhost/*" == allowed[_]
+            startswith(profile, "localhost/")
         }
 
         # annotation localhost without wildcard
         allowed_profile(profile, file, allowed) {
-        	startswith(profile, "localhost/")
-        	profile == allowed[_]
+            startswith(profile, "localhost/")
+            profile == allowed[_]
         }
 
         # Localhost files from annotation scheme
         get_annotation_localhost_files[file] {
-        	profile := input.parameters.allowedProfiles[_]
-        	startswith(profile, "localhost/")
-        	file := replace(profile, "localhost/", "")
+            profile := input.parameters.allowedProfiles[_]
+            startswith(profile, "localhost/")
+            file := replace(profile, "localhost/", "")
         }
 
         # The profiles explicitly in the list
         get_allowed_profiles[allowed] {
-        	allowed := input.parameters.allowedProfiles[_]
+            allowed := input.parameters.allowedProfiles[_]
         }
 
         # The simply translated profiles
         get_allowed_profiles[allowed] {
-        	profile := input.parameters.allowedProfiles[_]
-        	not startswith(lower(profile), "localhost")
-        	allowed := naming_translation[profile][_]
+            profile := input.parameters.allowedProfiles[_]
+            not startswith(lower(profile), "localhost")
+            allowed := naming_translation[profile][_]
         }
 
         # Seccomp Localhost to annotation translation
         get_allowed_profiles[allowed] {
-        	profile := input.parameters.allowedProfiles[_]
-        	profile == "Localhost"
-        	file := object.get(input.parameters, "allowedLocalhostFiles", [])[_]
-        	allowed := sprintf("%v/%v", [naming_translation[profile][_], file])
+            profile := input.parameters.allowedProfiles[_]
+            profile == "Localhost"
+            file := object.get(input.parameters, "allowedLocalhostFiles", [])[_]
+            allowed := sprintf("%v/%v", [naming_translation[profile][_], file])
         }
 
         # Annotation localhost to Seccomp translation
         get_allowed_profiles[allowed] {
-        	profile := input.parameters.allowedProfiles[_]
-        	startswith(profile, "localhost")
-        	allowed := naming_translation.localhost[_]
+            profile := input.parameters.allowedProfiles[_]
+            startswith(profile, "localhost")
+            allowed := naming_translation.localhost[_]
         }
 
         # Container profile as defined in pod annotation
         get_profile(container) = {"profile": profile, "file": "", "location": location} {
-        	not has_securitycontext_container(container)
-        	not has_annotation(get_container_annotation_key(container.name))
-        	not has_securitycontext_pod
-        	profile := input.review.object.metadata.annotations[pod_annotation_key]
-        	location := sprintf("annotation %v", [pod_annotation_key])
+            not has_securitycontext_container(container)
+            not has_annotation(get_container_annotation_key(container.name))
+            not has_securitycontext_pod
+            profile := input.review.object.metadata.annotations[pod_annotation_key]
+            location := sprintf("annotation %v", [pod_annotation_key])
         }
 
         # Container profile as defined in container annotation
         get_profile(container) = {"profile": profile, "file": "", "location": location} {
-        	not has_securitycontext_container(container)
-        	not has_securitycontext_pod
-        	container_annotation := get_container_annotation_key(container.name)
-        	has_annotation(container_annotation)
-        	profile := input.review.object.metadata.annotations[container_annotation]
-        	location := sprintf("annotation %v", [container_annotation])
+            not has_securitycontext_container(container)
+            not has_securitycontext_pod
+            container_annotation := get_container_annotation_key(container.name)
+            has_annotation(container_annotation)
+            profile := input.review.object.metadata.annotations[container_annotation]
+            location := sprintf("annotation %v", [container_annotation])
         }
 
         # Container profile as defined in pods securityContext
         get_profile(container) = {"profile": profile, "file": file, "location": location} {
-        	not has_securitycontext_container(container)
-        	profile := input.review.object.spec.securityContext.seccompProfile.type
-        	file := object.get(input.review.object.spec.securityContext.seccompProfile, "localhostProfile", "")
-        	location := "pod securityContext"
+            not has_securitycontext_container(container)
+            profile := input.review.object.spec.securityContext.seccompProfile.type
+            file := object.get(input.review.object.spec.securityContext.seccompProfile, "localhostProfile", "")
+            location := "pod securityContext"
         }
 
         # Container profile as defined in containers securityContext
         get_profile(container) = {"profile": profile, "file": file, "location": location} {
-        	has_securitycontext_container(container)
-        	profile := container.securityContext.seccompProfile.type
-        	file := object.get(container.securityContext.seccompProfile, "localhostProfile", "")
-        	location := "container securityContext"
+            has_securitycontext_container(container)
+            profile := container.securityContext.seccompProfile.type
+            file := object.get(container.securityContext.seccompProfile, "localhostProfile", "")
+            location := "container securityContext"
         }
 
         # Container profile missing
         get_profile(container) = {"profile": "not configured", "file": "", "location": "no explicit profile found"} {
-        	not has_annotation(get_container_annotation_key(container.name))
-        	not has_annotation(pod_annotation_key)
-        	not has_securitycontext_pod
-        	not has_securitycontext_container(container)
+            not has_annotation(get_container_annotation_key(container.name))
+            not has_annotation(pod_annotation_key)
+            not has_securitycontext_pod
+            not has_securitycontext_container(container)
         }
 
         has_annotation(annotation) {
-        	input.review.object.metadata.annotations[annotation]
+            input.review.object.metadata.annotations[annotation]
         }
 
         has_securitycontext_pod {
-        	input.review.object.spec.securityContext.seccompProfile
+            input.review.object.spec.securityContext.seccompProfile
         }
 
         has_securitycontext_container(container) {
-        	container.securityContext.seccompProfile
+            container.securityContext.seccompProfile
         }
 
         get_container_annotation_key(name) = annotation {
-        	annotation := concat("", [container_annotation_key_prefix, name])
+            annotation := concat("", [container_annotation_key_prefix, name])
         }
 
         input_containers[container.name] = container {
-        	container := input.review.object.spec.containers[_]
+            container := input.review.object.spec.containers[_]
         }
 
         input_containers[container.name] = container {
-        	container := input.review.object.spec.initContainers[_]
+            container := input.review.object.spec.initContainers[_]
         }
       libs:
         - |

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -196,6 +196,7 @@ spec:
         # Container profile as defined in container annotation
         get_profile(container) = {"profile": profile, "file": "", "location": location} {
         	not has_securitycontext_container(container)
+        	not has_securitycontext_pod
         	container_annotation := get_container_annotation_key(container.name)
         	has_annotation(container_annotation)
         	profile := input.review.object.metadata.annotations[container_annotation]

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -42,93 +42,93 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8spspseccomp
-        
+
         import data.lib.exempt_container.is_exempt
-        
+
         container_annotation_key_prefix = "container.seccomp.security.alpha.kubernetes.io/"
-        
+
         pod_annotation_key = "seccomp.security.alpha.kubernetes.io/pod"
-        
+
         violation[{"msg": msg}] {
-            not input_wildcard_allowed
-            container := input_containers[name]
-            not is_exempt(container)
-            result := get_profile(container)
-            not allowed_profile(result.profile)
-            msg := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [result.profile, name, result.location, input.parameters.allowedProfiles])
+        	not input_wildcard_allowed
+        	container := input_containers[name]
+        	not is_exempt(container)
+        	result := get_profile(container)
+        	not allowed_profile(result.profile)
+        	msg := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [result.profile, name, result.location, input.parameters.allowedProfiles])
         }
-        
+
         input_wildcard_allowed {
-            input.parameters.allowedProfiles[_] == "*"
+        	input.parameters.allowedProfiles[_] == "*"
         }
-        
+
         allowed_profile(profile) {
-            profile == input.parameters.allowedProfiles[_]
+        	profile == input.parameters.allowedProfiles[_]
         }
-        
+
         # Container profile as defined in pod annotation
         get_profile(container) = {"profile": profile, "location": location} {
-            not has_securitycontext_container(container)
-            not has_annotation(get_container_annotation_key(container.name))
-            profile := input.review.object.metadata.annotations[pod_annotation_key]
-            location := sprintf("annotation %v", [pod_annotation_key])
+        	not has_securitycontext_container(container)
+        	not has_annotation(get_container_annotation_key(container.name))
+        	profile := input.review.object.metadata.annotations[pod_annotation_key]
+        	location := sprintf("annotation %v", [pod_annotation_key])
         }
-        
+
         # Container profile as defined in container annotation
         get_profile(container) = {"profile": profile, "location": location} {
-            container_annotation := get_container_annotation_key(container.name)
-            has_annotation(container_annotation)
-            profile := input.review.object.metadata.annotations[container_annotation]
-            location := sprintf("annotation %v", [container_annotation])
+        	container_annotation := get_container_annotation_key(container.name)
+        	has_annotation(container_annotation)
+        	profile := input.review.object.metadata.annotations[container_annotation]
+        	location := sprintf("annotation %v", [container_annotation])
         }
-        
+
         # Container profile as defined in pods securityContext
         get_profile(container) = {"profile": profile, "location": location} {
-            not has_securitycontext_container(container)
-            not has_annotation(get_container_annotation_key(container.name))
-            not has_annotation(pod_annotation_key)
-            profile := input.review.object.spec.securityContext.seccompProfile.type
-            location := "pod securityContext"
+        	not has_securitycontext_container(container)
+        	not has_annotation(get_container_annotation_key(container.name))
+        	not has_annotation(pod_annotation_key)
+        	profile := input.review.object.spec.securityContext.seccompProfile.type
+        	location := "pod securityContext"
         }
-        
+
         # Container profile as defined in containers securityContext
         get_profile(container) = {"profile": profile, "location": location} {
-            not has_annotation(get_container_annotation_key(container.name))
-            has_securitycontext_container(container)
-            profile := container.securityContext.seccompProfile.type
-            location := "container securityContext"
+        	not has_annotation(get_container_annotation_key(container.name))
+        	has_securitycontext_container(container)
+        	profile := container.securityContext.seccompProfile.type
+        	location := "container securityContext"
         }
-        
+
         # Container profile missing
         get_profile(container) = {"profile": "not configured", "location": "no explicit profile found"} {
-            not has_annotation(get_container_annotation_key(container.name))
-            not has_annotation(pod_annotation_key)
-            not has_securitycontext_pod
-            not has_securitycontext_container(container)
+        	not has_annotation(get_container_annotation_key(container.name))
+        	not has_annotation(pod_annotation_key)
+        	not has_securitycontext_pod
+        	not has_securitycontext_container(container)
         }
-        
+
         has_annotation(annotation) {
-            input.review.object.metadata.annotations[annotation]
+        	input.review.object.metadata.annotations[annotation]
         }
-        
+
         has_securitycontext_pod {
-            input.review.object.spec.securityContext.seccompProfile
+        	input.review.object.spec.securityContext.seccompProfile
         }
-        
+
         has_securitycontext_container(container) {
-            container.securityContext.seccompProfile
+        	container.securityContext.seccompProfile
         }
-        
+
         get_container_annotation_key(name) = annotation {
-            annotation := concat("", [container_annotation_key_prefix, name])
+        	annotation := concat("", [container_annotation_key_prefix, name])
         }
-        
+
         input_containers[container.name] = container {
-            container := input.review.object.spec.containers[_]
+        	container := input.review.object.spec.containers[_]
         }
-        
+
         input_containers[container.name] = container {
-            container := input.review.object.spec.initContainers[_]
+        	container := input.review.object.spec.initContainers[_]
         }
       libs:
         - |

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -154,7 +154,7 @@ spec:
         get_annotation_localhost_files[file] {
         	profile := input.parameters.allowedProfiles[_]
         	startswith(profile, "localhost/")
-        	file := split(profile, "/")[1]
+        	file := replace(profile, "localhost/", "")
         }
 
         # The profiles explicitly in the list

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -35,9 +35,32 @@ spec:
                 type: string
             allowedProfiles:
               type: array
-              description: "An array of allowed profile values for seccomp annotations on Pods."
+              description: >-
+                An array of allowed profile values for seccomp on Pods/Containers.
+
+                Can use the annotation naming scheme: `runtime/default`, `docker/default`, `unconfined` and/or
+                `localhost/some-profile.json`. The item `localhost/*` will allow any localhost based profile.
+
+                Can also use the securityContext naming scheme: `RuntimeDefault`, `Unconfined`
+                and/or `Localhost`. For securityContext `Localhost`, use the parameter `allowedLocalhostProfiles`
+                to list the allowed profile JSON files.
+
+                The policy code will translate between the two schemes so it is not necessary to use both.
+
+                Putting a `*` in this array allows all Profiles to be used.
+
+                This field is required since with an empty list this policy will block all workloads.
               items:
                 type: string
+            allowedLocalhostFiles:
+              type: array
+              description: >-
+                When using securityContext naming scheme for seccomp and including `Localhost` this array holds
+                the allowed profile JSON files.
+
+                Putting a `*` in this array will allows all JSON files to be used.
+
+                This field is required to allow `Localhost` in securityContext as with an empty list it will block.
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
@@ -49,33 +72,118 @@ spec:
 
         pod_annotation_key = "seccomp.security.alpha.kubernetes.io/pod"
 
+        naming_translation = {
+        	# securityContext -> annotation
+        	"RuntimeDefault": ["runtime/default", "docker/default"],
+        	"Unconfined": ["unconfined"],
+        	"Localhost": ["localhost"],
+        	# annotation -> securityContext
+        	"runtime/default": ["RuntimeDefault"],
+        	"docker/default": ["RuntimeDefault"],
+        	"unconfined": ["Unconfined"],
+        	"localhost": ["Localhost"],
+        }
+
         violation[{"msg": msg}] {
-        	not input_wildcard_allowed
+        	not input_wildcard_allowed_profiles
+        	allowed_profiles := get_allowed_profiles
         	container := input_containers[name]
         	not is_exempt(container)
         	result := get_profile(container)
-        	not allowed_profile(result.profile)
-        	msg := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [result.profile, name, result.location, input.parameters.allowedProfiles])
+        	not allowed_profile(result.profile, result.file, allowed_profiles)
+        	msg := get_message(result.profile, result.file, name, result.location, allowed_profiles)
         }
 
-        input_wildcard_allowed {
+        get_message(profile, file, name, location, allowed_profiles) = message {
+          not profile == "Localhost"
+          message := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, name, location, allowed_profiles])
+        }
+
+        get_message(profile, file, name, location, allowed_profiles) = message {
+          profile == "Localhost"
+          message := sprintf("Seccomp profile '%v' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, file, name, location, allowed_profiles])
+        }
+
+        input_wildcard_allowed_profiles {
         	input.parameters.allowedProfiles[_] == "*"
         }
 
-        allowed_profile(profile) {
-        	profile == input.parameters.allowedProfiles[_]
+        input_wildcard_allowed_files {
+        	input.parameters.allowedLocalhostFiles[_] == "*"
+        }
+
+        # Simple allowed Profiles
+        allowed_profile(profile, file, allowed) {
+            not startswith(lower(profile), "localhost")
+        	profile == allowed[_]
+        }
+
+        # seccomp Localhost without wildcard
+        allowed_profile(profile, file, allowed) {
+        	profile == "Localhost"
+        	not input_wildcard_allowed_files
+        	profile == allowed[_]
+        	file == input.parameters.allowedLocalhostFiles[_]
+        }
+
+        # seccomp Localhost with wildcard
+        allowed_profile(profile, file, allowed) {
+        	profile == "Localhost"
+        	input_wildcard_allowed_files
+        	profile == allowed[_]
+        }
+
+        # annotation localhost with wildcard
+        allowed_profile(profile, file, allowed) {
+        	"localhost/*" == allowed[_]
+        	startswith(profile, "localhost/")
+        }
+
+        # annotation localhost without wildcard
+        allowed_profile(profile, file, allowed) {
+        	startswith(profile, "localhost/")
+        	profile == allowed[_]
+        }
+
+        # The profiles explicitly in the list
+        get_allowed_profiles[allowed] {
+        	allowed := input.parameters.allowedProfiles[_]
+        }
+
+        # The simply translated profiles
+        get_allowed_profiles[allowed] {
+        	profile := input.parameters.allowedProfiles[_]
+        	not startswith(lower(profile), "localhost")
+        	allowed := naming_translation[profile][_]
+        }
+
+        # Seccomp Localhost to annotation translation
+        get_allowed_profiles[allowed] {
+        	profile := input.parameters.allowedProfiles[_]
+        	profile == "Localhost"
+        	file := object.get(input.parameters, "allowedLocalhostFiles", [])[_]
+        	allowed := sprintf("%v/%v", [naming_translation[profile][_], file])
+        }
+
+        # Annotation localhost to Seccomp translation
+        get_allowed_profiles[allowed] {
+        	profile := input.parameters.allowedProfiles[_]
+        	startswith(profile, "localhost")
+        	allowed := naming_translation.localhost[_]
         }
 
         # Container profile as defined in pod annotation
-        get_profile(container) = {"profile": profile, "location": location} {
+        get_profile(container) = {"profile": profile, "file": "", "location": location} {
         	not has_securitycontext_container(container)
         	not has_annotation(get_container_annotation_key(container.name))
+        	not has_securitycontext_pod
         	profile := input.review.object.metadata.annotations[pod_annotation_key]
         	location := sprintf("annotation %v", [pod_annotation_key])
         }
 
         # Container profile as defined in container annotation
-        get_profile(container) = {"profile": profile, "location": location} {
+        get_profile(container) = {"profile": profile, "file": "", "location": location} {
+        	not has_securitycontext_container(container)
         	container_annotation := get_container_annotation_key(container.name)
         	has_annotation(container_annotation)
         	profile := input.review.object.metadata.annotations[container_annotation]
@@ -83,24 +191,24 @@ spec:
         }
 
         # Container profile as defined in pods securityContext
-        get_profile(container) = {"profile": profile, "location": location} {
+        get_profile(container) = {"profile": profile, "file": file, "location": location} {
         	not has_securitycontext_container(container)
         	not has_annotation(get_container_annotation_key(container.name))
-        	not has_annotation(pod_annotation_key)
         	profile := input.review.object.spec.securityContext.seccompProfile.type
+        	file := object.get(input.review.object.spec.securityContext.seccompProfile, "localhostProfile", "")
         	location := "pod securityContext"
         }
 
         # Container profile as defined in containers securityContext
-        get_profile(container) = {"profile": profile, "location": location} {
-        	not has_annotation(get_container_annotation_key(container.name))
+        get_profile(container) = {"profile": profile, "file": file, "location": location} {
         	has_securitycontext_container(container)
         	profile := container.securityContext.seccompProfile.type
+        	file := object.get(container.securityContext.seccompProfile, "localhostProfile", "")
         	location := "container securityContext"
         }
 
         # Container profile missing
-        get_profile(container) = {"profile": "not configured", "location": "no explicit profile found"} {
+        get_profile(container) = {"profile": "not configured", "file": "", "location": "no explicit profile found"} {
         	not has_annotation(get_container_annotation_key(container.name))
         	not has_annotation(pod_annotation_key)
         	not has_securitycontext_pod

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -42,45 +42,89 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8spspseccomp
-
+        
         import data.lib.exempt_container.is_exempt
-
-        violation[{"msg": msg, "details": {}}] {
-            metadata := input.review.object.metadata
-            not input_wildcard_allowed(metadata)
-            container := input_containers[_]
+        
+        container_annotation_key_prefix = "container.seccomp.security.alpha.kubernetes.io/"
+        
+        pod_annotation_key = "seccomp.security.alpha.kubernetes.io/pod"
+        
+        violation[{"msg": msg}] {
+            not input_wildcard_allowed
+            container := input_containers[name]
             not is_exempt(container)
-            not input_container_allowed(metadata, container)
-            msg := sprintf("Seccomp profile is not allowed, pod: %v, container: %v, Allowed profiles: %v", [metadata.name, container.name, input.parameters.allowedProfiles])
+            result := get_profile(container)
+            not allowed_profile(result.profile)
+            msg := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [result.profile, name, result.location, input.parameters.allowedProfiles])
         }
-
-        input_wildcard_allowed(metadata) {
+        
+        input_wildcard_allowed {
             input.parameters.allowedProfiles[_] == "*"
         }
-
-        input_container_allowed(metadata, container) {
-            not get_container_profile(metadata, container)
-            metadata.annotations["seccomp.security.alpha.kubernetes.io/pod"] == input.parameters.allowedProfiles[_]
-        }
-
-        input_container_allowed(metadata, container) {
-            profile := get_container_profile(metadata, container)
+        
+        allowed_profile(profile) {
             profile == input.parameters.allowedProfiles[_]
         }
-
-        get_container_profile(metadata, container) = profile {
-            value := metadata.annotations[key]
-            startswith(key, "container.seccomp.security.alpha.kubernetes.io/")
-            [prefix, name] := split(key, "/")
-            name == container.name
-            profile = value
+        
+        # Container profile as defined in pod annotation
+        get_profile(container) = {"profile": profile, "location": location} {
+            not has_annotation(get_container_annotation_key(container.name))
+            profile := input.review.object.metadata.annotations[pod_annotation_key]
+            location := sprintf("annotation %v", [pod_annotation_key])
         }
-
-        input_containers[c] {
-            c := input.review.object.spec.containers[_]
+        
+        # Container profile as defined in container annotation
+        get_profile(container) = {"profile": profile, "location": location} {
+            container_annotation := get_container_annotation_key(container.name)
+            has_annotation(container_annotation)
+            profile := input.review.object.metadata.annotations[container_annotation]
+            location := sprintf("annotation %v", [container_annotation])
         }
-        input_containers[c] {
-            c := input.review.object.spec.initContainers[_]
+        
+        # Container profile as defined in pods securityContext
+        get_profile(container) = {"profile": profile, "location": location} {
+            not has_securitycontext_container(container)
+            profile := input.review.object.spec.securityContext.seccompProfile.type
+            location := "pod securityContext"
+        }
+        
+        # Container profile as defined in containers securityContext
+        get_profile(container) = {"profile": profile, "location": location} {
+            has_securitycontext_container(container)
+            profile := container.securityContext.seccompProfile.type
+            location := "container securityContext"
+        }
+        
+        # Container profile missing
+        get_profile(container) = {"profile": "not configured", "location": "no explicit profile found"} {
+            not has_annotation(get_container_annotation_key(container.name))
+            not has_annotation(pod_annotation_key)
+            not has_securitycontext_pod
+            not has_securitycontext_container(container)
+        }
+        
+        has_annotation(annotation) {
+            input.review.object.metadata.annotations[annotation]
+        }
+        
+        has_securitycontext_pod {
+            input.review.object.spec.securityContext.seccompProfile
+        }
+        
+        has_securitycontext_container(container) {
+            container.securityContext.seccompProfile
+        }
+        
+        get_container_annotation_key(name) = annotation {
+            annotation := concat("", [container_annotation_key_prefix, name])
+        }
+        
+        input_containers[container.name] = container {
+            container := input.review.object.spec.containers[_]
+        }
+        
+        input_containers[container.name] = container {
+            container := input.review.object.spec.initContainers[_]
         }
       libs:
         - |

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -70,14 +70,12 @@ spec:
         get_profile(container) = {"profile": profile, "location": location} {
             not has_securitycontext_container(container)
             not has_annotation(get_container_annotation_key(container.name))
-            not has_securitycontext_pod
             profile := input.review.object.metadata.annotations[pod_annotation_key]
             location := sprintf("annotation %v", [pod_annotation_key])
         }
         
         # Container profile as defined in container annotation
         get_profile(container) = {"profile": profile, "location": location} {
-            not has_securitycontext_container(container)
             container_annotation := get_container_annotation_key(container.name)
             has_annotation(container_annotation)
             profile := input.review.object.metadata.annotations[container_annotation]
@@ -88,12 +86,14 @@ spec:
         get_profile(container) = {"profile": profile, "location": location} {
             not has_securitycontext_container(container)
             not has_annotation(get_container_annotation_key(container.name))
+            not has_annotation(pod_annotation_key)
             profile := input.review.object.spec.securityContext.seccompProfile.type
             location := "pod securityContext"
         }
         
         # Container profile as defined in containers securityContext
         get_profile(container) = {"profile": profile, "location": location} {
+            not has_annotation(get_container_annotation_key(container.name))
             has_securitycontext_container(container)
             profile := container.securityContext.seccompProfile.type
             location := "container securityContext"

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -112,6 +112,10 @@ spec:
         	input.parameters.allowedLocalhostFiles[_] == "*"
         }
 
+        input_wildcard_allowed_files {
+        	"localhost/*" == input.parameters.allowedProfiles[_]
+        }
+
         # Simple allowed Profiles
         allowed_profile(profile, file, allowed) {
         	not startswith(lower(profile), "localhost")

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -95,13 +95,13 @@ spec:
         }
 
         get_message(profile, file, name, location, allowed_profiles) = message {
-          not profile == "Localhost"
-          message := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, name, location, allowed_profiles])
+        	not profile == "Localhost"
+        	message := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, name, location, allowed_profiles])
         }
 
         get_message(profile, file, name, location, allowed_profiles) = message {
-          profile == "Localhost"
-          message := sprintf("Seccomp profile '%v' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, file, name, location, allowed_profiles])
+        	profile == "Localhost"
+        	message := sprintf("Seccomp profile '%v' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, file, name, location, allowed_profiles])
         }
 
         input_wildcard_allowed_profiles {
@@ -114,7 +114,7 @@ spec:
 
         # Simple allowed Profiles
         allowed_profile(profile, file, allowed) {
-            not startswith(lower(profile), "localhost")
+        	not startswith(lower(profile), "localhost")
         	profile == allowed[_]
         }
 
@@ -123,7 +123,8 @@ spec:
         	profile == "Localhost"
         	not input_wildcard_allowed_files
         	profile == allowed[_]
-        	file == input.parameters.allowedLocalhostFiles[_]
+        	allowed_files := {x | x := object.get(input.parameters, "allowedLocalhostFiles", [])[_]} | get_annotation_localhost_files
+        	file == allowed_files[_]
         }
 
         # seccomp Localhost with wildcard
@@ -143,6 +144,13 @@ spec:
         allowed_profile(profile, file, allowed) {
         	startswith(profile, "localhost/")
         	profile == allowed[_]
+        }
+
+        # Localhost files from annotation scheme
+        get_annotation_localhost_files[file] {
+        	profile := input.parameters.allowedProfiles[_]
+        	startswith(profile, "localhost/")
+        	file := split(profile, "/")[1]
         }
 
         # The profiles explicitly in the list

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -68,13 +68,16 @@ spec:
         
         # Container profile as defined in pod annotation
         get_profile(container) = {"profile": profile, "location": location} {
+            not has_securitycontext_container(container)
             not has_annotation(get_container_annotation_key(container.name))
+            not has_securitycontext_pod
             profile := input.review.object.metadata.annotations[pod_annotation_key]
             location := sprintf("annotation %v", [pod_annotation_key])
         }
         
         # Container profile as defined in container annotation
         get_profile(container) = {"profile": profile, "location": location} {
+            not has_securitycontext_container(container)
             container_annotation := get_container_annotation_key(container.name)
             has_annotation(container_annotation)
             profile := input.review.object.metadata.annotations[container_annotation]
@@ -84,6 +87,7 @@ spec:
         # Container profile as defined in pods securityContext
         get_profile(container) = {"profile": profile, "location": location} {
             not has_securitycontext_container(container)
+            not has_annotation(get_container_annotation_key(container.name))
             profile := input.review.object.spec.securityContext.seccompProfile.type
             location := "pod securityContext"
         }

--- a/src/pod-security-policy/seccomp/constraint.tmpl
+++ b/src/pod-security-policy/seccomp/constraint.tmpl
@@ -35,9 +35,32 @@ spec:
                 type: string
             allowedProfiles:
               type: array
-              description: "An array of allowed profile values for seccomp annotations on Pods."
+              description: >-
+                An array of allowed profile values for seccomp on Pods/Containers.
+
+                Can use the annotation naming scheme: `runtime/default`, `docker/default`, `unconfined` and/or
+                `localhost/some-profile.json`. The item `localhost/*` will allow any localhost based profile.
+
+                Can also use the securityContext naming scheme: `RuntimeDefault`, `Unconfined`
+                and/or `Localhost`. For securityContext `Localhost`, use the parameter `allowedLocalhostProfiles`
+                to list the allowed profile JSON files.
+
+                The policy code will translate between the two schemes so it is not necessary to use both.
+
+                Putting a `*` in this array allows all Profiles to be used.
+
+                This field is required since with an empty list this policy will block all workloads.
               items:
                 type: string
+            allowedLocalhostFiles:
+              type: array
+              description: >-
+                When using securityContext naming scheme for seccomp and including `Localhost` this array holds
+                the allowed profile JSON files.
+
+                Putting a `*` in this array will allows all JSON files to be used.
+
+                This field is required to allow `Localhost` in securityContext as with an empty list it will block.
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -7,180 +7,180 @@ container_annotation_key_prefix = "container.seccomp.security.alpha.kubernetes.i
 pod_annotation_key = "seccomp.security.alpha.kubernetes.io/pod"
 
 naming_translation = {
-	# securityContext -> annotation
-	"RuntimeDefault": ["runtime/default", "docker/default"],
-	"Unconfined": ["unconfined"],
-	"Localhost": ["localhost"],
-	# annotation -> securityContext
-	"runtime/default": ["RuntimeDefault"],
-	"docker/default": ["RuntimeDefault"],
-	"unconfined": ["Unconfined"],
-	"localhost": ["Localhost"],
+    # securityContext -> annotation
+    "RuntimeDefault": ["runtime/default", "docker/default"],
+    "Unconfined": ["unconfined"],
+    "Localhost": ["localhost"],
+    # annotation -> securityContext
+    "runtime/default": ["RuntimeDefault"],
+    "docker/default": ["RuntimeDefault"],
+    "unconfined": ["Unconfined"],
+    "localhost": ["Localhost"],
 }
 
 violation[{"msg": msg}] {
-	not input_wildcard_allowed_profiles
-	allowed_profiles := get_allowed_profiles
-	container := input_containers[name]
-	not is_exempt(container)
-	result := get_profile(container)
-	not allowed_profile(result.profile, result.file, allowed_profiles)
-	msg := get_message(result.profile, result.file, name, result.location, allowed_profiles)
+    not input_wildcard_allowed_profiles
+    allowed_profiles := get_allowed_profiles
+    container := input_containers[name]
+    not is_exempt(container)
+    result := get_profile(container)
+    not allowed_profile(result.profile, result.file, allowed_profiles)
+    msg := get_message(result.profile, result.file, name, result.location, allowed_profiles)
 }
 
 get_message(profile, file, name, location, allowed_profiles) = message {
-	not profile == "Localhost"
-	message := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, name, location, allowed_profiles])
+    not profile == "Localhost"
+    message := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, name, location, allowed_profiles])
 }
 
 get_message(profile, file, name, location, allowed_profiles) = message {
-	profile == "Localhost"
-	message := sprintf("Seccomp profile '%v' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, file, name, location, allowed_profiles])
+    profile == "Localhost"
+    message := sprintf("Seccomp profile '%v' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, file, name, location, allowed_profiles])
 }
 
 input_wildcard_allowed_profiles {
-	input.parameters.allowedProfiles[_] == "*"
+    input.parameters.allowedProfiles[_] == "*"
 }
 
 input_wildcard_allowed_files {
-	input.parameters.allowedLocalhostFiles[_] == "*"
+    input.parameters.allowedLocalhostFiles[_] == "*"
 }
 
 input_wildcard_allowed_files {
-	"localhost/*" == input.parameters.allowedProfiles[_]
+    "localhost/*" == input.parameters.allowedProfiles[_]
 }
 
 # Simple allowed Profiles
 allowed_profile(profile, file, allowed) {
-	not startswith(lower(profile), "localhost")
-	profile == allowed[_]
+    not startswith(lower(profile), "localhost")
+    profile == allowed[_]
 }
 
 # seccomp Localhost without wildcard
 allowed_profile(profile, file, allowed) {
-	profile == "Localhost"
-	not input_wildcard_allowed_files
-	profile == allowed[_]
-	allowed_files := {x | x := object.get(input.parameters, "allowedLocalhostFiles", [])[_]} | get_annotation_localhost_files
-	file == allowed_files[_]
+    profile == "Localhost"
+    not input_wildcard_allowed_files
+    profile == allowed[_]
+    allowed_files := {x | x := object.get(input.parameters, "allowedLocalhostFiles", [])[_]} | get_annotation_localhost_files
+    file == allowed_files[_]
 }
 
 # seccomp Localhost with wildcard
 allowed_profile(profile, file, allowed) {
-	profile == "Localhost"
-	input_wildcard_allowed_files
-	profile == allowed[_]
+    profile == "Localhost"
+    input_wildcard_allowed_files
+    profile == allowed[_]
 }
 
 # annotation localhost with wildcard
 allowed_profile(profile, file, allowed) {
-	"localhost/*" == allowed[_]
-	startswith(profile, "localhost/")
+    "localhost/*" == allowed[_]
+    startswith(profile, "localhost/")
 }
 
 # annotation localhost without wildcard
 allowed_profile(profile, file, allowed) {
-	startswith(profile, "localhost/")
-	profile == allowed[_]
+    startswith(profile, "localhost/")
+    profile == allowed[_]
 }
 
 # Localhost files from annotation scheme
 get_annotation_localhost_files[file] {
-	profile := input.parameters.allowedProfiles[_]
-	startswith(profile, "localhost/")
-	file := replace(profile, "localhost/", "")
+    profile := input.parameters.allowedProfiles[_]
+    startswith(profile, "localhost/")
+    file := replace(profile, "localhost/", "")
 }
 
 # The profiles explicitly in the list
 get_allowed_profiles[allowed] {
-	allowed := input.parameters.allowedProfiles[_]
+    allowed := input.parameters.allowedProfiles[_]
 }
 
 # The simply translated profiles
 get_allowed_profiles[allowed] {
-	profile := input.parameters.allowedProfiles[_]
-	not startswith(lower(profile), "localhost")
-	allowed := naming_translation[profile][_]
+    profile := input.parameters.allowedProfiles[_]
+    not startswith(lower(profile), "localhost")
+    allowed := naming_translation[profile][_]
 }
 
 # Seccomp Localhost to annotation translation
 get_allowed_profiles[allowed] {
-	profile := input.parameters.allowedProfiles[_]
-	profile == "Localhost"
-	file := object.get(input.parameters, "allowedLocalhostFiles", [])[_]
-	allowed := sprintf("%v/%v", [naming_translation[profile][_], file])
+    profile := input.parameters.allowedProfiles[_]
+    profile == "Localhost"
+    file := object.get(input.parameters, "allowedLocalhostFiles", [])[_]
+    allowed := sprintf("%v/%v", [naming_translation[profile][_], file])
 }
 
 # Annotation localhost to Seccomp translation
 get_allowed_profiles[allowed] {
-	profile := input.parameters.allowedProfiles[_]
-	startswith(profile, "localhost")
-	allowed := naming_translation.localhost[_]
+    profile := input.parameters.allowedProfiles[_]
+    startswith(profile, "localhost")
+    allowed := naming_translation.localhost[_]
 }
 
 # Container profile as defined in pod annotation
 get_profile(container) = {"profile": profile, "file": "", "location": location} {
-	not has_securitycontext_container(container)
-	not has_annotation(get_container_annotation_key(container.name))
-	not has_securitycontext_pod
-	profile := input.review.object.metadata.annotations[pod_annotation_key]
-	location := sprintf("annotation %v", [pod_annotation_key])
+    not has_securitycontext_container(container)
+    not has_annotation(get_container_annotation_key(container.name))
+    not has_securitycontext_pod
+    profile := input.review.object.metadata.annotations[pod_annotation_key]
+    location := sprintf("annotation %v", [pod_annotation_key])
 }
 
 # Container profile as defined in container annotation
 get_profile(container) = {"profile": profile, "file": "", "location": location} {
-	not has_securitycontext_container(container)
-	not has_securitycontext_pod
-	container_annotation := get_container_annotation_key(container.name)
-	has_annotation(container_annotation)
-	profile := input.review.object.metadata.annotations[container_annotation]
-	location := sprintf("annotation %v", [container_annotation])
+    not has_securitycontext_container(container)
+    not has_securitycontext_pod
+    container_annotation := get_container_annotation_key(container.name)
+    has_annotation(container_annotation)
+    profile := input.review.object.metadata.annotations[container_annotation]
+    location := sprintf("annotation %v", [container_annotation])
 }
 
 # Container profile as defined in pods securityContext
 get_profile(container) = {"profile": profile, "file": file, "location": location} {
-	not has_securitycontext_container(container)
-	profile := input.review.object.spec.securityContext.seccompProfile.type
-	file := object.get(input.review.object.spec.securityContext.seccompProfile, "localhostProfile", "")
-	location := "pod securityContext"
+    not has_securitycontext_container(container)
+    profile := input.review.object.spec.securityContext.seccompProfile.type
+    file := object.get(input.review.object.spec.securityContext.seccompProfile, "localhostProfile", "")
+    location := "pod securityContext"
 }
 
 # Container profile as defined in containers securityContext
 get_profile(container) = {"profile": profile, "file": file, "location": location} {
-	has_securitycontext_container(container)
-	profile := container.securityContext.seccompProfile.type
-	file := object.get(container.securityContext.seccompProfile, "localhostProfile", "")
-	location := "container securityContext"
+    has_securitycontext_container(container)
+    profile := container.securityContext.seccompProfile.type
+    file := object.get(container.securityContext.seccompProfile, "localhostProfile", "")
+    location := "container securityContext"
 }
 
 # Container profile missing
 get_profile(container) = {"profile": "not configured", "file": "", "location": "no explicit profile found"} {
-	not has_annotation(get_container_annotation_key(container.name))
-	not has_annotation(pod_annotation_key)
-	not has_securitycontext_pod
-	not has_securitycontext_container(container)
+    not has_annotation(get_container_annotation_key(container.name))
+    not has_annotation(pod_annotation_key)
+    not has_securitycontext_pod
+    not has_securitycontext_container(container)
 }
 
 has_annotation(annotation) {
-	input.review.object.metadata.annotations[annotation]
+    input.review.object.metadata.annotations[annotation]
 }
 
 has_securitycontext_pod {
-	input.review.object.spec.securityContext.seccompProfile
+    input.review.object.spec.securityContext.seccompProfile
 }
 
 has_securitycontext_container(container) {
-	container.securityContext.seccompProfile
+    container.securityContext.seccompProfile
 }
 
 get_container_annotation_key(name) = annotation {
-	annotation := concat("", [container_annotation_key_prefix, name])
+    annotation := concat("", [container_annotation_key_prefix, name])
 }
 
 input_containers[container.name] = container {
-	container := input.review.object.spec.containers[_]
+    container := input.review.object.spec.containers[_]
 }
 
 input_containers[container.name] = container {
-	container := input.review.object.spec.initContainers[_]
+    container := input.review.object.spec.initContainers[_]
 }

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -50,7 +50,7 @@ get_profile(container) = {"profile": profile, "location": location} {
 
 # Container profile as defined in containers securityContext
 get_profile(container) = {"profile": profile, "location": location} {
-    not has_annotation(get_container_annotation_key(container.name))
+	not has_annotation(get_container_annotation_key(container.name))
 	has_securitycontext_container(container)
 	profile := container.securityContext.seccompProfile.type
 	location := "container securityContext"

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -27,14 +27,12 @@ allowed_profile(profile) {
 get_profile(container) = {"profile": profile, "location": location} {
 	not has_securitycontext_container(container)
 	not has_annotation(get_container_annotation_key(container.name))
-	not has_securitycontext_pod
 	profile := input.review.object.metadata.annotations[pod_annotation_key]
 	location := sprintf("annotation %v", [pod_annotation_key])
 }
 
 # Container profile as defined in container annotation
 get_profile(container) = {"profile": profile, "location": location} {
-	not has_securitycontext_container(container)
 	container_annotation := get_container_annotation_key(container.name)
 	has_annotation(container_annotation)
 	profile := input.review.object.metadata.annotations[container_annotation]
@@ -45,12 +43,14 @@ get_profile(container) = {"profile": profile, "location": location} {
 get_profile(container) = {"profile": profile, "location": location} {
 	not has_securitycontext_container(container)
 	not has_annotation(get_container_annotation_key(container.name))
+	not has_annotation(pod_annotation_key)
 	profile := input.review.object.spec.securityContext.seccompProfile.type
 	location := "pod securityContext"
 }
 
 # Container profile as defined in containers securityContext
 get_profile(container) = {"profile": profile, "location": location} {
+    not has_annotation(get_container_annotation_key(container.name))
 	has_securitycontext_container(container)
 	profile := container.securityContext.seccompProfile.type
 	location := "container securityContext"

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -88,7 +88,7 @@ allowed_profile(profile, file, allowed) {
 get_annotation_localhost_files[file] {
 	profile := input.parameters.allowedProfiles[_]
 	startswith(profile, "localhost/")
-	file := split(profile, "/")[1]
+	file := replace(profile, "localhost/", "")
 }
 
 # The profiles explicitly in the list

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -46,6 +46,10 @@ input_wildcard_allowed_files {
 	input.parameters.allowedLocalhostFiles[_] == "*"
 }
 
+input_wildcard_allowed_files {
+	"localhost/*" == input.parameters.allowedProfiles[_]
+}
+
 # Simple allowed Profiles
 allowed_profile(profile, file, allowed) {
 	not startswith(lower(profile), "localhost")

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -130,6 +130,7 @@ get_profile(container) = {"profile": profile, "file": "", "location": location} 
 # Container profile as defined in container annotation
 get_profile(container) = {"profile": profile, "file": "", "location": location} {
 	not has_securitycontext_container(container)
+	not has_securitycontext_pod
 	container_annotation := get_container_annotation_key(container.name)
 	has_annotation(container_annotation)
 	profile := input.review.object.metadata.annotations[container_annotation]

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -29,13 +29,13 @@ violation[{"msg": msg}] {
 }
 
 get_message(profile, file, name, location, allowed_profiles) = message {
-  not profile == "Localhost"
-  message := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, name, location, allowed_profiles])
+	not profile == "Localhost"
+	message := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, name, location, allowed_profiles])
 }
 
 get_message(profile, file, name, location, allowed_profiles) = message {
-  profile == "Localhost"
-  message := sprintf("Seccomp profile '%v' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, file, name, location, allowed_profiles])
+	profile == "Localhost"
+	message := sprintf("Seccomp profile '%v' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, file, name, location, allowed_profiles])
 }
 
 input_wildcard_allowed_profiles {
@@ -48,7 +48,7 @@ input_wildcard_allowed_files {
 
 # Simple allowed Profiles
 allowed_profile(profile, file, allowed) {
-    not startswith(lower(profile), "localhost")
+	not startswith(lower(profile), "localhost")
 	profile == allowed[_]
 }
 
@@ -57,7 +57,8 @@ allowed_profile(profile, file, allowed) {
 	profile == "Localhost"
 	not input_wildcard_allowed_files
 	profile == allowed[_]
-	file == input.parameters.allowedLocalhostFiles[_]
+	allowed_files := {x | x := object.get(input.parameters, "allowedLocalhostFiles", [])[_]} | get_annotation_localhost_files
+	file == allowed_files[_]
 }
 
 # seccomp Localhost with wildcard
@@ -77,6 +78,13 @@ allowed_profile(profile, file, allowed) {
 allowed_profile(profile, file, allowed) {
 	startswith(profile, "localhost/")
 	profile == allowed[_]
+}
+
+# Localhost files from annotation scheme
+get_annotation_localhost_files[file] {
+	profile := input.parameters.allowedProfiles[_]
+	startswith(profile, "localhost/")
+	file := split(profile, "/")[1]
 }
 
 # The profiles explicitly in the list

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -25,13 +25,16 @@ allowed_profile(profile) {
 
 # Container profile as defined in pod annotation
 get_profile(container) = {"profile": profile, "location": location} {
+	not has_securitycontext_container(container)
 	not has_annotation(get_container_annotation_key(container.name))
+	not has_securitycontext_pod
 	profile := input.review.object.metadata.annotations[pod_annotation_key]
 	location := sprintf("annotation %v", [pod_annotation_key])
 }
 
 # Container profile as defined in container annotation
 get_profile(container) = {"profile": profile, "location": location} {
+	not has_securitycontext_container(container)
 	container_annotation := get_container_annotation_key(container.name)
 	has_annotation(container_annotation)
 	profile := input.review.object.metadata.annotations[container_annotation]
@@ -41,6 +44,7 @@ get_profile(container) = {"profile": profile, "location": location} {
 # Container profile as defined in pods securityContext
 get_profile(container) = {"profile": profile, "location": location} {
 	not has_securitycontext_container(container)
+	not has_annotation(get_container_annotation_key(container.name))
 	profile := input.review.object.spec.securityContext.seccompProfile.type
 	location := "pod securityContext"
 }

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -2,40 +2,84 @@ package k8spspseccomp
 
 import data.lib.exempt_container.is_exempt
 
-violation[{"msg": msg, "details": {}}] {
-    metadata := input.review.object.metadata
-    not input_wildcard_allowed(metadata)
-    container := input_containers[_]
-    not is_exempt(container)
-    not input_container_allowed(metadata, container)
-    msg := sprintf("Seccomp profile is not allowed, pod: %v, container: %v, Allowed profiles: %v", [metadata.name, container.name, input.parameters.allowedProfiles])
+container_annotation_key_prefix = "container.seccomp.security.alpha.kubernetes.io/"
+
+pod_annotation_key = "seccomp.security.alpha.kubernetes.io/pod"
+
+violation[{"msg": msg}] {
+	not input_wildcard_allowed
+	container := input_containers[name]
+	not is_exempt(container)
+	result := get_profile(container)
+	not allowed_profile(result.profile)
+	msg := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [result.profile, name, result.location, input.parameters.allowedProfiles])
 }
 
-input_wildcard_allowed(metadata) {
-    input.parameters.allowedProfiles[_] == "*"
+input_wildcard_allowed {
+	input.parameters.allowedProfiles[_] == "*"
 }
 
-input_container_allowed(metadata, container) {
-    not get_container_profile(metadata, container)
-    metadata.annotations["seccomp.security.alpha.kubernetes.io/pod"] == input.parameters.allowedProfiles[_]
+allowed_profile(profile) {
+	profile == input.parameters.allowedProfiles[_]
 }
 
-input_container_allowed(metadata, container) {
-    profile := get_container_profile(metadata, container)
-    profile == input.parameters.allowedProfiles[_]
+# Container profile as defined in pod annotation
+get_profile(container) = {"profile": profile, "location": location} {
+	not has_annotation(get_container_annotation_key(container.name))
+	profile := input.review.object.metadata.annotations[pod_annotation_key]
+	location := sprintf("annotation %v", [pod_annotation_key])
 }
 
-get_container_profile(metadata, container) = profile {
-    value := metadata.annotations[key]
-    startswith(key, "container.seccomp.security.alpha.kubernetes.io/")
-    [prefix, name] := split(key, "/")
-    name == container.name
-    profile = value
+# Container profile as defined in container annotation
+get_profile(container) = {"profile": profile, "location": location} {
+	container_annotation := get_container_annotation_key(container.name)
+	has_annotation(container_annotation)
+	profile := input.review.object.metadata.annotations[container_annotation]
+	location := sprintf("annotation %v", [container_annotation])
 }
 
-input_containers[c] {
-    c := input.review.object.spec.containers[_]
+# Container profile as defined in pods securityContext
+get_profile(container) = {"profile": profile, "location": location} {
+	not has_securitycontext_container(container)
+	profile := input.review.object.spec.securityContext.seccompProfile.type
+	location := "pod securityContext"
 }
-input_containers[c] {
-    c := input.review.object.spec.initContainers[_]
+
+# Container profile as defined in containers securityContext
+get_profile(container) = {"profile": profile, "location": location} {
+	has_securitycontext_container(container)
+	profile := container.securityContext.seccompProfile.type
+	location := "container securityContext"
+}
+
+# Container profile missing
+get_profile(container) = {"profile": "not configured", "location": "no explicit profile found"} {
+	not has_annotation(get_container_annotation_key(container.name))
+	not has_annotation(pod_annotation_key)
+	not has_securitycontext_pod
+	not has_securitycontext_container(container)
+}
+
+has_annotation(annotation) {
+	input.review.object.metadata.annotations[annotation]
+}
+
+has_securitycontext_pod {
+	input.review.object.spec.securityContext.seccompProfile
+}
+
+has_securitycontext_container(container) {
+	container.securityContext.seccompProfile
+}
+
+get_container_annotation_key(name) = annotation {
+	annotation := concat("", [container_annotation_key_prefix, name])
+}
+
+input_containers[container.name] = container {
+	container := input.review.object.spec.containers[_]
+}
+
+input_containers[container.name] = container {
+	container := input.review.object.spec.initContainers[_]
 }

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -140,7 +140,6 @@ get_profile(container) = {"profile": profile, "file": "", "location": location} 
 # Container profile as defined in pods securityContext
 get_profile(container) = {"profile": profile, "file": file, "location": location} {
 	not has_securitycontext_container(container)
-	not has_annotation(get_container_annotation_key(container.name))
 	profile := input.review.object.spec.securityContext.seccompProfile.type
 	file := object.get(input.review.object.spec.securityContext.seccompProfile, "localhostProfile", "")
 	location := "pod securityContext"

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -6,33 +6,118 @@ container_annotation_key_prefix = "container.seccomp.security.alpha.kubernetes.i
 
 pod_annotation_key = "seccomp.security.alpha.kubernetes.io/pod"
 
+naming_translation = {
+	# securityContext -> annotation
+	"RuntimeDefault": ["runtime/default", "docker/default"],
+	"Unconfined": ["unconfined"],
+	"Localhost": ["localhost"],
+	# annotation -> securityContext
+	"runtime/default": ["RuntimeDefault"],
+	"docker/default": ["RuntimeDefault"],
+	"unconfined": ["Unconfined"],
+	"localhost": ["Localhost"],
+}
+
 violation[{"msg": msg}] {
-	not input_wildcard_allowed
+	not input_wildcard_allowed_profiles
+	allowed_profiles := get_allowed_profiles
 	container := input_containers[name]
 	not is_exempt(container)
 	result := get_profile(container)
-	not allowed_profile(result.profile)
-	msg := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [result.profile, name, result.location, input.parameters.allowedProfiles])
+	not allowed_profile(result.profile, result.file, allowed_profiles)
+	msg := get_message(result.profile, result.file, name, result.location, allowed_profiles)
 }
 
-input_wildcard_allowed {
+get_message(profile, file, name, location, allowed_profiles) = message {
+  not profile == "Localhost"
+  message := sprintf("Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, name, location, allowed_profiles])
+}
+
+get_message(profile, file, name, location, allowed_profiles) = message {
+  profile == "Localhost"
+  message := sprintf("Seccomp profile '%v' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v", [profile, file, name, location, allowed_profiles])
+}
+
+input_wildcard_allowed_profiles {
 	input.parameters.allowedProfiles[_] == "*"
 }
 
-allowed_profile(profile) {
-	profile == input.parameters.allowedProfiles[_]
+input_wildcard_allowed_files {
+	input.parameters.allowedLocalhostFiles[_] == "*"
+}
+
+# Simple allowed Profiles
+allowed_profile(profile, file, allowed) {
+    not startswith(lower(profile), "localhost")
+	profile == allowed[_]
+}
+
+# seccomp Localhost without wildcard
+allowed_profile(profile, file, allowed) {
+	profile == "Localhost"
+	not input_wildcard_allowed_files
+	profile == allowed[_]
+	file == input.parameters.allowedLocalhostFiles[_]
+}
+
+# seccomp Localhost with wildcard
+allowed_profile(profile, file, allowed) {
+	profile == "Localhost"
+	input_wildcard_allowed_files
+	profile == allowed[_]
+}
+
+# annotation localhost with wildcard
+allowed_profile(profile, file, allowed) {
+	"localhost/*" == allowed[_]
+	startswith(profile, "localhost/")
+}
+
+# annotation localhost without wildcard
+allowed_profile(profile, file, allowed) {
+	startswith(profile, "localhost/")
+	profile == allowed[_]
+}
+
+# The profiles explicitly in the list
+get_allowed_profiles[allowed] {
+	allowed := input.parameters.allowedProfiles[_]
+}
+
+# The simply translated profiles
+get_allowed_profiles[allowed] {
+	profile := input.parameters.allowedProfiles[_]
+	not startswith(lower(profile), "localhost")
+	allowed := naming_translation[profile][_]
+}
+
+# Seccomp Localhost to annotation translation
+get_allowed_profiles[allowed] {
+	profile := input.parameters.allowedProfiles[_]
+	profile == "Localhost"
+	file := object.get(input.parameters, "allowedLocalhostFiles", [])[_]
+	allowed := sprintf("%v/%v", [naming_translation[profile][_], file])
+}
+
+# Annotation localhost to Seccomp translation
+get_allowed_profiles[allowed] {
+	profile := input.parameters.allowedProfiles[_]
+	startswith(profile, "localhost")
+	allowed := naming_translation.localhost[_]
 }
 
 # Container profile as defined in pod annotation
-get_profile(container) = {"profile": profile, "location": location} {
+get_profile(container) = {"profile": profile, "file": "", "location": location} {
 	not has_securitycontext_container(container)
 	not has_annotation(get_container_annotation_key(container.name))
+	not has_securitycontext_pod
 	profile := input.review.object.metadata.annotations[pod_annotation_key]
 	location := sprintf("annotation %v", [pod_annotation_key])
 }
 
 # Container profile as defined in container annotation
-get_profile(container) = {"profile": profile, "location": location} {
+get_profile(container) = {"profile": profile, "file": "", "location": location} {
+	not has_securitycontext_container(container)
 	container_annotation := get_container_annotation_key(container.name)
 	has_annotation(container_annotation)
 	profile := input.review.object.metadata.annotations[container_annotation]
@@ -40,24 +125,24 @@ get_profile(container) = {"profile": profile, "location": location} {
 }
 
 # Container profile as defined in pods securityContext
-get_profile(container) = {"profile": profile, "location": location} {
+get_profile(container) = {"profile": profile, "file": file, "location": location} {
 	not has_securitycontext_container(container)
 	not has_annotation(get_container_annotation_key(container.name))
-	not has_annotation(pod_annotation_key)
 	profile := input.review.object.spec.securityContext.seccompProfile.type
+	file := object.get(input.review.object.spec.securityContext.seccompProfile, "localhostProfile", "")
 	location := "pod securityContext"
 }
 
 # Container profile as defined in containers securityContext
-get_profile(container) = {"profile": profile, "location": location} {
-	not has_annotation(get_container_annotation_key(container.name))
+get_profile(container) = {"profile": profile, "file": file, "location": location} {
 	has_securitycontext_container(container)
 	profile := container.securityContext.seccompProfile.type
+	file := object.get(container.securityContext.seccompProfile, "localhostProfile", "")
 	location := "container securityContext"
 }
 
 # Container profile missing
-get_profile(container) = {"profile": "not configured", "location": "no explicit profile found"} {
+get_profile(container) = {"profile": "not configured", "file": "", "location": "no explicit profile found"} {
 	not has_annotation(get_container_annotation_key(container.name))
 	not has_annotation(pod_annotation_key)
 	not has_securitycontext_pod

--- a/src/pod-security-policy/seccomp/src_test.rego
+++ b/src/pod-security-policy/seccomp/src_test.rego
@@ -383,6 +383,12 @@ test_input_both_seccomp_container_context_and_annotation {
 	count(results) == 0
 }
 
+test_input_both_seccomp_pod_context_container_annotation_not_allowed {
+	input := {"review": get_object(container_annotation_unconfined, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
 test_input_both_seccomp_pod_annotation_container_context_not_allowed {
 	input := {"review": get_object(pod_annotation_unconfined, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
 	results := violation with input as input

--- a/src/pod-security-policy/seccomp/src_test.rego
+++ b/src/pod-security-policy/seccomp/src_test.rego
@@ -438,6 +438,18 @@ test_input_translation_seccomp_context_match_allowed_annotation {
 	count(results) == 0
 }
 
+test_input_translation_seccomp_context_localhost_allowed_annotation {
+	input := {"review": get_object({}, context_localhost1, single_container, {}), "parameters": input_parameters_annotation}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_translation_seccomp_context_localhost_allowed_annotation_missing {
+	input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_annotation}
+	results := violation with input as input
+	count(results) == 1
+}
+
 # Create Review Object
 get_object(annotations, podcontext, containers, initcontainers) = {"object": {
 	"metadata": {
@@ -547,6 +559,8 @@ container_annotations_mixed = {
 # Test securityContexts
 context_localhost = {"seccompProfile": {"type": "Localhost", "localhostProfile": "profile.json"}}
 
+context_localhost1 = {"seccompProfile": {"type": "Localhost", "localhostProfile": "profile1.json"}}
+
 context_runtimedefault = {"seccompProfile": {"type": "RuntimeDefault"}}
 
 context_unconfined = {"seccompProfile": {"type": "Unconfined"}}
@@ -602,19 +616,11 @@ input_parameters_sc = {
 }
 
 input_parameters_sc_localhost_wildcard_file = {
-	"allowedProfiles": [
-		"Localhost",
-	],
-	"allowedLocalhostFiles": [
-		"*"
-	],
+	"allowedProfiles": ["Localhost"],
+	"allowedLocalhostFiles": ["*"],
 }
 
-input_parameters_sc_localhost_no_file = {
-	"allowedProfiles": [
-		"Localhost",
-	]
-}
+input_parameters_sc_localhost_no_file = {"allowedProfiles": ["Localhost"]}
 
 allowed_full_translated = {
 	"Localhost", "localhost/profile1.json", "localhost/profile2.json",

--- a/src/pod-security-policy/seccomp/src_test.rego
+++ b/src/pod-security-policy/seccomp/src_test.rego
@@ -237,6 +237,12 @@ test_input_seccomp_pod_localhost_allowed_annotation_wildcard_file {
 	count(results) == 0
 }
 
+test_input_seccomp_pod_localhost_allowed_both_wildcard_file {
+	input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_localhost_wildcard_both}
+	results := violation with input as input
+	count(results) == 0
+}
+
 test_input_seccomp_not_allowed_not_configured {
 	input := {"review": get_object({}, {}, single_container, {}), "parameters": input_parameter_in_list}
 	results := violation with input as input
@@ -577,6 +583,8 @@ input_parameters_empty = {"allowedProfiles": []}
 input_parameters_wildcard = {"allowedProfiles": ["*"]}
 
 input_parameters_localhost_wildcard = {"allowedProfiles": ["localhost/*"]}
+
+input_parameters_localhost_wildcard_both = {"allowedProfiles": ["localhost/*"], "allowedLocalhostFiles": ["*"]}
 
 input_parameter_in_list = {"allowedProfiles": [
 	"runtime/default",

--- a/src/pod-security-policy/seccomp/src_test.rego
+++ b/src/pod-security-policy/seccomp/src_test.rego
@@ -360,7 +360,7 @@ test_input_seccomp_pod_initcontainer_mixed_not_allowed {
 
 # Both annotation and securityContext based seccomp mixed
 test_input_both_seccomp_pod_context_container_annotation {
-	input := {"review": get_object(container_annotation, context_unconfined, single_container, {}), "parameters": input_parameter_in_list}
+	input := {"review": get_object(container_annotation_unconfined, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
 	results := violation with input as input
 	count(results) == 0
 }
@@ -379,12 +379,6 @@ test_input_both_seccomp_pod_context_and_annotation {
 
 test_input_both_seccomp_container_context_and_annotation {
 	input := {"review": get_object(container_annotation, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
-}
-
-test_input_both_seccomp_pod_context_container_annotation {
-	input := {"review": get_object(container_annotation, context_unconfined, single_container, {}), "parameters": input_parameters_not_in_list}
 	results := violation with input as input
 	count(results) == 0
 }
@@ -557,6 +551,8 @@ pod_container_annotations_mixed_rev = {
 }
 
 container_annotation = {"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"}
+
+container_annotation_unconfined = {"container.seccomp.security.alpha.kubernetes.io/nginx": "unconfined"}
 
 container_annotations = {
 	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",

--- a/src/pod-security-policy/seccomp/src_test.rego
+++ b/src/pod-security-policy/seccomp/src_test.rego
@@ -231,6 +231,12 @@ test_input_seccomp_pod_localhost_allowed_wildcard_file {
 	count(results) == 0
 }
 
+test_input_seccomp_pod_localhost_allowed_annotation_wildcard_file {
+	input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_localhost_wildcard}
+	results := violation with input as input
+	count(results) == 0
+}
+
 test_input_seccomp_not_allowed_not_configured {
 	input := {"review": get_object({}, {}, single_container, {}), "parameters": input_parameter_in_list}
 	results := violation with input as input
@@ -569,6 +575,8 @@ context_unconfined = {"seccompProfile": {"type": "Unconfined"}}
 input_parameters_empty = {"allowedProfiles": []}
 
 input_parameters_wildcard = {"allowedProfiles": ["*"]}
+
+input_parameters_localhost_wildcard = {"allowedProfiles": ["localhost/*"]}
 
 input_parameter_in_list = {"allowedProfiles": [
 	"runtime/default",

--- a/src/pod-security-policy/seccomp/src_test.rego
+++ b/src/pod-security-policy/seccomp/src_test.rego
@@ -1,401 +1,467 @@
 package k8spspseccomp
 
+# Annotation based seccomp with containers
+test_input_annotation_seccomp_empty_parameters {
+	input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_empty}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_allowed_all {
+	input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_allowed_in_list {
+	input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_not_allowed_not_in_list {
+	input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_pod_multiple_empty_parameters {
+	input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_empty}
+	results := violation with input as input
+	count(results) == 2
+}
+
+test_input_annotation_seccomp_pod_multiple_allowed_all {
+	input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_multiple_allowed_in_list {
+	input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_multiple_not_allowed_not_in_list {
+	input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
+}
+
+test_input_annotation_seccomp_container_allowed_all {
+	input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_container_allowed_in_list {
+	input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_container_not_allowed_not_in_list {
+	input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_containers_allowed_in_list {
+	input := {"review": get_object(container_annotations, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_containers_not_allowed_not_in_list {
+	input := {"review": get_object(container_annotations, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
+}
+
+test_input_annotation_seccomp_containers_mixed {
+	input := {"review": get_object(container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_containers_mixed_missing {
+	input := {"review": get_object(container_annotation, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_containers_allowed_in_list_multiple {
+	input := {"review": get_object(container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_container {
+	input := {"review": get_object(pod_container_annotations, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_container_not_allowed {
+	input := {"review": get_object(pod_container_annotations, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
+}
+
+test_input_annotation_seccomp_pod_container_both_allowed {
+	input := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_container_mixed_allowed {
+	input := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_pod_container_mixed_not_allowed {
+	input := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
+}
+
+test_input_annotation_seccomp_pod_container_both_allowed_reversed {
+	input := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_container_mixed_allowed_reversed {
+	input := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_pod_container_mixed_not_allowed_reversed {
+	input := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
+}
+
+# Annotation based seccomp with init containers
+test_input_annotation_seccomp_pod_initcontainer_both_allowed {
+	input := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameters_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_initcontainer_mixed_allowed {
+	input := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_pod_initcontainer_mixed_not_allowed {
+	input := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
+}
+
+# securityContext based seccomp with containers
 test_input_seccomp_empty_parameters {
-    input := { "review": input_review_pod_single, "parameters": input_parameters_empty}
-    results := violation with input as input
-    count(results) == 1
+	input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_empty}
+	results := violation with input as input
+	count(results) == 1
 }
 
 test_input_seccomp_allowed_all {
-    input := { "review": input_review_pod_single, "parameters": input_parameters_wildcard}
-    results := violation with input as input
-    count(results) == 0
+	input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as input
+	count(results) == 0
 }
 
 test_input_seccomp_allowed_in_list {
-    input := { "review": input_review_pod_single, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 0
+	input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
 }
 
 test_input_seccomp_not_allowed_not_in_list {
-    input := { "review": input_review_pod_single, "parameters": input_parameters_not_in_list}
-    results := violation with input as input
-    count(results) == 1
+	input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 1
 }
 
 test_input_seccomp_pod_multiple_empty_parameters {
-    input := { "review": input_review_pod_multiple, "parameters": input_parameters_empty}
-    results := violation with input as input
-    count(results) == 2
+	input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_empty}
+	results := violation with input as input
+	count(results) == 2
 }
 
 test_input_seccomp_pod_multiple_allowed_all {
-    input := { "review": input_review_pod_multiple, "parameters": input_parameters_wildcard}
-    results := violation with input as input
-    count(results) == 0
+	input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as input
+	count(results) == 0
 }
 
 test_input_seccomp_pod_multiple_allowed_in_list {
-    input := { "review": input_review_pod_multiple, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 0
+	input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
 }
 
 test_input_seccomp_pod_multiple_not_allowed_not_in_list {
-    input := { "review": input_review_pod_multiple, "parameters": input_parameters_not_in_list}
-    results := violation with input as input
-    count(results) == 2
+	input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
 }
 
-test_input_seccomp_not_allowed_no_annotation {
-    input := { "review": input_review_no_annotation, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 1
+test_input_seccomp_not_allowed_not_configured {
+	input := {"review": get_object({}, {}, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
 }
 
-test_input_seccomp_not_allowed_multiple_no_annotation {
-    input := { "review": input_review_containers_no_annotation, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 2
+test_input_seccomp_not_allowed_multiple_not_configured {
+	input := {"review": get_object({}, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 2
 }
 
 test_input_seccomp_container_allowed_all {
-    input := { "review": input_review_container, "parameters": input_parameters_wildcard}
-    results := violation with input as input
-    count(results) == 0
+	input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as input
+	count(results) == 0
 }
 
 test_input_seccomp_container_allowed_in_list {
-    input := { "review": input_review_container, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 0
+	input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
 }
 
 test_input_seccomp_container_not_allowed_not_in_list {
-    input := { "review": input_review_container, "parameters": input_parameters_not_in_list}
-    results := violation with input as input
-    count(results) == 1
+	input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 1
 }
 
 test_input_seccomp_containers_allowed_in_list {
-    input := { "review": input_review_containers, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 0
+	input := {"review": get_object({}, {}, multiple_containers_sc, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
 }
 
 test_input_seccomp_containers_not_allowed_not_in_list {
-    input := { "review": input_review_containers, "parameters": input_parameters_not_in_list}
-    results := violation with input as input
-    count(results) == 2
+	input := {"review": get_object({}, {}, multiple_containers_sc, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
 }
 
 test_input_seccomp_containers_mixed {
-    input := { "review": input_review_containers_mixed, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 1
+	input := {"review": get_object({}, {}, multiple_containers_sc_mixed, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
 }
 
-test_input_seccomp_containers_mixed_missing_annotation {
-    input := { "review": input_review_containers_missing, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 1
+test_input_seccomp_containers_mixed_missing {
+	input := {"review": get_object({}, {}, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
 }
 
 test_input_seccomp_containers_allowed_in_list_multiple {
-    input := { "review": input_review_containers_mixed, "parameters": input_parameters_in_list}
-    results := violation with input as input
-    count(results) == 0
+	input := {"review": get_object({}, {}, multiple_containers_sc_mixed, {}), "parameters": input_parameters_in_list}
+	results := violation with input as input
+	count(results) == 0
 }
 
-test_input_seccomp_pod_container_annotation {
-    input := { "review": input_review_pod_container, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 0
+test_input_seccomp_pod_container {
+	input := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
 }
 
-test_input_seccomp_pod_container_annotation_not_allowed {
-    input := { "review": input_review_pod_container, "parameters": input_parameters_not_in_list}
-    results := violation with input as input
-    count(results) == 2
+test_input_seccomp_pod_container_mixed_not_allowed_but_exempt {
+	input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_exempt}
+	results := violation with input as input
+	count(results) == 0
 }
 
-test_input_seccomp_pod_container_annotation_both_allowed {
-    input := { "review": input_review_pod_container_mixed, "parameters": input_parameters_in_list}
-    results := violation with input as input
-    count(results) == 0
+test_input_seccomp_pod_container_not_allowed {
+	input := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
 }
 
-test_input_seccomp_pod_container_annotation_mixed_allowed {
-    input := { "review": input_review_pod_container_mixed, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 1
+test_input_seccomp_pod_container_both_allowed {
+	input := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameters_in_list}
+	results := violation with input as input
+	count(results) == 0
 }
 
-test_input_seccomp_pod_container_annotation_mixed_not_allowed {
-    input := { "review": input_review_pod_container_mixed, "parameters": input_parameters_not_in_list}
-    results := violation with input as input
-    count(results) == 2
+test_input_seccomp_pod_container_mixed_allowed {
+	input := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
 }
 
-test_input_seccomp_pod_container_annotation_both_allowed_reversed {
-    input := { "review": input_review_pod_container_mixed_reversed, "parameters": input_parameters_in_list}
-    results := violation with input as input
-    count(results) == 0
+test_input_seccomp_pod_container_mixed_not_allowed {
+	input := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
 }
 
-test_input_seccomp_pod_container_annotation_mixed_allowed_reversed {
-    input := { "review": input_review_pod_container_mixed_reversed, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 1
+# securityContext based seccomp with init containers
+test_input_seccomp_pod_initcontainer_both_allowed {
+	input := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameters_in_list}
+	results := violation with input as input
+	count(results) == 0
 }
 
-test_input_seccomp_pod_container_annotation_mixed_not_allowed_reversed {
-    input := { "review": input_review_pod_container_mixed_reversed, "parameters": input_parameters_not_in_list}
-    results := violation with input as input
-    count(results) == 2
+test_input_seccomp_pod_initcontainer_mixed_allowed {
+	input := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
 }
 
-#Init Containers
-test_input_init_seccomp_pod_container_annotation_both_allowed {
-    input := { "review": input_review_init_pod_container_mixed, "parameters": input_parameters_in_list}
-    results := violation with input as input
-    count(results) == 0
+test_input_seccomp_pod_initcontainer_mixed_not_allowed {
+	input := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 2
 }
 
-test_input_init_seccomp_pod_container_annotation_mixed_allowed {
-    input := { "review": input_review_init_pod_container_mixed, "parameters": input_parameter_in_list}
-    results := violation with input as input
-    count(results) == 1
-}
+# Create Review Object
+get_object(annotations, podcontext, containers, initcontainers) = {"object": {
+	"metadata": {
+		"name": "nginx",
+		"annotations": annotations,
+	},
+	"spec": {
+		"containers": containers,
+		"initContainers": initcontainers,
+		"securityContext": podcontext,
+	},
+}}
 
-test_input_init_seccomp_pod_container_annotation_mixed_not_allowed {
-    input := { "review": input_review_init_pod_container_mixed, "parameters": input_parameters_not_in_list}
-    results := violation with input as input
-    count(results) == 2
-}
-
-test_input_init_seccomp_pod_container_annotation_mixed_not_allowed_but_exempt {
-    input := { "review": input_review_init_pod_container_mixed, "parameters": input_parameters_exempt}
-    results := violation with input as input
-    count(results) == 0
-}
-
-input_review_pod_single = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "seccomp.security.alpha.kubernetes.io/pod": "runtime/default"
-            }
-        },
-        "spec": {
-            "containers": single_container
-        }
-    }
-}
-
-input_review_pod_multiple = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "seccomp.security.alpha.kubernetes.io/pod": "runtime/default"
-            }
-        },
-        "spec": {
-            "containers": multiple_containers
-        }
-    }
-}
-
-input_review_container = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"
-            }
-        },
-        "spec": {
-            "containers": single_container
-        }
-    }
-}
-
-input_review_containers = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
-                "container.seccomp.security.alpha.kubernetes.io/nginx2": "runtime/default"
-            }
-        },
-        "spec": {
-            "containers": multiple_containers
-        }
-    }
-}
-
-input_review_containers_mixed = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
-                "container.seccomp.security.alpha.kubernetes.io/nginx2": "docker/default"
-            }
-        },
-        "spec": {
-            "containers": multiple_containers
-        }
-    }
-}
-
-input_review_containers_missing = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"
-            }
-        },
-        "spec": {
-            "containers": multiple_containers
-        }
-    }
-}
-
-input_review_pod_container = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
-                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"
-            }
-        },
-        "spec": {
-            "containers": multiple_containers
-        }
-    }
-}
-
-input_review_pod_container_mixed = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
-                "container.seccomp.security.alpha.kubernetes.io/nginx": "docker/default"
-            }
-        },
-        "spec": {
-            "containers": multiple_containers
-        }
-    }
-}
-
-input_review_pod_container_mixed_reversed = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "seccomp.security.alpha.kubernetes.io/pod": "docker/default",
-                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"
-            }
-        },
-        "spec": {
-            "containers": multiple_containers
-        }
-    }
-}
-
-input_review_init_pod_container_mixed = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
-                "container.seccomp.security.alpha.kubernetes.io/nginx": "docker/default"
-            }
-        },
-        "spec": {
-            "initContainers": multiple_containers
-        }
-    }
-}
-
-
-input_review_no_annotation = {
-    "object": {
-        "metadata": {
-            "name": "nginx"
-        },
-        "spec": {
-            "containers": single_container
-        }
-    }
-}
-
-
-input_review_containers_no_annotation = {
-    "object": {
-        "metadata": {
-            "name": "nginx"
-        },
-        "spec": {
-            "containers": multiple_containers
-        }
-    }
-}
-
+# Test Containers
 single_container = [{
-    "name": "nginx",
-    "image": "nginx"
+	"name": "nginx",
+	"image": "nginx",
 }]
 
-multiple_containers = [{
-    "name": "nginx",
-    "image": "nginx"
-}, {
-    "name": "nginx2",
-    "image": "nginx"
+multiple_containers = [
+	{
+		"name": "nginx",
+		"image": "nginx",
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+	},
+]
+
+single_container_sc = [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": context_runtimedefault,
 }]
 
-input_parameters_empty = {
-    "allowedProfiles": []
+multiple_containers_sc = [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+]
+
+multiple_containers_sc_mixed = [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"securityContext": context_localhost,
+	},
+]
+
+multiple_containers_sc_missing = [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+	},
+]
+
+# Test Annotations
+pod_annotation = {"seccomp.security.alpha.kubernetes.io/pod": "runtime/default"}
+
+pod_container_annotations = {
+	"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
 }
 
-input_parameters_wildcard = {
-    "allowedProfiles": [
-        "*"
-    ]
+pod_container_annotations_mixed = {
+	"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+	"container.seccomp.security.alpha.kubernetes.io/nginx": "docker/default",
 }
 
-input_parameter_in_list = {
-    "allowedProfiles": [
-        "runtime/default"
-    ]
+pod_container_annotations_mixed_rev = {
+	"seccomp.security.alpha.kubernetes.io/pod": "docker/default",
+	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
 }
 
-input_parameters_in_list = {
-    "allowedProfiles": [
-        "runtime/default",
-        "docker/default"
-    ]
+container_annotation = {"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"}
+
+container_annotations = {
+	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+	"container.seccomp.security.alpha.kubernetes.io/nginx2": "runtime/default",
 }
 
-input_parameters_not_in_list = {
-    "allowedProfiles": [
-        "unconfined"
-    ]
+container_annotations_mixed = {
+	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+	"container.seccomp.security.alpha.kubernetes.io/nginx2": "docker/default",
 }
+
+# Test securityContexts
+context_localhost = {"seccompProfile": {"type": "Localhost"}}
+
+context_runtimedefault = {"seccompProfile": {"type": "RuntimeDefault"}}
+
+context_unconfined = {"seccompProfile": {"type": "Unconfined"}}
+
+# Test Parameters
+input_parameters_empty = {"allowedProfiles": []}
+
+input_parameters_wildcard = {"allowedProfiles": ["*"]}
+
+input_parameter_in_list = {"allowedProfiles": [
+	"runtime/default",
+	"RuntimeDefault",
+]}
+
+input_parameters_in_list = {"allowedProfiles": [
+	"runtime/default",
+	"RuntimeDefault",
+	"docker/default",
+	"Localhost",
+]}
+
+input_parameters_not_in_list = {"allowedProfiles": [
+	"unconfined",
+	"Unconfined",
+]}
 
 input_parameters_exempt = {
-    "exemptImages": ["nginx"],
-    "allowedProfiles": [
-        "unconfined"
-    ]
+	"exemptImages": ["nginx"],
+	"allowedProfiles": ["unconfined"],
 }

--- a/src/pod-security-policy/seccomp/src_test.rego
+++ b/src/pod-security-policy/seccomp/src_test.rego
@@ -328,6 +328,61 @@ test_input_seccomp_pod_initcontainer_mixed_not_allowed {
 	count(results) == 2
 }
 
+# Both annotation and securityContext based seccomp mixed
+test_input_both_seccomp_pod_context_container_annotation {
+	input := {"review": get_object(container_annotation, context_unconfined, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_both_seccomp_pod_annotation_container_context {
+	input := {"review": get_object(pod_annotation_unconfined, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_both_seccomp_pod_context_and_annotation {
+	input := {"review": get_object(pod_annotation, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_both_seccomp_container_context_and_annotation {
+	input := {"review": get_object(container_annotation, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 0
+}
+
+test_input_both_seccomp_pod_context_container_annotation_not_allowed {
+	input := {"review": get_object(container_annotation, context_unconfined, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_both_seccomp_pod_annotation_container_context_not_allowed {
+	input := {"review": get_object(pod_annotation_unconfined, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_both_seccomp_pod_context_and_annotation_not_allowed {
+	input := {"review": get_object(pod_annotation, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_both_seccomp_container_context_and_annotation_not_allowed {
+	input := {"review": get_object(container_annotation, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
+test_input_both_seccomp_pod_context_container_annotation_multiple_mixed {
+	input := {"review": get_object(container_annotation, context_unconfined, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as input
+	count(results) == 1
+}
+
 # Create Review Object
 get_object(annotations, podcontext, containers, initcontainers) = {"object": {
 	"metadata": {
@@ -404,6 +459,8 @@ multiple_containers_sc_missing = [
 
 # Test Annotations
 pod_annotation = {"seccomp.security.alpha.kubernetes.io/pod": "runtime/default"}
+
+pod_annotation_unconfined = {"seccomp.security.alpha.kubernetes.io/pod": "unconfined"}
 
 pod_container_annotations = {
 	"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",

--- a/src/pod-security-policy/seccomp/src_test.rego
+++ b/src/pod-security-policy/seccomp/src_test.rego
@@ -383,10 +383,10 @@ test_input_both_seccomp_container_context_and_annotation {
 	count(results) == 0
 }
 
-test_input_both_seccomp_pod_context_container_annotation_not_allowed {
+test_input_both_seccomp_pod_context_container_annotation {
 	input := {"review": get_object(container_annotation, context_unconfined, single_container, {}), "parameters": input_parameters_not_in_list}
 	results := violation with input as input
-	count(results) == 1
+	count(results) == 0
 }
 
 test_input_both_seccomp_pod_annotation_container_context_not_allowed {

--- a/src/pod-security-policy/seccomp/src_test.rego
+++ b/src/pod-security-policy/seccomp/src_test.rego
@@ -2,538 +2,538 @@ package k8spspseccomp
 
 # Annotation based seccomp with containers
 test_input_annotation_seccomp_empty_parameters {
-	input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_empty}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_annotation_seccomp_allowed_all {
-	input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_wildcard}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_allowed_in_list {
-	input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_not_allowed_not_in_list {
-	input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_annotation_seccomp_pod_multiple_empty_parameters {
-	input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_empty}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_annotation_seccomp_pod_multiple_allowed_all {
-	input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_wildcard}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_pod_multiple_allowed_in_list {
-	input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_pod_multiple_not_allowed_not_in_list {
-	input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_annotation_seccomp_container_allowed_all {
-	input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_wildcard}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_container_allowed_in_list {
-	input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_container_not_allowed_not_in_list {
-	input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_annotation_seccomp_containers_allowed_in_list {
-	input := {"review": get_object(container_annotations, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(container_annotations, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_containers_not_allowed_not_in_list {
-	input := {"review": get_object(container_annotations, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object(container_annotations, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_annotation_seccomp_containers_mixed {
-	input := {"review": get_object(container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_annotation_seccomp_containers_mixed_missing {
-	input := {"review": get_object(container_annotation, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(container_annotation, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_annotation_seccomp_containers_allowed_in_list_multiple {
-	input := {"review": get_object(container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_pod_container {
-	input := {"review": get_object(pod_container_annotations, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(pod_container_annotations, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_pod_container_not_allowed {
-	input := {"review": get_object(pod_container_annotations, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object(pod_container_annotations, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_annotation_seccomp_pod_container_both_allowed {
-	input := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_pod_container_mixed_allowed {
-	input := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_annotation_seccomp_pod_container_mixed_not_allowed {
-	input := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_annotation_seccomp_pod_container_both_allowed_reversed {
-	input := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_pod_container_mixed_allowed_reversed {
-	input := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_annotation_seccomp_pod_container_mixed_not_allowed_reversed {
-	input := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 # Annotation based seccomp with init containers
 test_input_annotation_seccomp_pod_initcontainer_both_allowed {
-	input := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameters_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_annotation_seccomp_pod_initcontainer_mixed_allowed {
-	input := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_annotation_seccomp_pod_initcontainer_mixed_not_allowed {
-	input := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 # securityContext based seccomp with containers
 test_input_seccomp_empty_parameters {
-	input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_empty}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_seccomp_allowed_all {
-	input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_wildcard}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_allowed_in_list {
-	input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_not_allowed_not_in_list {
-	input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_seccomp_pod_multiple_empty_parameters {
-	input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_empty}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_seccomp_pod_multiple_allowed_all {
-	input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_wildcard}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_pod_multiple_allowed_in_list {
-	input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_pod_multiple_not_allowed_not_in_list {
-	input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_seccomp_pod_localhost_allowed_wrong_file {
-	input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_seccomp_pod_localhost_allowed_no_specified_file {
-	input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc_localhost_no_file}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc_localhost_no_file}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_seccomp_pod_localhost_allowed_wildcard_file {
-	input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc_localhost_wildcard_file}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc_localhost_wildcard_file}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_pod_localhost_allowed_annotation_wildcard_file {
-	input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_localhost_wildcard}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_localhost_wildcard}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_pod_localhost_allowed_both_wildcard_file {
-	input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_localhost_wildcard_both}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_localhost_wildcard_both}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_not_allowed_not_configured {
-	input := {"review": get_object({}, {}, single_container, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, {}, single_container, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_seccomp_not_allowed_multiple_not_configured {
-	input := {"review": get_object({}, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object({}, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_seccomp_container_allowed_all {
-	input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_wildcard}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_container_allowed_in_list {
-	input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_container_not_allowed_not_in_list {
-	input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_seccomp_containers_allowed_in_list {
-	input := {"review": get_object({}, {}, multiple_containers_sc, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, {}, multiple_containers_sc, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_containers_not_allowed_not_in_list {
-	input := {"review": get_object({}, {}, multiple_containers_sc, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object({}, {}, multiple_containers_sc, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_seccomp_containers_mixed {
-	input := {"review": get_object({}, {}, multiple_containers_sc_mixed, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, {}, multiple_containers_sc_mixed, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_seccomp_containers_mixed_missing {
-	input := {"review": get_object({}, {}, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, {}, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_seccomp_containers_allowed_in_list_multiple {
-	input := {"review": get_object({}, {}, multiple_containers_sc_mixed, {}), "parameters": input_parameters_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, {}, multiple_containers_sc_mixed, {}), "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_pod_container {
-	input := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_pod_container_mixed_not_allowed_but_exempt {
-	input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_exempt}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_exempt}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_pod_container_not_allowed {
-	input := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_seccomp_pod_container_both_allowed {
-	input := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameters_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_pod_container_mixed_allowed {
-	input := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_seccomp_pod_container_mixed_not_allowed {
-	input := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 # securityContext based seccomp with init containers
 test_input_seccomp_pod_initcontainer_both_allowed {
-	input := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameters_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_seccomp_pod_initcontainer_mixed_allowed {
-	input := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_seccomp_pod_initcontainer_mixed_not_allowed {
-	input := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 2
+    input := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 # Both annotation and securityContext based seccomp mixed
 test_input_both_seccomp_pod_context_container_annotation {
-	input := {"review": get_object(container_annotation_unconfined, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(container_annotation_unconfined, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_both_seccomp_pod_annotation_container_context {
-	input := {"review": get_object(pod_annotation_unconfined, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(pod_annotation_unconfined, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_both_seccomp_pod_context_and_annotation {
-	input := {"review": get_object(pod_annotation, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(pod_annotation, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_both_seccomp_container_context_and_annotation {
-	input := {"review": get_object(container_annotation, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(container_annotation, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_both_seccomp_pod_context_container_annotation_not_allowed {
-	input := {"review": get_object(container_annotation_unconfined, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(container_annotation_unconfined, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_both_seccomp_pod_annotation_container_context_not_allowed {
-	input := {"review": get_object(pod_annotation_unconfined, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(pod_annotation_unconfined, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_both_seccomp_pod_context_and_annotation_not_allowed {
-	input := {"review": get_object(pod_annotation, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(pod_annotation, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_both_seccomp_container_context_and_annotation_not_allowed {
-	input := {"review": get_object(container_annotation, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(container_annotation, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_both_seccomp_pod_context_container_annotation_multiple_mixed {
-	input := {"review": get_object(container_annotation, context_unconfined, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object(container_annotation, context_unconfined, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 # Testing translation between annotation and securityContext
 test_translation_seccomp_allowed_annotation_all {
-	input := {"parameters": input_parameters_annotation}
-	output := get_allowed_profiles with input as input
-	output == allowed_full_translated
+    input := {"parameters": input_parameters_annotation}
+    output := get_allowed_profiles with input as input
+    output == allowed_full_translated
 }
 
 test_translation_seccomp_allowed_context_all {
-	input := {"parameters": input_parameters_sc}
-	output := get_allowed_profiles with input as input
-	output == allowed_full_translated
+    input := {"parameters": input_parameters_sc}
+    output := get_allowed_profiles with input as input
+    output == allowed_full_translated
 }
 
 test_translation_seccomp_allowed_context_localhost_wildcard_file {
-	input := {"parameters": input_parameters_sc_localhost_wildcard_file}
-	output := get_allowed_profiles with input as input
-	output == {"Localhost", "localhost/*"}
+    input := {"parameters": input_parameters_sc_localhost_wildcard_file}
+    output := get_allowed_profiles with input as input
+    output == {"Localhost", "localhost/*"}
 }
 
 test_translation_seccomp_allowed_context_localhost_no_file {
-	input := {"parameters": input_parameters_sc_localhost_no_file}
-	output := get_allowed_profiles with input as input
-	output == {"Localhost"}
+    input := {"parameters": input_parameters_sc_localhost_no_file}
+    output := get_allowed_profiles with input as input
+    output == {"Localhost"}
 }
 
 test_input_translation_seccomp_annotation_match_allowed_context {
-	input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_sc}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_sc}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_translation_seccomp_context_match_allowed_annotation {
-	input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_annotation}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_annotation}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_translation_seccomp_context_localhost_allowed_annotation {
-	input := {"review": get_object({}, context_localhost1, single_container, {}), "parameters": input_parameters_annotation}
-	results := violation with input as input
-	count(results) == 0
+    input := {"review": get_object({}, context_localhost1, single_container, {}), "parameters": input_parameters_annotation}
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_translation_seccomp_context_localhost_allowed_annotation_missing {
-	input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_annotation}
-	results := violation with input as input
-	count(results) == 1
+    input := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_annotation}
+    results := violation with input as input
+    count(results) == 1
 }
 
 # Create Review Object
 get_object(annotations, podcontext, containers, initcontainers) = {"object": {
-	"metadata": {
-		"name": "nginx",
-		"annotations": annotations,
-	},
-	"spec": {
-		"containers": containers,
-		"initContainers": initcontainers,
-		"securityContext": podcontext,
-	},
+    "metadata": {
+        "name": "nginx",
+        "annotations": annotations,
+    },
+    "spec": {
+        "containers": containers,
+        "initContainers": initcontainers,
+        "securityContext": podcontext,
+    },
 }}
 
 # Test Containers
 single_container = [{
-	"name": "nginx",
-	"image": "nginx",
+    "name": "nginx",
+    "image": "nginx",
 }]
 
 multiple_containers = [
-	{
-		"name": "nginx",
-		"image": "nginx",
-	},
-	{
-		"name": "nginx2",
-		"image": "nginx",
-	},
+    {
+        "name": "nginx",
+        "image": "nginx",
+    },
+    {
+        "name": "nginx2",
+        "image": "nginx",
+    },
 ]
 
 single_container_sc = [{
-	"name": "nginx",
-	"image": "nginx",
-	"securityContext": context_runtimedefault,
+    "name": "nginx",
+    "image": "nginx",
+    "securityContext": context_runtimedefault,
 }]
 
 multiple_containers_sc = [
-	{
-		"name": "nginx",
-		"image": "nginx",
-		"securityContext": context_runtimedefault,
-	},
-	{
-		"name": "nginx2",
-		"image": "nginx",
-		"securityContext": context_runtimedefault,
-	},
+    {
+        "name": "nginx",
+        "image": "nginx",
+        "securityContext": context_runtimedefault,
+    },
+    {
+        "name": "nginx2",
+        "image": "nginx",
+        "securityContext": context_runtimedefault,
+    },
 ]
 
 multiple_containers_sc_mixed = [
-	{
-		"name": "nginx",
-		"image": "nginx",
-		"securityContext": context_runtimedefault,
-	},
-	{
-		"name": "nginx2",
-		"image": "nginx",
-		"securityContext": context_localhost,
-	},
+    {
+        "name": "nginx",
+        "image": "nginx",
+        "securityContext": context_runtimedefault,
+    },
+    {
+        "name": "nginx2",
+        "image": "nginx",
+        "securityContext": context_localhost,
+    },
 ]
 
 multiple_containers_sc_missing = [
-	{
-		"name": "nginx",
-		"image": "nginx",
-		"securityContext": context_runtimedefault,
-	},
-	{
-		"name": "nginx2",
-		"image": "nginx",
-	},
+    {
+        "name": "nginx",
+        "image": "nginx",
+        "securityContext": context_runtimedefault,
+    },
+    {
+        "name": "nginx2",
+        "image": "nginx",
+    },
 ]
 
 # Test Annotations
@@ -542,18 +542,18 @@ pod_annotation = {"seccomp.security.alpha.kubernetes.io/pod": "runtime/default"}
 pod_annotation_unconfined = {"seccomp.security.alpha.kubernetes.io/pod": "unconfined"}
 
 pod_container_annotations = {
-	"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
-	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+    "seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+    "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
 }
 
 pod_container_annotations_mixed = {
-	"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
-	"container.seccomp.security.alpha.kubernetes.io/nginx": "localhost/profile.json",
+    "seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+    "container.seccomp.security.alpha.kubernetes.io/nginx": "localhost/profile.json",
 }
 
 pod_container_annotations_mixed_rev = {
-	"seccomp.security.alpha.kubernetes.io/pod": "localhost/profile.json",
-	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+    "seccomp.security.alpha.kubernetes.io/pod": "localhost/profile.json",
+    "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
 }
 
 container_annotation = {"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"}
@@ -561,13 +561,13 @@ container_annotation = {"container.seccomp.security.alpha.kubernetes.io/nginx": 
 container_annotation_unconfined = {"container.seccomp.security.alpha.kubernetes.io/nginx": "unconfined"}
 
 container_annotations = {
-	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
-	"container.seccomp.security.alpha.kubernetes.io/nginx2": "runtime/default",
+    "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+    "container.seccomp.security.alpha.kubernetes.io/nginx2": "runtime/default",
 }
 
 container_annotations_mixed = {
-	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
-	"container.seccomp.security.alpha.kubernetes.io/nginx2": "localhost/profile.json",
+    "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+    "container.seccomp.security.alpha.kubernetes.io/nginx2": "localhost/profile.json",
 }
 
 # Test securityContexts
@@ -589,59 +589,59 @@ input_parameters_localhost_wildcard = {"allowedProfiles": ["localhost/*"]}
 input_parameters_localhost_wildcard_both = {"allowedProfiles": ["localhost/*"], "allowedLocalhostFiles": ["*"]}
 
 input_parameter_in_list = {"allowedProfiles": [
-	"runtime/default",
-	"RuntimeDefault",
+    "runtime/default",
+    "RuntimeDefault",
 ]}
 
 input_parameters_in_list = {
-	"allowedProfiles": [
-		"runtime/default",
-		"RuntimeDefault",
-		"docker/default",
-		"Localhost",
-	],
-	"allowedLocalhostFiles": ["profile.json"],
+    "allowedProfiles": [
+        "runtime/default",
+        "RuntimeDefault",
+        "docker/default",
+        "Localhost",
+    ],
+    "allowedLocalhostFiles": ["profile.json"],
 }
 
 input_parameters_not_in_list = {"allowedProfiles": [
-	"unconfined",
-	"Unconfined",
+    "unconfined",
+    "Unconfined",
 ]}
 
 input_parameters_exempt = {
-	"exemptImages": ["nginx"],
-	"allowedProfiles": ["unconfined"],
+    "exemptImages": ["nginx"],
+    "allowedProfiles": ["unconfined"],
 }
 
 input_parameters_annotation = {"allowedProfiles": [
-	"runtime/default",
-	"docker/default",
-	"localhost/profile1.json",
-	"localhost/profile2.json",
-	"unconfined",
+    "runtime/default",
+    "docker/default",
+    "localhost/profile1.json",
+    "localhost/profile2.json",
+    "unconfined",
 ]}
 
 input_parameters_sc = {
-	"allowedProfiles": [
-		"RuntimeDefault",
-		"Localhost",
-		"Unconfined",
-	],
-	"allowedLocalhostFiles": [
-		"profile1.json",
-		"profile2.json",
-	],
+    "allowedProfiles": [
+        "RuntimeDefault",
+        "Localhost",
+        "Unconfined",
+    ],
+    "allowedLocalhostFiles": [
+        "profile1.json",
+        "profile2.json",
+    ],
 }
 
 input_parameters_sc_localhost_wildcard_file = {
-	"allowedProfiles": ["Localhost"],
-	"allowedLocalhostFiles": ["*"],
+    "allowedProfiles": ["Localhost"],
+    "allowedLocalhostFiles": ["*"],
 }
 
 input_parameters_sc_localhost_no_file = {"allowedProfiles": ["Localhost"]}
 
 allowed_full_translated = {
-	"Localhost", "localhost/profile1.json", "localhost/profile2.json",
-	"RuntimeDefault", "docker/default", "runtime/default",
-	"Unconfined", "unconfined",
+    "Localhost", "localhost/profile1.json", "localhost/profile2.json",
+    "RuntimeDefault", "docker/default", "runtime/default",
+    "Unconfined", "unconfined",
 }


### PR DESCRIPTION
Reworked the Rego policy code for k8spspseccomp so that it will support seccomp configuration found in the pods securityContext while still keeping support for the annotation based seccomp configuration that has been deprecated (to be removed in kubernetes v1.25).

This new policy code was tested with the original unit tests first to ensure backwards compatibility, however I have refactored and expanded the unit tests to cover all locations where a seccomp profile can be found.

The messaging to the user is improved, since there are now 4 locations where a profile can be detected for each container (pod annotation, container annotation, pod securityContext, and container securityContext) I made it clear which location the profile was detected in for each container. I also continue to return a violation when a container has no profile detected from any source as per the original policy, however this is a bit more explicit in the new policy code.

Gator tests were also confirmed to be passing with new messages, I have fixed one which was referencing the incorrect example file.

Fixes: https://github.com/open-policy-agent/gatekeeper-library/issues/79

Signed-off-by: Alain Baxter <alain.baxter@sada.com>