### PR TITLE
Add v1 Ingress version to uniqueingresshost sync object

### DIFF
--- a/artifacthub/library/general/uniqueingresshost/1.0.0/sync.yaml
+++ b/artifacthub/library/general/uniqueingresshost/1.0.0/sync.yaml
@@ -12,3 +12,6 @@ spec:
       - group: "networking.k8s.io"
         version: "v1beta1"
         kind: "Ingress"
+      - group: "networking.k8s.io"
+        version: "v1"
+        kind: "Ingress"

--- a/library/general/uniqueingresshost/sync.yaml
+++ b/library/general/uniqueingresshost/sync.yaml
@@ -12,3 +12,6 @@ spec:
       - group: "networking.k8s.io"
         version: "v1beta1"
         kind: "Ingress"
+      - group: "networking.k8s.io"
+        version: "v1"
+        kind: "Ingress"


### PR DESCRIPTION
Ingress went GA, but the sync object for the unique ingress host policy is only syncing previous API versions of the object.

This PR updates the sync object to include `v1` of the API