### PR TITLE
Fix storageclass no datasync test

### DIFF
--- a/library/general/storageclass/template.yaml
+++ b/library/general/storageclass/template.yaml
@@ -44,7 +44,6 @@ spec:
         }
 
         violation[{"msg": pvc_storageclass_badname_msg}] {
-          input.parameters.includeStorageClassesInMessage == true
           is_pvc(input.review.object)
           not storageclass_found(input.review.object.spec.storageClassName)
         }

--- a/library/general/storageclass/template.yaml
+++ b/library/general/storageclass/template.yaml
@@ -35,7 +35,7 @@ spec:
         }
 
         violation[{"msg": msg}] {
-          count(data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"]) == 0
+          not data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"]
           msg := sprintf("StorageClasses not synced. Gatekeeper may be misconfigured. Please have a cluster-admin consult the documentation.", [])
         }
 

--- a/src/general/storageclass/src.rego
+++ b/src/general/storageclass/src.rego
@@ -11,7 +11,7 @@ is_statefulset(obj) {
 }
 
 violation[{"msg": msg}] {
-  count(data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"]) == 0
+  not data.inventory.cluster["storage.k8s.io/v1"]["StorageClass"]
   msg := sprintf("StorageClasses not synced. Gatekeeper may be misconfigured. Please have a cluster-admin consult the documentation.", [])
 }
 

--- a/src/general/storageclass/src.rego
+++ b/src/general/storageclass/src.rego
@@ -20,7 +20,6 @@ storageclass_found(name) {
 }
 
 violation[{"msg": pvc_storageclass_badname_msg}] {
-  input.parameters.includeStorageClassesInMessage == true
   is_pvc(input.review.object)
   not storageclass_found(input.review.object.spec.storageClassName)
 }

--- a/src/general/storageclass/src_test.rego
+++ b/src/general/storageclass/src_test.rego
@@ -3,7 +3,9 @@ package k8sstorageclass
 test_input_denied_no_datasync {
     input := { "review": input_review_pvc_name("fast"), "parameters": { "includeStorageClassesInMessage": true } }
     results := violation with input as input with data.inventory as inv_nosync
-    count(results) == 1
+    count(results) == 2
+  	results[result]
+  	contains(result.msg, "misconfigured")
 }
 test_input_allowed_pvc_fast {
     input := { "review": input_review_pvc_name("fast"), "parameters": { "includeStorageClassesInMessage": true } }

--- a/src/general/storageclass/src_test.rego
+++ b/src/general/storageclass/src_test.rego
@@ -4,8 +4,8 @@ test_input_denied_no_datasync {
     input := { "review": input_review_pvc_name("fast"), "parameters": { "includeStorageClassesInMessage": true } }
     results := violation with input as input with data.inventory as inv_nosync
     count(results) == 2
-  	results[result]
-  	contains(result.msg, "misconfigured")
+    results[result]
+    contains(result.msg, "misconfigured")
 }
 test_input_allowed_pvc_fast {
     input := { "review": input_review_pvc_name("fast"), "parameters": { "includeStorageClassesInMessage": true } }

--- a/src/general/storageclass/src_test.rego
+++ b/src/general/storageclass/src_test.rego
@@ -3,7 +3,6 @@ package k8sstorageclass
 test_input_denied_no_datasync {
     input := { "review": input_review_pvc_name("fast"), "parameters": { "includeStorageClassesInMessage": true } }
     results := violation with input as input with data.inventory as inv_nosync
-    count(results) == 2
     results[result]
     contains(result.msg, "misconfigured")
 }
@@ -19,6 +18,11 @@ test_input_allowed_pvc_slow {
 }
 test_input_denied_pvc_bad_storageclassname {
     input := { "review": input_review_pvc_name("other"), "parameters": { "includeStorageClassesInMessage": true } }
+    results := violation with input as input with data.inventory as inv
+    count(results) == 1
+}
+test_input_denied_pvc_bad_storageclassname_excludestorageclassesinmessage {
+    input := { "review": input_review_pvc_name("other"), "parameters": { "includeStorageClassesInMessage": false } }
     results := violation with input as input with data.inventory as inv
     count(results) == 1
 }


### PR DESCRIPTION
`results` before:

```
{{"msg": "pvc did not specify a valid storage class name <fast>. Must be one of []"}}
```

`results` after:

```
{{"msg": "StorageClasses not synced. Gatekeeper may be misconfigured. Please have a cluster-admin consult the documentation."}, {"msg": "pvc did not specify a valid storage class name <fast>. Must be one of []"}}
```