### PR TITLE
remove Kubernetes from policy titles

### DIFF
--- a/library/general/allowedrepos/template.yaml
+++ b/library/general/allowedrepos/template.yaml
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8sallowedrepos
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Allowed Repositories"
+    metadata.gatekeeper.sh/title: "Allowed Repositories"
     description: >-
       Requires container images to begin with a string from the specified list.
 spec:

--- a/library/general/block-endpoint-edit-default-role/template.yaml
+++ b/library/general/block-endpoint-edit-default-role/template.yaml
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8sblockendpointeditdefaultrole
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Block Endpoint Edit Default Role"
+    metadata.gatekeeper.sh/title: "Block Endpoint Edit Default Role"
     description: >-
       Many Kubernetes installations by default have a system:aggregate-to-edit
       ClusterRole which does not properly restrict access to editing Endpoints.

--- a/library/general/containerlimits/template.yaml
+++ b/library/general/containerlimits/template.yaml
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8scontainerlimits
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Container Limits"
+    metadata.gatekeeper.sh/title: "Container Limits"
     description: >-
       Requires containers to have memory and CPU limits set and constrains
       limits to be within the specified maximum values.

--- a/library/general/containerresources/template.yaml
+++ b/library/general/containerresources/template.yaml
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8srequiredresources
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Required Resources"
+    metadata.gatekeeper.sh/title: "Required Resources"
     description: >-
       Requires containers to have defined resources set.
 

--- a/library/general/requiredlabels/template.yaml
+++ b/library/general/requiredlabels/template.yaml
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8srequiredlabels
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Required Labels"
+    metadata.gatekeeper.sh/title: "Required Labels"
     description: >-
       Requires resources to contain specified labels, with values matching
       provided regular expressions.

--- a/library/general/requiredprobes/template.yaml
+++ b/library/general/requiredprobes/template.yaml
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8srequiredprobes
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Required Probes"
+    metadata.gatekeeper.sh/title: "Required Probes"
     description: Requires Pods to have readiness and/or liveness probes.
 spec:
   crd:

--- a/src/general/allowedrepos/constraint.tmpl
+++ b/src/general/allowedrepos/constraint.tmpl
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8sallowedrepos
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Allowed Repositories"
+    metadata.gatekeeper.sh/title: "Allowed Repositories"
     description: >-
       Requires container images to begin with a string from the specified list.
 spec:

--- a/src/general/block-endpoint-edit-default-role/constraint.tmpl
+++ b/src/general/block-endpoint-edit-default-role/constraint.tmpl
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8sblockendpointeditdefaultrole
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Block Endpoint Edit Default Role"
+    metadata.gatekeeper.sh/title: "Block Endpoint Edit Default Role"
     description: >-
       Many Kubernetes installations by default have a system:aggregate-to-edit
       ClusterRole which does not properly restrict access to editing Endpoints.

--- a/src/general/containerlimits/constraint.tmpl
+++ b/src/general/containerlimits/constraint.tmpl
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8scontainerlimits
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Container Limits"
+    metadata.gatekeeper.sh/title: "Container Limits"
     description: >-
       Requires containers to have memory and CPU limits set and constrains
       limits to be within the specified maximum values.

--- a/src/general/containerresources/constraint.tmpl
+++ b/src/general/containerresources/constraint.tmpl
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8srequiredresources
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Required Resources"
+    metadata.gatekeeper.sh/title: "Required Resources"
     description: >-
       Requires containers to have defined resources set.
 

--- a/src/general/requiredlabels/constraint.tmpl
+++ b/src/general/requiredlabels/constraint.tmpl
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8srequiredlabels
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Required Labels"
+    metadata.gatekeeper.sh/title: "Required Labels"
     description: >-
       Requires resources to contain specified labels, with values matching
       provided regular expressions.

--- a/src/general/requiredprobes/constraint.tmpl
+++ b/src/general/requiredprobes/constraint.tmpl
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8srequiredprobes
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Required Probes"
+    metadata.gatekeeper.sh/title: "Required Probes"
     description: Requires Pods to have readiness and/or liveness probes.
 spec:
   crd:

--- a/website/docs/allowedrepos.md
+++ b/website/docs/allowedrepos.md
@@ -1,9 +1,9 @@
 ---
 id: allowedrepos
-title: Kubernetes Allowed Repositories
+title: Allowed Repositories
 ---
 
-# Kubernetes Allowed Repositories
+# Allowed Repositories
 
 ## Description
 Requires container images to begin with a string from the specified list.
@@ -15,7 +15,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8sallowedrepos
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Allowed Repositories"
+    metadata.gatekeeper.sh/title: "Allowed Repositories"
     description: >-
       Requires container images to begin with a string from the specified list.
 spec:

--- a/website/docs/block-endpoint-edit-default-role.md
+++ b/website/docs/block-endpoint-edit-default-role.md
@@ -1,9 +1,9 @@
 ---
 id: block-endpoint-edit-default-role
-title: Kubernetes Block Endpoint Edit Default Role
+title: Block Endpoint Edit Default Role
 ---
 
-# Kubernetes Block Endpoint Edit Default Role
+# Block Endpoint Edit Default Role
 
 ## Description
 Many Kubernetes installations by default have a system:aggregate-to-edit ClusterRole which does not properly restrict access to editing Endpoints. This ConstraintTemplate forbids the system:aggregate-to-edit ClusterRole from granting permission to create/patch/update Endpoints.
@@ -16,7 +16,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8sblockendpointeditdefaultrole
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Block Endpoint Edit Default Role"
+    metadata.gatekeeper.sh/title: "Block Endpoint Edit Default Role"
     description: >-
       Many Kubernetes installations by default have a system:aggregate-to-edit
       ClusterRole which does not properly restrict access to editing Endpoints.

--- a/website/docs/containerlimits.md
+++ b/website/docs/containerlimits.md
@@ -1,9 +1,9 @@
 ---
 id: containerlimits
-title: Kubernetes Container Limits
+title: Container Limits
 ---
 
-# Kubernetes Container Limits
+# Container Limits
 
 ## Description
 Requires containers to have memory and CPU limits set and constrains limits to be within the specified maximum values.
@@ -16,7 +16,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8scontainerlimits
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Container Limits"
+    metadata.gatekeeper.sh/title: "Container Limits"
     description: >-
       Requires containers to have memory and CPU limits set and constrains
       limits to be within the specified maximum values.

--- a/website/docs/containerresources.md
+++ b/website/docs/containerresources.md
@@ -1,9 +1,9 @@
 ---
 id: containerresources
-title: Kubernetes Required Resources
+title: Required Resources
 ---
 
-# Kubernetes Required Resources
+# Required Resources
 
 ## Description
 Requires containers to have defined resources set.
@@ -16,7 +16,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8srequiredresources
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Required Resources"
+    metadata.gatekeeper.sh/title: "Required Resources"
     description: >-
       Requires containers to have defined resources set.
 

--- a/website/docs/requiredlabels.md
+++ b/website/docs/requiredlabels.md
@@ -1,9 +1,9 @@
 ---
 id: requiredlabels
-title: Kubernetes Required Labels
+title: Required Labels
 ---
 
-# Kubernetes Required Labels
+# Required Labels
 
 ## Description
 Requires resources to contain specified labels, with values matching provided regular expressions.
@@ -15,7 +15,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8srequiredlabels
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Required Labels"
+    metadata.gatekeeper.sh/title: "Required Labels"
     description: >-
       Requires resources to contain specified labels, with values matching
       provided regular expressions.

--- a/website/docs/requiredprobes.md
+++ b/website/docs/requiredprobes.md
@@ -1,9 +1,9 @@
 ---
 id: requiredprobes
-title: Kubernetes Required Probes
+title: Required Probes
 ---
 
-# Kubernetes Required Probes
+# Required Probes
 
 ## Description
 Requires Pods to have readiness and/or liveness probes.
@@ -15,7 +15,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8srequiredprobes
   annotations:
-    metadata.gatekeeper.sh/title: "Kubernetes Required Probes"
+    metadata.gatekeeper.sh/title: "Required Probes"
     description: Requires Pods to have readiness and/or liveness probes.
 spec:
   crd:


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

remove Kubernetes from titles as all the policies are Kubernetes policies