### PR TITLE
Add noupdateserviceaccount policy to library

### DIFF
--- a/library/general/noupdateserviceaccount/README.md
+++ b/library/general/noupdateserviceaccount/README.md
@@ -1,0 +1,13 @@
+# NoUpdateServiceAccount
+
+**NOTE:** This policy is ignored in `audit` mode, because it only blocks
+updates to existing resources, not specific configurations.
+
+The `NoUpdateServiceAccount` constraint blocks updating the service account on
+resources that abstract over Pods.
+
+This policy helps prevent workloads with "update-self" permissions from
+escalating further in the cluster by selecting a new service account to
+run as. It is especially useful for workloads running in sensitive
+namespaces like `kube-system`, where nearby service accounts are likely to
+have cluster admin rights.

--- a/library/general/noupdateserviceaccount/kustomization.yaml
+++ b/library/general/noupdateserviceaccount/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/noupdateserviceaccount/samples/noupdateserviceaccount/constraint.yaml
+++ b/library/general/noupdateserviceaccount/samples/noupdateserviceaccount/constraint.yaml
@@ -1,0 +1,33 @@
+# IMPORTANT: Before deploying this policy, make sure you allow-list any groups
+# or users that need to deploy workloads to kube-system, such as cluster-
+# lifecycle controllers, addon managers, etc. Such controllers may need to
+# update service account names during automated rollouts (e.g. of refactored
+# configurations). You can allow-list them with the allowedGroups and
+# allowedUsers properties of the NoUpdateServiceAccount Constraint.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: NoUpdateServiceAccount
+metadata:
+  name: no-update-kube-system-service-account
+spec:
+  match:
+    namespaces: ["kube-system"]
+    kinds:
+    - apiGroups: [""]
+      kinds:
+      # You can optionally add "Pod" here, but it is unnecessary because
+      # Pod service account immutability is enforced by the Kubernetes API.
+      - "ReplicationController"
+    - apiGroups: ["apps"]
+      kinds:
+      - "ReplicaSet"
+      - "Deployment"
+      - "StatefulSet"
+      - "DaemonSet"
+    - apiGroups: ["batch"]
+      kinds:
+      # You can optionally add "Job" here, but it is unnecessary because
+      # Job service account immutability is enforced by the Kubernetes API.
+      - "CronJob"
+  parameters:
+    allowedGroups: []
+    allowedUsers: []

--- a/library/general/noupdateserviceaccount/samples/noupdateserviceaccount/example_allowed.yaml
+++ b/library/general/noupdateserviceaccount/samples/noupdateserviceaccount/example_allowed.yaml
@@ -1,0 +1,31 @@
+# Note: The gator tests currently require exactly one object per example file.
+# Since this is an update-triggered policy, at least two objects are technically
+# required to demonstrate it. Due to the gator requirement, we only have one
+# object below. The policy should allow changing everything but the
+# serviceAccountName field.
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: policy-test
+  namespace: kube-system
+  labels:
+    app: policy-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: policy-test-deploy
+  template:
+    metadata:
+      labels:
+        app: policy-test-deploy
+    spec:
+      # Changing anything except this field should be allowed by the policy.
+      serviceAccountName: policy-test-sa-1
+      containers:
+      - name: policy-test
+        image: ubuntu
+        command:
+        - /bin/bash
+        - -c
+        - sleep 99999

--- a/library/general/noupdateserviceaccount/suite.yaml
+++ b/library/general/noupdateserviceaccount/suite.yaml
@@ -1,0 +1,20 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: noupdateserviceaccount
+tests:
+  - name: noupdateserviceaccount
+    template: template.yaml
+    constraint: samples/noupdateserviceaccount/constraint.yaml
+    cases:
+      - name: example-allowed
+        object: samples/noupdateserviceaccount/example_allowed.yaml
+        assertions:
+          - violations: no
+      # Since the tests are currently stateless, they can't exercise level-triggered
+      # events like changing a field. For now, manually test example_disallowed.yaml
+      # instead.
+      # - name: example-disallowed
+      #   object: samples/noupdateserviceaccount/example_disallowed.yaml
+      #   assertions:
+      #     - violations: yes

--- a/library/general/noupdateserviceaccount/template.yaml
+++ b/library/general/noupdateserviceaccount/template.yaml
@@ -1,0 +1,99 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: noupdateserviceaccount
+  annotations:
+    description: "Blocks updating the service account on resources that abstract over Pods. This policy is ignored in audit mode."
+spec:
+  crd:
+    spec:
+      names:
+        kind: NoUpdateServiceAccount
+      validation:
+        openAPIV3Schema:
+          properties:
+            allowedGroups:
+              description: Groups that should be allowed to bypass the policy.
+              type: array
+              items: string
+            allowedUsers:
+              description: Users that should be allowed to bypass the policy.
+              type: array
+              items: string
+  targets:
+  - target: admission.k8s.gatekeeper.sh
+    rego: |
+      package noupdateserviceaccount
+
+      privileged(userInfo, allowedUsers, allowedGroups) {
+        # Allow if the user is in allowedUsers.
+        # Use object.get so omitted parameters can't cause policy bypass by
+        # evaluating to undefined.
+        username := object.get(userInfo, "username", "")
+        allowedUsers[_] == username
+      } {
+        # Allow if the user's groups intersect allowedGroups.
+        # Use object.get so omitted parameters can't cause policy bypass by
+        # evaluating to undefined.
+        userGroups := object.get(userInfo, "groups", [])
+        groups := {g | g := userGroups[_]}
+        allowed := {g | g := allowedGroups[_]}
+        intersection := groups & allowed
+        count(intersection) > 0
+      }
+
+      get_service_account(obj) = spec {
+        obj.kind == "Pod"
+        spec := obj.spec.serviceAccountName
+      } {
+        obj.kind == "ReplicationController"
+        spec := obj.spec.template.spec.serviceAccountName
+      } {
+        obj.kind == "ReplicaSet"
+        spec := obj.spec.template.spec.serviceAccountName
+      } {
+        obj.kind == "Deployment"
+        spec := obj.spec.template.spec.serviceAccountName
+      } {
+        obj.kind == "StatefulSet"
+        spec := obj.spec.template.spec.serviceAccountName
+      } {
+        obj.kind == "DaemonSet"
+        spec := obj.spec.template.spec.serviceAccountName
+      } {
+        obj.kind == "Job"
+        spec := obj.spec.template.spec.serviceAccountName
+      } {
+        obj.kind == "CronJob"
+        spec := obj.spec.jobTemplate.spec.template.spec.serviceAccountName
+      }
+
+      violation[{"msg": msg}] {
+        # This policy only applies to updates of existing resources.
+        input.review.operation == "UPDATE"
+
+        # Use object.get so omitted parameters can't cause policy bypass by
+        # evaluating to undefined.
+        params := object.get(input, "parameters", {})
+        allowedUsers := object.get(params, "allowedUsers", [])
+        allowedGroups := object.get(params, "allowedGroups", [])
+
+        # Extract the service account.
+        oldKSA := get_service_account(input.review.oldObject)
+        newKSA := get_service_account(input.review.object)
+
+        # Deny unprivileged users and groups from changing serviceAccountName.
+        not privileged(input.review.userInfo, allowedUsers, allowedGroups)
+        oldKSA != newKSA
+        msg := "user does not have permission to modify serviceAccountName"
+      } {
+        # Defensively require object to have a serviceAccountName.
+        input.review.operation == "UPDATE"
+        not get_service_account(input.review.object)
+        msg := "missing serviceAccountName field in object under review"
+      } {
+        # Defensively require oldObject to have a serviceAccountName.
+        input.review.operation == "UPDATE"
+        not get_service_account(input.review.oldObject)
+        msg := "missing serviceAccountName field in oldObject under review"
+      }

--- a/src/general/noupdateserviceaccount/constraint.tmpl
+++ b/src/general/noupdateserviceaccount/constraint.tmpl
@@ -1,0 +1,26 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: noupdateserviceaccount
+  annotations:
+    description: "Blocks updating the service account on resources that abstract over Pods. This policy is ignored in audit mode."
+spec:
+  crd:
+    spec:
+      names:
+        kind: NoUpdateServiceAccount
+      validation:
+        openAPIV3Schema:
+          properties:
+            allowedGroups:
+              description: Groups that should be allowed to bypass the policy.
+              type: array
+              items: string
+            allowedUsers:
+              description: Users that should be allowed to bypass the policy.
+              type: array
+              items: string
+  targets:
+  - target: admission.k8s.gatekeeper.sh
+    rego: |
+{{ file.Read "src/general/noupdateserviceaccount/src.rego" | strings.Indent 6 | strings.TrimSuffix "\n" }}

--- a/src/general/noupdateserviceaccount/src.rego
+++ b/src/general/noupdateserviceaccount/src.rego
@@ -1,0 +1,74 @@
+package noupdateserviceaccount
+
+privileged(userInfo, allowedUsers, allowedGroups) {
+  # Allow if the user is in allowedUsers.
+  # Use object.get so omitted parameters can't cause policy bypass by
+  # evaluating to undefined.
+  username := object.get(userInfo, "username", "")
+  allowedUsers[_] == username
+} {
+  # Allow if the user's groups intersect allowedGroups.
+  # Use object.get so omitted parameters can't cause policy bypass by
+  # evaluating to undefined.
+  userGroups := object.get(userInfo, "groups", [])
+  groups := {g | g := userGroups[_]}
+  allowed := {g | g := allowedGroups[_]}
+  intersection := groups & allowed
+  count(intersection) > 0
+}
+
+get_service_account(obj) = spec {
+  obj.kind == "Pod"
+  spec := obj.spec.serviceAccountName
+} {
+  obj.kind == "ReplicationController"
+  spec := obj.spec.template.spec.serviceAccountName
+} {
+  obj.kind == "ReplicaSet"
+  spec := obj.spec.template.spec.serviceAccountName
+} {
+  obj.kind == "Deployment"
+  spec := obj.spec.template.spec.serviceAccountName
+} {
+  obj.kind == "StatefulSet"
+  spec := obj.spec.template.spec.serviceAccountName
+} {
+  obj.kind == "DaemonSet"
+  spec := obj.spec.template.spec.serviceAccountName
+} {
+  obj.kind == "Job"
+  spec := obj.spec.template.spec.serviceAccountName
+} {
+  obj.kind == "CronJob"
+  spec := obj.spec.jobTemplate.spec.template.spec.serviceAccountName
+}
+
+violation[{"msg": msg}] {
+  # This policy only applies to updates of existing resources.
+  input.review.operation == "UPDATE"
+
+  # Use object.get so omitted parameters can't cause policy bypass by
+  # evaluating to undefined.
+  params := object.get(input, "parameters", {})
+  allowedUsers := object.get(params, "allowedUsers", [])
+  allowedGroups := object.get(params, "allowedGroups", [])
+
+  # Extract the service account.
+  oldKSA := get_service_account(input.review.oldObject)
+  newKSA := get_service_account(input.review.object)
+
+  # Deny unprivileged users and groups from changing serviceAccountName.
+  not privileged(input.review.userInfo, allowedUsers, allowedGroups)
+  oldKSA != newKSA
+  msg := "user does not have permission to modify serviceAccountName"
+} {
+  # Defensively require object to have a serviceAccountName.
+  input.review.operation == "UPDATE"
+  not get_service_account(input.review.object)
+  msg := "missing serviceAccountName field in object under review"
+} {
+  # Defensively require oldObject to have a serviceAccountName.
+  input.review.operation == "UPDATE"
+  not get_service_account(input.review.oldObject)
+  msg := "missing serviceAccountName field in oldObject under review"
+}

--- a/src/general/noupdateserviceaccount/src_test.rego
+++ b/src/general/noupdateserviceaccount/src_test.rego
@@ -1,0 +1,317 @@
+package noupdateserviceaccount
+
+# Pod
+pod_spec(sa_name) = spec {
+    spec = {
+        "serviceAccountName": sa_name,
+    }
+}
+
+pod(sa_name) = obj {
+    obj = {
+        "kind": "Pod",
+        "spec": pod_spec(sa_name),
+    }
+}
+
+test_deny_pod {
+    input := {
+        "review": update(pod("sa1"), pod("sa2"), {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    result == policy_violation
+}
+
+# ReplicationController
+rc(sa_name) = obj {
+    obj = {
+        "kind": "ReplicationController",
+        "spec": {
+            "template": {
+                "spec": pod_spec(sa_name),
+            }
+        }
+    }
+}
+
+test_deny_rc {
+    input := {
+        "review": update(rc("sa1"), rc("sa2"), {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    result == policy_violation
+}
+
+# ReplicaSet
+rs(sa_name) = obj {
+    obj = {
+        "kind": "ReplicaSet",
+        "spec": {
+            "template": {
+                "spec": pod_spec(sa_name),
+            }
+        }
+    }
+}
+
+test_deny_rs {
+    input := {
+        "review": update(rs("sa1"), rs("sa2"), {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    result == policy_violation
+}
+
+# Deployment
+deploy(sa_name) = obj {
+    obj = {
+        "kind": "Deployment",
+        "spec": {
+            "template": {
+                "spec": pod_spec(sa_name),
+            }
+        }
+    }
+}
+
+test_deny_deploy {
+    input := {
+        "review": update(deploy("sa1"), deploy("sa2"), {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    result == policy_violation
+}
+
+# StatefulSet
+ss(sa_name) = obj {
+    obj = {
+        "kind": "StatefulSet",
+        "spec": {
+            "template": {
+                "spec": pod_spec(sa_name),
+            }
+        }
+    }
+}
+
+test_deny_ss {
+    input := {
+        "review": update(ss("sa1"), ss("sa2"), {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    result == policy_violation
+}
+
+# DaemonSet
+ds(sa_name) = obj {
+    obj = {
+        "kind": "DaemonSet",
+        "spec": {
+            "template": {
+                "spec": pod_spec(sa_name),
+            }
+        }
+    }
+}
+
+test_deny_ds {
+    input := {
+        "review": update(ds("sa1"), ds("sa2"), {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    result == policy_violation
+}
+
+# Job
+job(sa_name) = obj {
+    obj = {
+        "kind": "Job",
+        "spec": {
+            "template": {
+                "spec": pod_spec(sa_name),
+            }
+        }
+    }
+}
+
+test_deny_job {
+    input := {
+        "review": update(job("sa1"), job("sa2"), {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    result == policy_violation
+}
+
+# CronJob
+cronjob(sa_name) = obj {
+    obj = {
+        "kind": "CronJob",
+        "spec": {
+            "jobTemplate": {
+                "spec": {
+                    "template": {
+                        "spec": pod_spec(sa_name),
+                    }
+                }
+            }
+        }
+    }
+}
+
+test_deny_cronjob {
+    input := {
+        "review": update(cronjob("sa1"), cronjob("sa2"), {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    result == policy_violation
+}
+
+# Allow unrelated modification
+test_allow_unrelated {
+    a := deploy("sa")
+    b := {
+        "kind": "Deployment",
+        "spec": {
+            "template": {
+                "spec": {
+                    "serviceAccountName": "sa",
+                    "containers": [{"name": "newcontainer"}],
+                }
+            }
+        }
+    }
+    input := {
+        "review": update(a, b, {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    count(result) == 0
+}
+
+# Allow create and delete
+test_allow_create {
+    input := {
+        "review": create(deploy("sa1")),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    count(result) == 0
+}
+
+test_allow_delete {
+    input := {
+        "review": delete(deploy("sa1")),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    count(result) == 0
+}
+
+# Allowlist users and groups
+test_allow_users {
+    input := {
+        "review": update(deploy("sa1"), deploy("sa2"), {"username": "myuser"}),
+        "parameters": allow(["myuser"], []),
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    count(result) == 0
+}
+
+test_allow_groups {
+    input := {
+        "review": update(deploy("sa1"), deploy("sa2"), {"groups": ["mygroup"]}),
+        "parameters": allow([], ["mygroup"]),
+    }
+    result := violation with input as input
+    trace(sprintf("result: %v", [result]))
+    count(result) == 0
+}
+
+# Malformed
+test_deny_missing_old {
+    input := {
+        "review": update({}, pod("sa"), {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("%v", [result]))
+    result == missing_old_violation
+}
+
+test_deny_missing_new {
+    input := {
+        "review": update(pod("sa"), {}, {}),
+        "parameters": {},
+    }
+    result := violation with input as input
+    trace(sprintf("%v", [result]))
+    result == missing_new_violation
+}
+
+# Other helpers
+
+update(old, new, user) = output {
+    output = {
+        "operation": "UPDATE",
+        "oldObject": old,
+        "object": new,
+        "userInfo": user,
+    }
+}
+
+create(obj) = output {
+    output = {
+        "operation": "CREATE",
+        "oldObject": null,
+        "object": obj,
+        "userInfo": {},
+    }
+}
+
+delete(obj) = output {
+    output = {
+        "operation": "DELETE",
+        "oldObject": obj,
+        "object": null,
+        "userInfo": {},
+    }
+}
+
+allow(users, groups) = params {
+    params = {
+        "allowedUsers": users,
+        "allowedGroups": groups,
+    }
+}
+
+missing_old_violation[{"msg": msg}] {
+    msg := "missing serviceAccountName field in oldObject under review"
+}
+
+missing_new_violation[{"msg": msg}] {
+    msg := "missing serviceAccountName field in object under review"
+}
+
+policy_violation[{"msg": msg}] {
+    msg := "user does not have permission to modify serviceAccountName"
+}


### PR DESCRIPTION
This policy helps prevent workloads with "update-self" permissions from
escalating further in the cluster by selecting a new service account to
run as. It is especially useful for workloads running in sensitive
namespaces like kube-system, where nearby service accounts are likely to
have cluster admin rights.

@maxsmythe 