### PR TITLE
Fix kustomization.yaml

### DIFF
--- a/library/general/disallowedtags/kustomization.yaml
+++ b/library/general/disallowedtags/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
   - template.yaml


### PR DESCRIPTION
This should resolve following bug:

```shell
kustomize build .opa-policies` failed exit status 1: Error: accumulating resources: accumulation err='accumulating resources from 'github.com/open-policy-agent/gatekeeper-library/blob/master/library/general/disallowedtags': evalsymlink failure on '.opa-policies/github.com/open-policy-agent/gatekeeper-library/blob/master/library/general/disallowedtags' : lstat .opa-policies/github.com: no such file or directory': evalsymlink failure on '/tmp/kustomize-010481153/blob/master/library/general/disallowedtags' : lstat /tmp/kustomize-010481153/blob: no such file or directory
FATA[0006] Operation has completed with phase: Error
```

This is how my own Kustomize file looks like

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- github.com/open-policy-agent/gatekeeper-library/blob/master/library/general/disallowedtags/
- image-tagging/image-must-not-have-latest-tag-constraint.yaml
```