### PR TITLE
fix: Capitalize Gatekeeper

### DIFF
--- a/library/general/storageclass/template.yaml
+++ b/library/general/storageclass/template.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k8sstorageclass
   annotations:
     description: >-
-      Requires storage classes to be specified when used. Only gatekeeper 3.9+ is supported.
+      Requires storage classes to be specified when used. Only Gatekeeper 3.9+ is supported.
 spec:
   crd:
     spec:

--- a/src/general/storageclass/constraint.tmpl
+++ b/src/general/storageclass/constraint.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: k8sstorageclass
   annotations:
     description: >-
-      Requires storage classes to be specified when used. Only gatekeeper 3.9+ is supported.
+      Requires storage classes to be specified when used. Only Gatekeeper 3.9+ is supported.
 spec:
   crd:
     spec:


### PR DESCRIPTION
* Capitalize Gatekeeper as it is a proper noun.