### PR TITLE
Constraint and Template change for requiredProbes to add supoort for Deployment and StatefulSet

### DIFF
--- a/library/general/requiredprobes/samples/must-have-probes/constraint.yaml
+++ b/library/general/requiredprobes/samples/must-have-probes/constraint.yaml
@@ -7,6 +7,8 @@ spec:
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment","StatefulSet"]
   parameters:
     probes: ["readinessProbe", "livenessProbe"]
     probeTypes: ["tcpSocket", "httpGet", "exec"]

--- a/library/general/requiredprobes/template.yaml
+++ b/library/general/requiredprobes/template.yaml
@@ -40,7 +40,12 @@ spec:
             probe_is_missing(container, probe)
             msg := get_violation_message(container, input.review, probe)
         }
-
+        violation[{"msg": msg}] {
+            container := input.review.object.spec.template.spec.containers[_]
+            probe := input.parameters.probes[_]
+            probe_is_missing(container, probe)
+            msg := get_violation_message(container, input.review, probe)
+        }
         probe_is_missing(ctr, probe) = true {
             not ctr[probe]
         }


### PR DESCRIPTION
This commit makes to restrict for Deployment and StatefulSet along with Pod