### PR TITLE
Add ephemeral containers to policies

### DIFF
--- a/library/general/allowedrepos/samples/repo-must-be-openpolicyagent/disallowed_both.yaml
+++ b/library/general/allowedrepos/samples/repo-must-be-openpolicyagent/disallowed_both.yaml
@@ -17,3 +17,10 @@ spec:
         limits:
           cpu: "100m"
           memory: "30Mi"
+  ephemeralContainers:
+    - name: nginx
+      image: nginx
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"

--- a/library/general/allowedrepos/suite.yaml
+++ b/library/general/allowedrepos/suite.yaml
@@ -26,8 +26,10 @@ tests:
   - name: both-disallowed
     object: samples/repo-must-be-openpolicyagent/disallowed_both.yaml
     assertions:
-    - violations: 2
+    - violations: 3
     - message: initContainer
       violations: 1
     - message: container
+      violations: 1
+    - message: ephemeralContainer
       violations: 1

--- a/library/general/allowedrepos/template.yaml
+++ b/library/general/allowedrepos/template.yaml
@@ -38,3 +38,10 @@ spec:
           not any(satisfied)
           msg := sprintf("initContainer <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
         }
+
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.ephemeralContainers[_]
+          satisfied := [good | repo = input.parameters.repos[_] ; good = startswith(container.image, repo)]
+          not any(satisfied)
+          msg := sprintf("ephemeralContainer <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
+        }

--- a/library/general/automount-serviceaccount-token/template.yaml
+++ b/library/general/automount-serviceaccount-token/template.yaml
@@ -45,6 +45,8 @@ spec:
             c := input.review.object.spec.initContainers[_]
         }
 
+        # Ephemeral containers not checked as it is not possible to set field.
+
         has_key(x, k) {
             _ = x[k]
         }

--- a/library/general/containerlimits/template.yaml
+++ b/library/general/containerlimits/template.yaml
@@ -172,6 +172,8 @@ spec:
           general_violation[{"msg": msg, "field": "initContainers"}]
         }
 
+        # Ephemeral containers not checked as it is not possible to set field.
+
         general_violation[{"msg": msg, "field": field}] {
           container := input.review.object.spec[field][_]
           not is_exempt(container)

--- a/library/general/containerrequests/template.yaml
+++ b/library/general/containerrequests/template.yaml
@@ -172,6 +172,8 @@ spec:
           general_violation[{"msg": msg, "field": "initContainers"}]
         }
 
+        # Ephemeral containers not checked as it is not possible to set field.
+
         general_violation[{"msg": msg, "field": field}] {
           container := input.review.object.spec[field][_]
           not is_exempt(container)

--- a/library/general/containerresourceratios/template.yaml
+++ b/library/general/containerresourceratios/template.yaml
@@ -182,6 +182,8 @@ spec:
           general_violation[{"msg": msg, "field": "initContainers"}]
         }
 
+        # Ephemeral containers not checked as it is not possible to set field.
+
         general_violation[{"msg": msg, "field": field}] {
           container := input.review.object.spec[field][_]
           not is_exempt(container)

--- a/library/general/disallowedtags/samples/container-image-must-not-have-latest-tag/example_disallowed_tag_ephemeral.yaml
+++ b/library/general/disallowedtags/samples/container-image-must-not-have-latest-tag/example_disallowed_tag_ephemeral.yaml
@@ -1,15 +1,8 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: opa-disallowed
+  name: opa-disallowed-ephemeral
 spec:
-  initContainers:
-    - name: opa
-      image: openpolicyagent/opa:0.9.2
-      args:
-        - "run"
-        - "--server"
-        - "--addr=localhost:8080"
   containers:
     - name: opa
       image: openpolicyagent/opa:0.9.2
@@ -19,7 +12,7 @@ spec:
         - "--addr=localhost:8080"
   ephemeralContainers:
     - name: opa
-      image: openpolicyagent/opa:0.9.2
+      image: openpolicyagent/opa:latest
       args:
         - "run"
         - "--server"

--- a/library/general/disallowedtags/suite.yaml
+++ b/library/general/disallowedtags/suite.yaml
@@ -23,6 +23,10 @@ tests:
     object: samples/container-image-must-not-have-latest-tag/example_disallowed_tag.yaml
     assertions:
     - violations: yes
+  - name: single-disallowed-tag-ephemeral
+    object: samples/container-image-must-not-have-latest-tag/example_disallowed_tag_ephemeral.yaml
+    assertions:
+    - violations: yes
   - name: some-disallow-tags
     object: samples/container-image-must-not-have-latest-tag/example_some_disallowed_tags.yaml
     assertions:

--- a/library/general/disallowedtags/template.yaml
+++ b/library/general/disallowedtags/template.yaml
@@ -61,6 +61,9 @@ spec:
         input_containers[c] {
             c := input.review.object.spec.initContainers[_]
         }
+        input_containers[c] {
+            c := input.review.object.spec.ephemeralContainers[_]
+        }
       libs:
         - |
           package lib.exempt_container

--- a/library/general/imagedigests/suite.yaml
+++ b/library/general/imagedigests/suite.yaml
@@ -14,4 +14,10 @@ tests:
   - name: example-disallowed
     object: samples/container-image-must-have-digest/example_disallowed.yaml
     assertions:
-    - violations: yes
+    - violations: 3
+    - message: initContainer
+      violations: 1
+    - message: container
+      violations: 1
+    - message: ephemeralContainer
+      violations: 1

--- a/library/general/imagedigests/template.yaml
+++ b/library/general/imagedigests/template.yaml
@@ -52,6 +52,14 @@ spec:
           not all(satisfied)
           msg := sprintf("initContainer <%v> uses an image without a digest <%v>", [container.name, container.image])
         }
+
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.ephemeralContainers[_]
+          not is_exempt(container)
+          satisfied := [re_match("@[a-z0-9]+([+._-][a-z0-9]+)*:[a-zA-Z0-9=_-]+", container.image)]
+          not all(satisfied)
+          msg := sprintf("ephemeralContainer <%v> uses an image without a digest <%v>", [container.name, container.image])
+        }
       libs:
         - |
           package lib.exempt_container

--- a/library/pod-security-policy/allow-privilege-escalation/samples/psp-allow-privilege-escalation-container/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/allow-privilege-escalation/samples/psp-allow-privilege-escalation-container/example_disallowed_ephemeral.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-privilege-escalation-disallowed
+  labels:
+    app: nginx-privilege-escalation
+spec:
+  ephemeralContainers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      allowPrivilegeEscalation: true

--- a/library/pod-security-policy/allow-privilege-escalation/suite.yaml
+++ b/library/pod-security-policy/allow-privilege-escalation/suite.yaml
@@ -15,3 +15,7 @@ tests:
         object: samples/psp-allow-privilege-escalation-container/example_disallowed.yaml
         assertions:
           - violations: yes
+      - name: example-disallowed-ephemeral
+        object: samples/psp-allow-privilege-escalation-container/example_disallowed_ephemeral.yaml
+        assertions:
+          - violations: yes

--- a/library/pod-security-policy/allow-privilege-escalation/template.yaml
+++ b/library/pod-security-policy/allow-privilege-escalation/template.yaml
@@ -58,6 +58,9 @@ spec:
         input_containers[c] {
             c := input.review.object.spec.initContainers[_]
         }
+        input_containers[c] {
+            c := input.review.object.spec.ephemeralContainers[_]
+        }
         # has_field returns whether an object has a field
         has_field(object, field) = true {
             object[field]

--- a/library/pod-security-policy/apparmor/samples/psp-apparmor/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/apparmor/samples/psp-apparmor/example_disallowed_ephemeral.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-apparmor-disallowed
+  annotations:
+    # apparmor.security.beta.kubernetes.io/pod: unconfined # runtime/default
+    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
+  labels:
+    app: nginx-apparmor
+spec:
+  ephemeralContainers:
+  - name: nginx
+    image: nginx

--- a/library/pod-security-policy/apparmor/suite.yaml
+++ b/library/pod-security-policy/apparmor/suite.yaml
@@ -15,3 +15,7 @@ tests:
         object: samples/psp-apparmor/example_disallowed.yaml
         assertions:
           - violations: yes
+      - name: example-disallowed-ephemeral
+        object: samples/psp-apparmor/example_disallowed_ephemeral.yaml
+        assertions:
+          - violations: yes

--- a/library/pod-security-policy/apparmor/template.yaml
+++ b/library/pod-security-policy/apparmor/template.yaml
@@ -63,6 +63,9 @@ spec:
         input_containers[c] {
             c := input.review.object.spec.initContainers[_]
         }
+        input_containers[c] {
+            c := input.review.object.spec.ephemeralContainers[_]
+        }
 
         get_annotation_for(container, metadata) = out {
             out = metadata.annotations[sprintf("container.apparmor.security.beta.kubernetes.io/%v", [container.name])]

--- a/library/pod-security-policy/capabilities/samples/capabilities-demo/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/capabilities/samples/capabilities-demo/example_disallowed_ephemeral.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: opa-disallowed
+  labels:
+    owner: me.agilebank.demo
+spec:
+  ephemeralContainers:
+    - name: opa
+      image: openpolicyagent/opa:0.9.2
+      args:
+        - "run"
+        - "--server"
+        - "--addr=localhost:8080"
+      securityContext:
+        capabilities:
+          add: ["disallowedcapability"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"

--- a/library/pod-security-policy/capabilities/suite.yaml
+++ b/library/pod-security-policy/capabilities/suite.yaml
@@ -15,3 +15,7 @@ tests:
         object: samples/capabilities-demo/example_allowed.yaml
         assertions:
           - violations: no
+      - name: example-disallowed-ephemeral
+        object: samples/capabilities-demo/example_disallowed_ephemeral.yaml
+        assertions:
+          - violations: yes

--- a/library/pod-security-policy/capabilities/template.yaml
+++ b/library/pod-security-policy/capabilities/template.yaml
@@ -81,6 +81,22 @@ spec:
         }
 
 
+
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.ephemeralContainers[_]
+          not is_exempt(container)
+          has_disallowed_capabilities(container)
+          msg := sprintf("ephemeral container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, get_default(input.parameters, "allowedCapabilities", "NONE")])
+        }
+
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.ephemeralContainers[_]
+          not is_exempt(container)
+          missing_drop_capabilities(container)
+          msg := sprintf("ephemeral container <%v> is not dropping all required capabilities. Container must drop all of %v or \"ALL\"", [container.name, input.parameters.requiredDropCapabilities])
+        }
+
+
         has_disallowed_capabilities(container) {
           allowed := {c | c := lower(input.parameters.allowedCapabilities[_])}
           not allowed["*"]

--- a/library/pod-security-policy/host-filesystem/samples/psp-host-filesystem/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/host-filesystem/samples/psp-host-filesystem/example_disallowed_ephemeral.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-host-filesystem
+  labels:
+    app: nginx-host-filesystem-disallowed
+spec:
+  ephemeralContainers:
+  - name: nginx
+    image: nginx
+    volumeMounts:
+    - mountPath: /cache
+      name: cache-volume
+      readOnly: true
+  volumes:
+  - name: cache-volume
+    hostPath:
+      path: /tmp # directory location on host

--- a/library/pod-security-policy/host-filesystem/suite.yaml
+++ b/library/pod-security-policy/host-filesystem/suite.yaml
@@ -15,3 +15,7 @@ tests:
         object: samples/psp-host-filesystem/example_allowed.yaml
         assertions:
           - violations: no
+      - name: example-disallowed-ephemeral
+        object: samples/psp-host-filesystem/example_disallowed_ephemeral.yaml
+        assertions:
+          - violations: yes

--- a/library/pod-security-policy/host-filesystem/template.yaml
+++ b/library/pod-security-policy/host-filesystem/template.yaml
@@ -128,3 +128,7 @@ spec:
         input_containers[c] {
             c := input.review.object.spec.initContainers[_]
         }
+
+        input_containers[c] {
+            c := input.review.object.spec.ephemeralContainers[_]
+        }

--- a/library/pod-security-policy/host-network-ports/samples/psp-host-network-ports/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/host-network-ports/samples/psp-host-network-ports/example_disallowed_ephemeral.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-host-networking-ports-disallowed
+  labels:
+    app: nginx-host-networking-ports
+spec:
+  hostNetwork: true
+  ephemeralContainers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 9001
+      hostPort: 9001

--- a/library/pod-security-policy/host-network-ports/suite.yaml
+++ b/library/pod-security-policy/host-network-ports/suite.yaml
@@ -15,3 +15,7 @@ tests:
     object: samples/psp-host-network-ports/example_allowed.yaml
     assertions:
     - violations: no
+  - name: example-disallowed-ephemeral
+    object: samples/psp-host-network-ports/example_disallowed_ephemeral.yaml
+    assertions:
+    - violations: yes

--- a/library/pod-security-policy/host-network-ports/template.yaml
+++ b/library/pod-security-policy/host-network-ports/template.yaml
@@ -78,6 +78,11 @@ spec:
             c := input.review.object.spec.initContainers[_]
             not is_exempt(c)
         }
+
+        input_containers[c] {
+            c := input.review.object.spec.ephemeralContainers[_]
+            not is_exempt(c)
+        }
       libs:
         - |
           package lib.exempt_container

--- a/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/example_disallowed_ephemeral.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-privileged-disallowed
+  labels:
+    app: nginx-privileged
+spec:
+  ephemeralContainers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      privileged: true

--- a/library/pod-security-policy/privileged-containers/suite.yaml
+++ b/library/pod-security-policy/privileged-containers/suite.yaml
@@ -15,3 +15,7 @@ tests:
     object: samples/psp-privileged-container/example_allowed.yaml
     assertions:
     - violations: no
+  - name: example-disallowed-ephemeral
+    object: samples/psp-privileged-container/example_disallowed_ephemeral.yaml
+    assertions:
+    - violations: yes

--- a/library/pod-security-policy/privileged-containers/template.yaml
+++ b/library/pod-security-policy/privileged-containers/template.yaml
@@ -53,6 +53,10 @@ spec:
         input_containers[c] {
             c := input.review.object.spec.initContainers[_]
         }
+
+        input_containers[c] {
+            c := input.review.object.spec.ephemeralContainers[_]
+        }
       libs:
         - |
           package lib.exempt_container

--- a/library/pod-security-policy/proc-mount/samples/psp-proc-mount/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/proc-mount/samples/psp-proc-mount/example_disallowed_ephemeral.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-proc-mount-disallowed
+  labels:
+    app: nginx-proc-mount
+spec:
+  ephemeralContainers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      procMount: Unmasked #Default

--- a/library/pod-security-policy/proc-mount/suite.yaml
+++ b/library/pod-security-policy/proc-mount/suite.yaml
@@ -15,3 +15,7 @@ tests:
     object: samples/psp-proc-mount/example_allowed.yaml
     assertions:
     - violations: no
+  - name: example-disallowed-ephemeral
+    object: samples/psp-proc-mount/example_disallowed_ephemeral.yaml
+    assertions:
+    - violations: yes

--- a/library/pod-security-policy/proc-mount/template.yaml
+++ b/library/pod-security-policy/proc-mount/template.yaml
@@ -74,6 +74,10 @@ spec:
             c := input.review.object.spec.initContainers[_]
             c.securityContext.procMount
         }
+        input_containers[c] {
+            c := input.review.object.spec.ephemeralContainers[_]
+            c.securityContext.procMount
+        }
 
         get_allowed_proc_mount(arg) = out {
             not arg.parameters

--- a/library/pod-security-policy/read-only-root-filesystem/samples/psp-readonlyrootfilesystem/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/samples/psp-readonlyrootfilesystem/example_disallowed_ephemeral.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-readonlyrootfilesystem-disallowed
+  labels:
+    app: nginx-readonlyrootfilesystem
+spec:
+  ephemeralContainers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      readOnlyRootFilesystem: false

--- a/library/pod-security-policy/read-only-root-filesystem/suite.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/suite.yaml
@@ -15,3 +15,7 @@ tests:
     object: samples/psp-readonlyrootfilesystem/example_allowed.yaml
     assertions:
     - violations: no
+  - name: example-disallowed-ephemeral
+    object: samples/psp-readonlyrootfilesystem/example_disallowed_ephemeral.yaml
+    assertions:
+    - violations: yes

--- a/library/pod-security-policy/read-only-root-filesystem/template.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/template.yaml
@@ -60,6 +60,9 @@ spec:
         input_containers[c] {
             c := input.review.object.spec.initContainers[_]
         }
+        input_containers[c] {
+            c := input.review.object.spec.ephemeralContainers[_]
+        }
 
         # has_field returns whether an object has a field
         has_field(object, field) = true {

--- a/library/pod-security-policy/seccomp/samples/psp-seccomp/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/seccomp/samples/psp-seccomp/example_disallowed_ephemeral.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-seccomp-disallowed
+  annotations:
+    container.seccomp.security.alpha.kubernetes.io/nginx: unconfined
+  labels:
+    app: nginx-seccomp
+spec:
+  ephemeralContainers:
+  - name: nginx
+    image: nginx

--- a/library/pod-security-policy/seccomp/suite.yaml
+++ b/library/pod-security-policy/seccomp/suite.yaml
@@ -25,3 +25,8 @@ tests:
     object: samples/psp-seccomp/example_allowed2.yaml
     assertions:
     - violations: no
+  - name: example-disallowed-container-ephemeral
+    object: samples/psp-seccomp/example_disallowed_ephemeral.yaml
+    assertions:
+    - violations: 1
+      message: "Seccomp profile 'unconfined' is not allowed for container 'nginx'. Found at: annotation container.seccomp.security.alpha.kubernetes.io/nginx"

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -252,6 +252,10 @@ spec:
         input_containers[container.name] = container {
             container := input.review.object.spec.initContainers[_]
         }
+
+        input_containers[container.name] = container {
+            container := input.review.object.spec.ephemeralContainers[_]
+        }
       libs:
         - |
           package lib.exempt_container

--- a/library/pod-security-policy/selinux/samples/psp-selinux-v2/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/selinux/samples/psp-selinux-v2/example_disallowed_ephemeral.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: nginx-selinux-disallowed
+    labels:
+        app: nginx-selinux
+spec:
+  ephemeralContainers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      seLinuxOptions:
+        level: s1:c234,c567
+        user: sysadm_u
+        role: sysadm_r
+        type: svirt_lxc_net_t

--- a/library/pod-security-policy/selinux/suite.yaml
+++ b/library/pod-security-policy/selinux/suite.yaml
@@ -15,3 +15,7 @@ tests:
     object: samples/psp-selinux-v2/example_allowed.yaml
     assertions:
     - violations: no
+  - name: example-disallowed-ephemeral
+    object: samples/psp-selinux-v2/example_disallowed_ephemeral.yaml
+    assertions:
+    - violations: yes

--- a/library/pod-security-policy/selinux/template.yaml
+++ b/library/pod-security-policy/selinux/template.yaml
@@ -97,6 +97,10 @@ spec:
             c := input.review.object.spec.initContainers[_]
             has_field(c.securityContext, "seLinuxOptions")
         }
+        input_security_context[c] {
+            c := input.review.object.spec.ephemeralContainers[_]
+            has_field(c.securityContext, "seLinuxOptions")
+        }
 
         # has_field returns whether an object has a field
         has_field(object, field) = true {

--- a/library/pod-security-policy/users/samples/psp-pods-allowed-user-ranges/example_disallowed_ephemeral.yaml
+++ b/library/pod-security-policy/users/samples/psp-pods-allowed-user-ranges/example_disallowed_ephemeral.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-users-disallowed
+  labels:
+    app: nginx-users
+spec:
+  securityContext:
+    supplementalGroups:
+      - 250
+    fsGroup: 250
+  ephemeralContainers:
+    - name: nginx
+      image: nginx
+      securityContext:
+        runAsUser: 250
+        runAsGroup: 250

--- a/library/pod-security-policy/users/suite.yaml
+++ b/library/pod-security-policy/users/suite.yaml
@@ -15,3 +15,7 @@ tests:
     object: samples/psp-pods-allowed-user-ranges/example_allowed.yaml
     assertions:
     - violations: no
+  - name: example-disallowed-ephemeral
+    object: samples/psp-pods-allowed-user-ranges/example_disallowed_ephemeral.yaml
+    assertions:
+    - violations: yes

--- a/library/pod-security-policy/users/template.yaml
+++ b/library/pod-security-policy/users/template.yaml
@@ -254,6 +254,9 @@ spec:
         input_containers[c] {
           c := input.review.object.spec.initContainers[_]
         }
+        input_containers[c] {
+            c := input.review.object.spec.ephemeralContainers[_]
+        }
       libs:
         - |
           package lib.exempt_container

--- a/mutation/pod-security-policy/allow-privilege-escalation/samples/mutation.yaml
+++ b/mutation/pod-security-policy/allow-privilege-escalation/samples/mutation.yaml
@@ -35,7 +35,7 @@ spec:
 apiVersion: mutations.gatekeeper.sh/v1alpha1
 kind: Assign
 metadata:
-  name: k8spspdefaultallowprivilegeescalation-init
+  name: k8spspdefaultallowprivilegeescalation-ephemeral
 spec:
   applyTo:
   - groups: [""]

--- a/mutation/pod-security-policy/allow-privilege-escalation/samples/mutation.yaml
+++ b/mutation/pod-security-policy/allow-privilege-escalation/samples/mutation.yaml
@@ -31,3 +31,20 @@ spec:
       condition: MustNotExist
     assign:
       value: false
+---
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: Assign
+metadata:
+  name: k8spspdefaultallowprivilegeescalation-init
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.ephemeralContainers[name:*].securityContext.allowPrivilegeEscalation"
+  parameters:
+    pathTests:
+    - subPath: "spec.ephemeralContainers[name:*].securityContext.allowPrivilegeEscalation"
+      condition: MustNotExist
+    assign:
+      value: false

--- a/src/general/allowedrepos/src.rego
+++ b/src/general/allowedrepos/src.rego
@@ -13,3 +13,10 @@ violation[{"msg": msg}] {
   not any(satisfied)
   msg := sprintf("initContainer <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
 }
+
+violation[{"msg": msg}] {
+  container := input.review.object.spec.ephemeralContainers[_]
+  satisfied := [good | repo = input.parameters.repos[_] ; good = startswith(container.image, repo)]
+  not any(satisfied)
+  msg := sprintf("ephemeralContainer <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
+}

--- a/src/general/automount-serviceaccount-token/src.rego
+++ b/src/general/automount-serviceaccount-token/src.rego
@@ -25,6 +25,8 @@ input_containers[c] {
     c := input.review.object.spec.initContainers[_]
 }
 
+# Ephemeral containers not checked as it is not possible to set field.
+
 has_key(x, k) {
     _ = x[k]
 }

--- a/src/general/containerlimits/src.rego
+++ b/src/general/containerlimits/src.rego
@@ -133,6 +133,8 @@ violation[{"msg": msg}] {
   general_violation[{"msg": msg, "field": "initContainers"}]
 }
 
+# Ephemeral containers not checked as it is not possible to set field.
+
 general_violation[{"msg": msg, "field": field}] {
   container := input.review.object.spec[field][_]
   not is_exempt(container)

--- a/src/general/containerrequests/src.rego
+++ b/src/general/containerrequests/src.rego
@@ -133,6 +133,8 @@ violation[{"msg": msg}] {
   general_violation[{"msg": msg, "field": "initContainers"}]
 }
 
+# Ephemeral containers not checked as it is not possible to set field.
+
 general_violation[{"msg": msg, "field": field}] {
   container := input.review.object.spec[field][_]
   not is_exempt(container)

--- a/src/general/containerresourceratios/src.rego
+++ b/src/general/containerresourceratios/src.rego
@@ -140,6 +140,8 @@ violation[{"msg": msg}] {
   general_violation[{"msg": msg, "field": "initContainers"}]
 }
 
+# Ephemeral containers not checked as it is not possible to set field.
+
 general_violation[{"msg": msg, "field": field}] {
   container := input.review.object.spec[field][_]
   not is_exempt(container)

--- a/src/general/disallowedtags/src.rego
+++ b/src/general/disallowedtags/src.rego
@@ -24,3 +24,6 @@ input_containers[c] {
 input_containers[c] {
     c := input.review.object.spec.initContainers[_]
 }
+input_containers[c] {
+    c := input.review.object.spec.ephemeralContainers[_]
+}

--- a/src/general/imagedigests/src.rego
+++ b/src/general/imagedigests/src.rego
@@ -17,3 +17,11 @@ violation[{"msg": msg}] {
   not all(satisfied)
   msg := sprintf("initContainer <%v> uses an image without a digest <%v>", [container.name, container.image])
 }
+
+violation[{"msg": msg}] {
+  container := input.review.object.spec.ephemeralContainers[_]
+  not is_exempt(container)
+  satisfied := [re_match("@[a-z0-9]+([+._-][a-z0-9]+)*:[a-zA-Z0-9=_-]+", container.image)]
+  not all(satisfied)
+  msg := sprintf("ephemeralContainer <%v> uses an image without a digest <%v>", [container.name, container.image])
+}

--- a/src/pod-security-policy/allow-privilege-escalation/src.rego
+++ b/src/pod-security-policy/allow-privilege-escalation/src.rego
@@ -21,6 +21,9 @@ input_containers[c] {
 input_containers[c] {
     c := input.review.object.spec.initContainers[_]
 }
+input_containers[c] {
+    c := input.review.object.spec.ephemeralContainers[_]
+}
 # has_field returns whether an object has a field
 has_field(object, field) = true {
     object[field]

--- a/src/pod-security-policy/apparmor/src.rego
+++ b/src/pod-security-policy/apparmor/src.rego
@@ -20,6 +20,9 @@ input_containers[c] {
 input_containers[c] {
     c := input.review.object.spec.initContainers[_]
 }
+input_containers[c] {
+    c := input.review.object.spec.ephemeralContainers[_]
+}
 
 get_annotation_for(container, metadata) = out {
     out = metadata.annotations[sprintf("container.apparmor.security.beta.kubernetes.io/%v", [container.name])]

--- a/src/pod-security-policy/capabilities/src.rego
+++ b/src/pod-security-policy/capabilities/src.rego
@@ -33,6 +33,22 @@ violation[{"msg": msg}] {
 }
 
 
+
+violation[{"msg": msg}] {
+  container := input.review.object.spec.ephemeralContainers[_]
+  not is_exempt(container)
+  has_disallowed_capabilities(container)
+  msg := sprintf("ephemeral container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, get_default(input.parameters, "allowedCapabilities", "NONE")])
+}
+
+violation[{"msg": msg}] {
+  container := input.review.object.spec.ephemeralContainers[_]
+  not is_exempt(container)
+  missing_drop_capabilities(container)
+  msg := sprintf("ephemeral container <%v> is not dropping all required capabilities. Container must drop all of %v or \"ALL\"", [container.name, input.parameters.requiredDropCapabilities])
+}
+
+
 has_disallowed_capabilities(container) {
   allowed := {c | c := lower(input.parameters.allowedCapabilities[_])}
   not allowed["*"]

--- a/src/pod-security-policy/host-filesystem/src.rego
+++ b/src/pod-security-policy/host-filesystem/src.rego
@@ -88,3 +88,7 @@ input_containers[c] {
 input_containers[c] {
     c := input.review.object.spec.initContainers[_]
 }
+
+input_containers[c] {
+    c := input.review.object.spec.ephemeralContainers[_]
+}

--- a/src/pod-security-policy/host-network-ports/src.rego
+++ b/src/pod-security-policy/host-network-ports/src.rego
@@ -31,3 +31,8 @@ input_containers[c] {
     c := input.review.object.spec.initContainers[_]
     not is_exempt(c)
 }
+
+input_containers[c] {
+    c := input.review.object.spec.ephemeralContainers[_]
+    not is_exempt(c)
+}

--- a/src/pod-security-policy/privileged-containers/src.rego
+++ b/src/pod-security-policy/privileged-containers/src.rego
@@ -16,3 +16,7 @@ input_containers[c] {
 input_containers[c] {
     c := input.review.object.spec.initContainers[_]
 }
+
+input_containers[c] {
+    c := input.review.object.spec.ephemeralContainers[_]
+}

--- a/src/pod-security-policy/proc-mount/src.rego
+++ b/src/pod-security-policy/proc-mount/src.rego
@@ -26,6 +26,10 @@ input_containers[c] {
     c := input.review.object.spec.initContainers[_]
     c.securityContext.procMount
 }
+input_containers[c] {
+    c := input.review.object.spec.ephemeralContainers[_]
+    c.securityContext.procMount
+}
 
 get_allowed_proc_mount(arg) = out {
     not arg.parameters

--- a/src/pod-security-policy/read-only-root-filesystem/src.rego
+++ b/src/pod-security-policy/read-only-root-filesystem/src.rego
@@ -22,6 +22,9 @@ input_containers[c] {
 input_containers[c] {
     c := input.review.object.spec.initContainers[_]
 }
+input_containers[c] {
+    c := input.review.object.spec.ephemeralContainers[_]
+}
 
 # has_field returns whether an object has a field
 has_field(object, field) = true {

--- a/src/pod-security-policy/seccomp/src.rego
+++ b/src/pod-security-policy/seccomp/src.rego
@@ -184,3 +184,7 @@ input_containers[container.name] = container {
 input_containers[container.name] = container {
     container := input.review.object.spec.initContainers[_]
 }
+
+input_containers[container.name] = container {
+    container := input.review.object.spec.ephemeralContainers[_]
+}

--- a/src/pod-security-policy/selinux/src.rego
+++ b/src/pod-security-policy/selinux/src.rego
@@ -40,6 +40,10 @@ input_security_context[c] {
     c := input.review.object.spec.initContainers[_]
     has_field(c.securityContext, "seLinuxOptions")
 }
+input_security_context[c] {
+    c := input.review.object.spec.ephemeralContainers[_]
+    has_field(c.securityContext, "seLinuxOptions")
+}
 
 # has_field returns whether an object has a field
 has_field(object, field) = true {

--- a/src/pod-security-policy/users/src.rego
+++ b/src/pod-security-policy/users/src.rego
@@ -121,3 +121,6 @@ input_containers[c] {
 input_containers[c] {
   c := input.review.object.spec.initContainers[_]
 }
+input_containers[c] {
+    c := input.review.object.spec.ephemeralContainers[_]
+}


### PR DESCRIPTION
This change adds ephemeral containers to all policies that currently check the containers and init containers field. It is kind of a quick solution just to bring all the policies to a level where ephemeral containers do not introduce security concerns. 

I have on purpose skipped the required probes policy as it currently only looks at the containers field. I have also only updated one of the mutation samples.

One thing that comes to mind when looking at the different policies is that there are a bunch of different ways to solve this problem. A couple of rules have a method which returns the container data from each field, and others duplicate code at different levels. I feel like it would be good to find a standard. Right now it would be easy to make mistakes and not include one of the containers field. At the same time I can see a situation where one would want to require read only root file systems for the init containers and containers fields, but not the ephemeral containers fields. Might be better to solve these challenges in the future.

Fixes #188 