### PR TITLE
Add checks for storage class usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
+docker := docker #You can build with podman by doing: make docker=podman
 KIND_VERSION ?= 0.14.0
 # note: k8s version pinned since KIND image availability lags k8s releases
 KUBERNETES_VERSION ?= 1.24.0
 KUSTOMIZE_VERSION ?= 4.5.5
 GATEKEEPER_VERSION ?= release-3.8
 BATS_VERSION ?= 1.3.0
-GATOR_VERSION ?= 3.8.1
+GATOR_VERSION ?= 3.9.0
 GOMPLATE_VERSION ?= 3.10.0
 
 integration-bootstrap:
@@ -38,19 +39,19 @@ verify-gator:
 
 .PHONY: verify-gator-dockerized
 verify-gator-dockerized: __build-gator
-	docker run -i -v $(shell pwd):/gatekeeper-library gator-container verify ./...
+	$(docker) run -i -v $(shell pwd):/gatekeeper-library gator-container verify ./...
 
 .PHONY: build-gator
 __build-gator:
-	docker build --build-arg GATOR_VERSION=$(GATOR_VERSION) -f build/gator/Dockerfile -t gator-container .
+	$(docker) build --build-arg GATOR_VERSION=$(GATOR_VERSION) -f build/gator/Dockerfile -t gator-container .
 
 .PHONY: generate
 generate: __build-gomplate
-	docker run -v $(shell pwd):/gatekeeper-library gomplate-container ./scripts/generate.sh
+	$(docker) run -v $(shell pwd):/gatekeeper-library gomplate-container ./scripts/generate.sh
 
 .PHONY: __build-gomplate
 __build-gomplate:
-	docker build --build-arg GOMPLATE_VERSION=$(GOMPLATE_VERSION) -f build/gomplate/Dockerfile -t gomplate-container .
+	$(docker) build --build-arg GOMPLATE_VERSION=$(GOMPLATE_VERSION) -f build/gomplate/Dockerfile -t gomplate-container .
 
 .PHONY: require-suites
 require-suites:

--- a/library/general/kustomization.yaml
+++ b/library/general/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
 - uniqueingresshost
 - uniqueserviceselector
 - containerresources
+- storageclass

--- a/library/general/storageclass/README.md
+++ b/library/general/storageclass/README.md
@@ -11,6 +11,6 @@ pending, and requires deleting the StatefulSet and any PVCs it has created along
 with redeploying the workload in order to fix. Blocking it up front makes it
 much easier to fix before there is a mess to clean up.
 
-There is a known limitation with this constraint. It only functions properly
+**WARNING** This constraint only functions properly
 on gatekeeper version 3.9 or above.
 

--- a/library/general/storageclass/README.md
+++ b/library/general/storageclass/README.md
@@ -7,7 +7,7 @@ storage class at all is specified.
 This policy helps prevent workloads from getting stuck indefinitely waiting
 for a storage class to provision the persistent storage that will never 
 happen. This often causes users to get confused as to why their pods are stuck
-pending, and requires deleting the StatefulSet and any PVCs its created along
+pending, and requires deleting the StatefulSet and any PVCs it has created along
 with redeploying the workload in order to fix. Blocking it up front makes it
 much easier to fix before there is a mess to clean up.
 

--- a/library/general/storageclass/README.md
+++ b/library/general/storageclass/README.md
@@ -1,0 +1,16 @@
+# StorageClass
+
+The `StorageClass` constraint blocks the creation of PVCs or StatefulSets 
+where the specified storage class doesn't exist on the cluster, or that no
+storage class at all is specified.
+
+This policy helps prevent workloads from getting stuck indefinitely waiting
+for a storage class to provision the persistent storage that will never 
+happen. This often causes users to get confused as to why their pods are stuck
+pending, and requires deleting the StatefulSet and any PVCs its created along
+with redeploying the workload in order to fix. Blocking it up front makes it
+much easier to fix before there is a mess to clean up.
+
+There is a known limitation with this constraint. It only functions properly
+on gatekeeper version 3.9 or above.
+

--- a/library/general/storageclass/kustomization.yaml
+++ b/library/general/storageclass/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/storageclass/samples/storageclass/constraint.yaml
+++ b/library/general/storageclass/samples/storageclass/constraint.yaml
@@ -1,0 +1,13 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sStorageClass
+metadata:
+  name: storageclass
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["PersistentVolumeClaim"]
+      - apiGroups: ["apps"]
+        kinds: ["StatefulSet"]
+  parameters:
+    includeStorageClassesInMessage: true

--- a/library/general/storageclass/samples/storageclass/example_allowed_pvc.yaml
+++ b/library/general/storageclass/samples/storageclass/example_allowed_pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ok
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 8Gi
+  storageClassName: somestorageclass

--- a/library/general/storageclass/samples/storageclass/example_allowed_ss.yaml
+++ b/library/general/storageclass/samples/storageclass/example_allowed_ss.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: volumeclaimstorageclass
+spec:
+  selector:
+    matchLabels:
+      app: volumeclaimstorageclass
+  serviceName: volumeclaimstorageclass
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: volumeclaimstorageclass
+    spec:
+      containers:
+      - name: main
+        image: k8s.gcr.io/nginx-slim:0.8
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      storageClassName: "somestorageclass"
+      resources:
+        requests:
+          storage: 1Gi

--- a/library/general/storageclass/samples/storageclass/example_disallowed_pvc_badname.yaml
+++ b/library/general/storageclass/samples/storageclass/example_disallowed_pvc_badname.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: badstorageclass
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 8Gi
+  storageClassName: badstorageclass

--- a/library/general/storageclass/samples/storageclass/example_disallowed_pvc_nonamename.yaml
+++ b/library/general/storageclass/samples/storageclass/example_disallowed_pvc_nonamename.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nostorageclass
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 8Gi

--- a/library/general/storageclass/samples/storageclass/example_disallowed_ssvct_badnamename.yaml
+++ b/library/general/storageclass/samples/storageclass/example_disallowed_ssvct_badnamename.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: badvolumeclaimstorageclass
+spec:
+  selector:
+    matchLabels:
+      app: badvolumeclaimstorageclass
+  serviceName: badvolumeclaimstorageclass
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: badvolumeclaimstorageclass
+    spec:
+      containers:
+      - name: main
+        image: k8s.gcr.io/nginx-slim:0.8
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      storageClassName: "badstorageclass"
+      resources:
+        requests:
+          storage: 1Gi

--- a/library/general/storageclass/samples/storageclass/example_disallowed_ssvct_nonamename.yaml
+++ b/library/general/storageclass/samples/storageclass/example_disallowed_ssvct_nonamename.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: novolumeclaimstorageclass
+spec:
+  selector:
+    matchLabels:
+      app: novolumeclaimstorageclass
+  serviceName: novolumeclaimstorageclass
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: novolumeclaimstorageclass
+    spec:
+      containers:
+      - name: main
+        image: k8s.gcr.io/nginx-slim:0.8
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi

--- a/library/general/storageclass/samples/storageclass/example_inventory_allowed_storageclass.yaml
+++ b/library/general/storageclass/samples/storageclass/example_inventory_allowed_storageclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: somestorageclass
+provisioner: foo
+parameters:
+allowVolumeExpansion: true

--- a/library/general/storageclass/suite.yaml
+++ b/library/general/storageclass/suite.yaml
@@ -1,0 +1,38 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: storageclass
+tests:
+- name: storageclass
+  template: template.yaml
+  constraint: samples/storageclass/constraint.yaml
+  cases:
+  - name: example-allowed-pvc
+    object: samples/storageclass/example_allowed_pvc.yaml
+    inventory:
+    - samples/storageclass/example_inventory_allowed_storageclass.yaml
+    assertions:
+    - violations: no
+  - name: example-allowed-ss
+    object: samples/storageclass/example_allowed_ss.yaml
+    inventory:
+    - samples/storageclass/example_inventory_allowed_storageclass.yaml
+    assertions:
+    - violations: no
+  - name: example-disallowed-pvc-badname
+    object: samples/storageclass/example_disallowed_pvc_badname.yaml
+    assertions:
+    - violations: yes
+  - name: example-disallowed-ssvct-badnamename
+    object: samples/storageclass/example_disallowed_ssvct_badnamename.yaml
+    assertions:
+    - violations: yes
+  - name: example-disallowed-pvc-nonamename
+    object: samples/storageclass/example_disallowed_pvc_nonamename.yaml
+    assertions:
+    - violations: yes
+  - name: example-disallowed-ssvct-nonamename
+    object: samples/storageclass/example_disallowed_ssvct_nonamename.yaml
+    assertions:
+    - violations: yes
+

--- a/library/general/storageclass/sync.yaml
+++ b/library/general/storageclass/sync.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.gatekeeper.sh/v1alpha1
+kind: Config
+metadata:
+  name: config
+  namespace: "gatekeeper-system"
+spec:
+  sync:
+    syncOnly:
+      - group: "storage.k8s.io"
+        version: "v1"
+        kind: "StorageClass"

--- a/library/general/storageclass/template.yaml
+++ b/library/general/storageclass/template.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k8sstorageclass
   annotations:
     description: >-
-      Requires storage classes to be specified when used.
+      Requires storage classes to be specified when used. Currently only gatekeeper 3.9+ is ssupoprted.
 spec:
   crd:
     spec:

--- a/library/general/storageclass/template.yaml
+++ b/library/general/storageclass/template.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k8sstorageclass
   annotations:
     description: >-
-      Requires storage classes to be specified when used. Currently only gatekeeper 3.9+ is ssupoprted.
+      Requires storage classes to be specified when used. Only gatekeeper 3.9+ is supported.
 spec:
   crd:
     spec:

--- a/library/general/storageclass/template.yaml
+++ b/library/general/storageclass/template.yaml
@@ -1,0 +1,112 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sstorageclass
+  annotations:
+    description: >-
+      Requires storage classes to be specified when used.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sStorageClass
+      validation:
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Requires storage classes to be specified when used.
+          properties:
+            includeStorageClassesInMessage:
+              type: boolean
+              default: true
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sstorageclass
+
+        is_pvc(obj) {
+          obj.apiVersion == "v1"
+          obj.kind == "PersistentVolumeClaim"
+        }
+
+        is_statefulset(obj) {
+          obj.apiVersion == "apps/v1"
+          obj.kind == "StatefulSet"
+        }
+
+        violation[{"msg": msg}] {
+          count(data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"]) == 0
+          msg := sprintf("StorageClasses not synced. Gatekeeper may be misconfigured. Please have a cluster-admin consult the documentation.", [])
+        }
+
+        storageclass_found(name) {
+          data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"][name]
+        }
+
+        violation[{"msg": pvc_storageclass_badname_msg}] {
+          input.parameters.includeStorageClassesInMessage == true
+          is_pvc(input.review.object)
+          not storageclass_found(input.review.object.spec.storageClassName)
+        }
+        pvc_storageclass_badname_msg := sprintf("pvc did not specify a valid storage class name <%v>. Must be one of [%v]", args) {
+          input.parameters.includeStorageClassesInMessage
+          args := [
+            input.review.object.spec.storageClassName,
+            concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"][n]])
+          ]
+        } else := sprintf(
+          "pvc did not specify a valid storage class name <%v>.",
+          [input.review.object.spec.storageClassName]
+        )
+
+        violation[{"msg": pvc_storageclass_noname_msg}] {
+          is_pvc(input.review.object)
+          not input.review.object.spec.storageClassName
+        }
+        pvc_storageclass_noname_msg := sprintf("pvc did not specify a storage class name. Must be one of [%v]", args) {
+          input.parameters.includeStorageClassesInMessage
+          args := [
+            concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"][n]])
+          ]
+        } else := sprintf(
+          "pvc did not specify a storage class name.",
+          []
+        )
+
+        violation[{"msg": statefulset_vct_badname_msg(vct)}] {
+          is_statefulset(input.review.object)
+          vct := input.review.object.spec.volumeClaimTemplates[_]
+          not storageclass_found(vct.spec.storageClassName)
+        }
+        statefulset_vct_badname_msg(vct) := msg {
+          input.parameters.includeStorageClassesInMessage
+          msg := sprintf(
+              "statefulset did not specify a valid storage class name <%v>. Must be one of [%v]", [
+              vct.spec.storageClassName,
+              concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"][n]])
+          ])
+        }
+        statefulset_vct_badname_msg(vct) := msg {
+          not input.parameters.includeStorageClassesInMessage
+          msg := sprintf(
+            "statefulset did not specify a valid storage class name <%v>.", [
+              vct.spec.storageClassName
+          ])
+        }
+
+        violation[{"msg": statefulset_vct_noname_msg}] {
+          is_statefulset(input.review.object)
+          vct := input.review.object.spec.volumeClaimTemplates[_]
+          not vct.spec.storageClassName
+        }
+        statefulset_vct_noname_msg := sprintf("statefulset did not specify a storage class name. Must be one of [%v]", args) {
+          input.parameters.includeStorageClassesInMessage
+          args := [
+            concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"][n]])
+          ]
+        } else := sprintf(
+          "statefulset did not specify a storage class name.",
+          []
+        )
+
+        #FIXME pod generic ephemeral might be good to validate some day too.

--- a/library/general/uniqueingresshost/samples/unique-ingress-host/example_allowed.yaml
+++ b/library/general/uniqueingresshost/samples/unique-ingress-host/example_allowed.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   rules:
-  - host: example-host.example.com
+  - host: example-allowed-host.example.com
     http:
       paths:
       - pathType: Prefix
@@ -15,7 +15,7 @@ spec:
             name: nginx
             port:
               number: 80
-  - host: example-host1.example.com
+  - host: example-allowed-host1.example.com
     http:
       paths:
       - pathType: Prefix

--- a/src/general/storageclass/constraint.tmpl
+++ b/src/general/storageclass/constraint.tmpl
@@ -1,0 +1,25 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sstorageclass
+  annotations:
+    description: >-
+      Requires storage classes to be specified when used. Currently only gatekeeper 3.9+ is ssupoprted.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sStorageClass
+      validation:
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Requires storage classes to be specified when used.
+          properties:
+            includeStorageClassesInMessage:
+              type: boolean
+              default: true
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/storageclass/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/general/storageclass/constraint.tmpl
+++ b/src/general/storageclass/constraint.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: k8sstorageclass
   annotations:
     description: >-
-      Requires storage classes to be specified when used. Currently only gatekeeper 3.9+ is ssupoprted.
+      Requires storage classes to be specified when used. Only gatekeeper 3.9+ is supported.
 spec:
   crd:
     spec:

--- a/src/general/storageclass/src.rego
+++ b/src/general/storageclass/src.rego
@@ -1,0 +1,88 @@
+package k8sstorageclass
+
+is_pvc(obj) {
+  obj.apiVersion == "v1"
+  obj.kind == "PersistentVolumeClaim"
+}
+
+is_statefulset(obj) {
+  obj.apiVersion == "apps/v1"
+  obj.kind == "StatefulSet"
+}
+
+violation[{"msg": msg}] {
+  count(data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"]) == 0
+  msg := sprintf("StorageClasses not synced. Gatekeeper may be misconfigured. Please have a cluster-admin consult the documentation.", [])
+}
+
+storageclass_found(name) {
+  data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"][name]
+}
+
+violation[{"msg": pvc_storageclass_badname_msg}] {
+  input.parameters.includeStorageClassesInMessage == true
+  is_pvc(input.review.object)
+  not storageclass_found(input.review.object.spec.storageClassName)
+}
+pvc_storageclass_badname_msg := sprintf("pvc did not specify a valid storage class name <%v>. Must be one of [%v]", args) {
+  input.parameters.includeStorageClassesInMessage
+  args := [
+    input.review.object.spec.storageClassName,
+    concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"][n]])
+  ]
+} else := sprintf(
+  "pvc did not specify a valid storage class name <%v>.",
+  [input.review.object.spec.storageClassName]
+)
+
+violation[{"msg": pvc_storageclass_noname_msg}] {
+  is_pvc(input.review.object)
+  not input.review.object.spec.storageClassName
+}
+pvc_storageclass_noname_msg := sprintf("pvc did not specify a storage class name. Must be one of [%v]", args) {
+  input.parameters.includeStorageClassesInMessage
+  args := [
+    concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"][n]])
+  ]
+} else := sprintf(
+  "pvc did not specify a storage class name.",
+  []
+)
+
+violation[{"msg": statefulset_vct_badname_msg(vct)}] {
+  is_statefulset(input.review.object)
+  vct := input.review.object.spec.volumeClaimTemplates[_]
+  not storageclass_found(vct.spec.storageClassName)
+}
+statefulset_vct_badname_msg(vct) := msg {
+  input.parameters.includeStorageClassesInMessage
+  msg := sprintf(
+      "statefulset did not specify a valid storage class name <%v>. Must be one of [%v]", [
+      vct.spec.storageClassName,
+      concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"][n]])
+  ])
+}
+statefulset_vct_badname_msg(vct) := msg {
+  not input.parameters.includeStorageClassesInMessage
+  msg := sprintf(
+    "statefulset did not specify a valid storage class name <%v>.", [
+      vct.spec.storageClassName
+  ])
+}
+
+violation[{"msg": statefulset_vct_noname_msg}] {
+  is_statefulset(input.review.object)
+  vct := input.review.object.spec.volumeClaimTemplates[_]
+  not vct.spec.storageClassName
+}
+statefulset_vct_noname_msg := sprintf("statefulset did not specify a storage class name. Must be one of [%v]", args) {
+  input.parameters.includeStorageClassesInMessage
+  args := [
+    concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"][n]])
+  ]
+} else := sprintf(
+  "statefulset did not specify a storage class name.",
+  []
+)
+
+#FIXME pod generic ephemeral might be good to validate some day too.

--- a/src/general/storageclass/src_test.rego
+++ b/src/general/storageclass/src_test.rego
@@ -1,0 +1,159 @@
+package k8sstorageclass
+
+test_input_denied_no_datasync {
+    input := { "review": input_review_pvc_name("fast"), "parameters": { "includeStorageClassesInMessage": true } }
+    results := violation with input as input with data.inventory as inv_nosync
+    count(results) == 1
+}
+test_input_allowed_pvc_fast {
+    input := { "review": input_review_pvc_name("fast"), "parameters": { "includeStorageClassesInMessage": true } }
+    results := violation with input as input with data.inventory as inv
+    count(results) == 0
+}
+test_input_allowed_pvc_slow {
+    input := { "review": input_review_pvc_name("slow"), "parameters": { "includeStorageClassesInMessage": true } }
+    results := violation with input as input with data.inventory as inv
+    count(results) == 0
+}
+test_input_denied_pvc_bad_storageclassname {
+    input := { "review": input_review_pvc_name("other"), "parameters": { "includeStorageClassesInMessage": true } }
+    results := violation with input as input with data.inventory as inv
+    count(results) == 1
+}
+test_input_denied_pvc_storageclassname_missing {
+    input := { "review": input_review_pvc_storageclassname_missing, "parameters": { "includeStorageClassesInMessage": true } }
+    results := violation with input as input with data.inventory as inv
+    count(results) == 1
+}
+test_input_allowed_statefulset_fast {
+    input := { "review": input_review_statefulset_name("fast"), "parameters": { "includeStorageClassesInMessage": true } }
+    results := violation with input as input with data.inventory as inv
+    count(results) == 0
+}
+test_input_allowed_statefulset_slow {
+    input := { "review": input_review_statefulset_name("slow"), "parameters": { "includeStorageClassesInMessage": true } }
+    results := violation with input as input with data.inventory as inv
+    count(results) == 0
+}
+test_input_denied_statefulset_bad_storageclassname {
+    input := { "review": input_review_statefulset_name("other"), "parameters": { "includeStorageClassesInMessage": true } }
+    results := violation with input as input with data.inventory as inv
+    count(results) == 1
+}
+test_input_denied_statefulset_storageclassname_missing {
+    input := { "review": input_review_statefulset_storageclassname_missing, "parameters": { "includeStorageClassesInMessage": true } }
+    results := violation with input as input with data.inventory as inv
+    count(results) == 1
+}
+
+input_review_pvc_name(name) = output {
+  output = {
+    "object": {
+      "apiVersion": "v1",
+      "kind": "PersistentVolumeClaim",
+      "metadata": {
+        "name": "foo"
+      },
+      "spec": {
+        "accessModes": ["ReadWriteOnce"],
+        "volumeMode": "Filesystem",
+        "resources": {
+          "requests": {
+            "storage": "8Gi"
+          }
+        },
+        "storageClassName": name
+      }
+    }
+  }
+}
+
+input_review_pvc_storageclassname_missing = {
+  "object": {
+    "apiVersion": "v1",
+    "kind": "PersistentVolumeClaim",
+    "metadata": {
+      "name": "foo"
+    },
+    "spec": {
+      "accessModes": ["ReadWriteOnce"],
+      "volumeMode": "Filesystem",
+      "resources": {
+        "requests": {
+          "storage": "8Gi"
+        }
+      },
+    }
+  }
+}
+
+input_review_statefulset_name(name) = output {
+  output = {
+    "object": {
+      "apiVersion": "apps/v1",
+      "kind": "StatefulSet",
+      "metadata": {
+        "name": "foo"
+      },
+      "spec": {
+        "volumeClaimTemplates": [{
+          "metadata": {"name": "bar"},
+          "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "volumeMode": "Filesystem",
+            "resources": {
+              "requests": {
+                "storage": "8Gi"
+              }
+            },
+            "storageClassName": name
+          }
+        }]
+      }
+    }
+  }
+}
+
+input_review_statefulset_storageclassname_missing = {
+  "object": {
+    "apiVersion": "apps/v1",
+    "kind": "StatefulSet",
+    "metadata": {
+      "name": "foo"
+    },
+    "spec": {
+      "volumeClaimTemplates": [{
+        "metadata": {"name": "bar"},
+        "spec": {
+          "accessModes": ["ReadWriteOnce"],
+          "volumeMode": "Filesystem",
+          "resources": {
+            "requests": {
+              "storage": "8Gi"
+            }
+          },
+        }
+      }]
+    }
+  }
+}
+
+inv = {
+  "cluster": {
+    "storage.k8s.io/v1": {
+      "StorageClass": {
+        "fast": {
+          "somestuff": 1
+        },
+        "slow": {
+          "somestuff": 2
+        },
+      }
+    }
+  }
+}
+
+inv_nosync = {
+  "cluster": {
+  }
+}

--- a/test/bats/sync.yaml
+++ b/test/bats/sync.yaml
@@ -21,3 +21,6 @@ spec:
       - group: "policy"
         version: "v1"
         kind: "PodDisruptionBudget"
+      - group: "storage.k8s.io"
+        version: "v1"
+        kind: "StorageClass"


### PR DESCRIPTION
This change checks statefulsets and pvc's to see if a storage class is specified and valid. This enables problems to be detected at the time the objects are loaded into the cluster rather then much later. This requires a lot less cleanup to happen to fix the misconfiguration.