### PR TITLE
Modify pdb error message for clearer instructions if replica is set to 1

### DIFF
--- a/library/general/poddisruptionbudget/template.yaml
+++ b/library/general/poddisruptionbudget/template.yaml
@@ -50,7 +50,7 @@ spec:
 
           not valid_pdb_min_available(obj, pdb)
           msg := sprintf(
-            "%v <%v> has %v replica(s) but PodDisruptionBudget <%v> has minAvailable of %v, only positive integers less than %v are allowed for minAvailable",
+            "%v <%v> has %v replica(s) but PodDisruptionBudget <%v> has minAvailable of %v, PodDisruptionBudget count should always be lower than replica(s), and not used when replica(s) is set to 1",
             [obj.kind, obj.metadata.name, obj.spec.replicas, pdb.metadata.name, pdb.spec.minAvailable, obj.spec.replicas],
           )
         }


### PR DESCRIPTION
We have had instances where engineers set the replica count to 1 and a pdb set to something else, usually 2 or above. The current error messaging is confusing when this happens as it calls for them to have a pdb minAvailable set to a "positive integer less than 1". 

This messaging is confusing in this case and we would like to make it clear that they should not have a PDB if replicas are set to 1. 

    Resource: "apps/v1, Resource=deployments", GroupVersionKind: "apps/v1, Kind=Deployment"
    99Name: "<redacted>", Namespace: "<redacted>"
    100for: "overlays/stage": admission webhook "validation.gatekeeper.sh" denied the request: [pod-distruption-budget]  
    Deployment <redacted> has 1 replica(s) but PodDisruptionBudget <redacted> has minAvailable of 2, 
    only positive integers less than 1 are allowed for minAvailable