### PR TITLE
Added policy to block LoadBalancer services

### DIFF
--- a/library/general/block-loadbalancer-services/kustomization.yaml
+++ b/library/general/block-loadbalancer-services/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/block-loadbalancer-services/samples/block-load-balancer/constraint.yaml
+++ b/library/general/block-loadbalancer-services/samples/block-load-balancer/constraint.yaml
@@ -1,0 +1,12 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sBlockLoadBalancer
+metadata:
+  name: block-load-balancer
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Service"]
+    excludedNamespaces:
+      - "ingress-nginx-private"
+      - "ingress-nginx-public"

--- a/library/general/block-loadbalancer-services/samples/block-load-balancer/example_allowed.yaml
+++ b/library/general/block-loadbalancer-services/samples/block-load-balancer/example_allowed.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-allowed
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80

--- a/library/general/block-loadbalancer-services/samples/block-load-balancer/example_disallowed.yaml
+++ b/library/general/block-loadbalancer-services/samples/block-load-balancer/example_disallowed.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-disallowed
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: 80
+      nodePort: 30007

--- a/library/general/block-loadbalancer-services/suite.yaml
+++ b/library/general/block-loadbalancer-services/suite.yaml
@@ -1,0 +1,17 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: block-loadbalancer-services
+tests:
+- name: block-loadbalancer-services
+  template: template.yaml
+  constraint: samples/block-load-balancer/constraint.yaml
+  cases:
+  - name: example-allowed
+    object: samples/block-load-balancer/example_allowed.yaml
+    assertions:
+    - violations: no    
+  - name: example-disallowed
+    object: samples/block-load-balancer/example_disallowed.yaml
+    assertions:
+    - violations: yes

--- a/library/general/block-loadbalancer-services/template.yaml
+++ b/library/general/block-loadbalancer-services/template.yaml
@@ -1,0 +1,24 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblockloadbalancer
+  annotations:
+    description: >-
+      Disallows all Services with type LoadBalancer.
+
+      https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockLoadBalancer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sblockloadbalancer
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Service"
+          input.review.object.spec.type == "LoadBalancer"
+          msg := "User is not allowed to create service of type LoadBalancer"
+        }

--- a/library/general/kustomization.yaml
+++ b/library/general/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - allowedrepos
 - automount-serviceaccount-token
 - block-endpoint-edit-default-role
+- block-loadbalancer-services
 - block-nodeport-services
 - block-wildcard-ingress
 - containerlimits

--- a/src/general/block-loadbalancer-services/constraint.tmpl
+++ b/src/general/block-loadbalancer-services/constraint.tmpl
@@ -1,0 +1,18 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblockloadbalancer
+  annotations:
+    description: >-
+      Disallows all Services with type LoadBalancer.
+
+      https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockLoadBalancer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/block-loadbalancer-services/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/general/block-loadbalancer-services/src.rego
+++ b/src/general/block-loadbalancer-services/src.rego
@@ -1,0 +1,7 @@
+package k8sblockloadbalancer
+
+violation[{"msg": msg}] {
+  input.review.kind.kind == "Service"
+  input.review.object.spec.type == "LoadBalancer"
+  msg := "User is not allowed to create service of type LoadBalancer"
+}

--- a/src/general/block-loadbalancer-services/src_test.rego
+++ b/src/general/block-loadbalancer-services/src_test.rego
@@ -1,0 +1,40 @@
+package k8sblockloadbalancer
+
+test_block_load_balancer {
+  input := {
+    "review": {
+      "kind": {"kind": "Service"},
+      "object": {
+        "spec": {
+          "type": "LoadBalancer"
+        },
+        "ports": {
+                "protocol": "TCP",
+                "port": 80,
+                "targetPort": 80
+            }
+        }
+      }
+  }
+  result := violation with input as input
+  count(result) == 1
+}
+test_allow_other_service_types {
+  input := {
+    "review": {
+      "kind": {"kind": "Service"},
+      "object": {
+        "spec": {
+          "type": "NodePort"
+        },
+        "ports": {
+                "port": 80,
+                "targetPort": 9376,
+                "nodePort": 30007
+            }
+        }
+      }
+  }
+  result := violation with input as input
+  count(result) == 0
+}


### PR DESCRIPTION
In some environments we'd like the cluster customers to use the pre-provisioned Ingress Controllers to expose their workloads to the outside world.  This policy allows the cluster administrator to block the creation of LoadBalancer services, which can lead to provisioning costly cloud resources (LBs).  This policy along with the one for NodePorts, on which this one is based, also prevent customers from exposing their workload in an unexpected and potentially unmonitored way, which can present a security issue.