### PR TITLE
Add all policies to kustomization.yaml and add test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KIND_VERSION ?= 0.11.1
 # note: k8s version pinned since KIND image availability lags k8s releases
 KUBERNETES_VERSION ?= 1.21.2
-KUSTOMIZE_VERSION ?= 3.7.0
+KUSTOMIZE_VERSION ?= 4.5.4
 GATEKEEPER_VERSION ?= release-3.5
 BATS_VERSION ?= 1.3.0
 GATOR_VERSION ?= 3.7.1

--- a/library/general/kustomization.yaml
+++ b/library/general/kustomization.yaml
@@ -1,22 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - allowedrepos
-  - automount-serviceaccount-token
-  - block-endpoint-edit-default-role
-  - block-nodeport-services
-  - block-wildcard-ingress
-  - containerlimits
-  - containerrequests
-  - containerresourceratios
-  - disallowanonymous
-  - disallowedtags
-  - externalip
-  - httpsonly
-  - imagedigests
-  - noupdateserviceaccount
-  - poddisruptionbudget
-  - replicalimits
-  - requiredannotations
-  - requiredlabels
-  - requiredprobes
-  - uniqueingresshost
-  - uniqueserviceselector
+- allowedrepos
+- automount-serviceaccount-token
+- block-endpoint-edit-default-role
+- block-nodeport-services
+- block-wildcard-ingress
+- containerlimits
+- containerrequests
+- containerresourceratios
+- disallowanonymous
+- disallowedtags
+- externalip
+- httpsonly
+- imagedigests
+- noupdateserviceaccount
+- poddisruptionbudget
+- replicalimits
+- requiredannotations
+- requiredlabels
+- requiredprobes
+- uniqueingresshost
+- uniqueserviceselector
+- containerresources

--- a/library/kustomization.yaml
+++ b/library/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - general
-  - pod-security-policy
+- general
+- pod-security-policy

--- a/library/pod-security-policy/kustomization.yaml
+++ b/library/pod-security-policy/kustomization.yaml
@@ -1,17 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - allow-privilege-escalation
-  - apparmor
-  - capabilities
-  - flexvolume-drivers
-  - forbidden-sysctls
-  - fsgroup
-  - host-filesystem
-  - host-namespaces
-  - host-network-ports
-  - privileged-containers
-  - proc-mount
-  - read-only-root-filesystem
-  - seccomp
-  - selinux
-  - users
-  - volumes
+- allow-privilege-escalation
+- apparmor
+- capabilities
+- flexvolume-drivers
+- forbidden-sysctls
+- fsgroup
+- host-filesystem
+- host-namespaces
+- host-network-ports
+- privileged-containers
+- proc-mount
+- read-only-root-filesystem
+- seccomp
+- selinux
+- users
+- volumes

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -17,6 +17,20 @@ setup() {
   kubectl config set-context --current --namespace default
 }
 
+@test "all policies are listed in kustomization.yaml" {
+  pushd library/general/
+  kustomize edit add resource $(find ./ -type d -maxdepth 1 -mindepth 1 -exec basename {} \;)
+  run git diff --quiet kustomization.yaml
+  assert_success
+  popd
+
+  pushd library/pod-security-policy/
+  kustomize edit add resource $(find ./ -type d -maxdepth 1 -mindepth 1 -exec basename {} \;)
+  run git diff --quiet kustomization.yaml
+  assert_success
+  popd
+}
+
 @test "gatekeeper-controller-manager is running" {
   wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl -n gatekeeper-system wait --for=condition=Ready --timeout=60s pod -l control-plane=controller-manager"
 }


### PR DESCRIPTION
I noticed some of the policies were missing from kustomization.yaml. I added those missing policies and a test that will ensure the CI pipeline fails if someone forgets to update kustomization.yaml after adding/removing policies.

In order to detect missing entries in the kustomization.yaml, I had to convert our files into the format that kustomize spits out (meaning it adds the apiVersion/kind and removed the leading space in lists)