### PR TITLE
feat: add Replicasknative policy

### DIFF
--- a/library/general/replicasknative/kustomization.yaml
+++ b/library/general/replicasknative/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/replicasknative/samples/constraint.yaml
+++ b/library/general/replicasknative/samples/constraint.yaml
@@ -1,0 +1,11 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sKnativeReplica
+metadata:
+  name: k8sknativereplica
+spec:
+  match:
+    kinds:
+      - apiGroups: ["serving.knative.dev"]
+        kinds: ["Service"]
+  parameters:
+    replicas: 10

--- a/library/general/replicasknative/samples/example_allowed.yaml
+++ b/library/general/replicasknative/samples/example_allowed.yaml
@@ -1,0 +1,13 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "5"
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go

--- a/library/general/replicasknative/samples/example_disallowed.yaml
+++ b/library/general/replicasknative/samples/example_disallowed.yaml
@@ -1,0 +1,13 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "8"
+        autoscaling.knative.dev/maxScale: "5"
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go

--- a/library/general/replicasknative/samples/example_empty_annotations.yaml
+++ b/library/general/replicasknative/samples/example_empty_annotations.yaml
@@ -1,0 +1,11 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+spec:
+  template:
+    metadata:
+      creationTimestamp: '2022-12-13T09:21:04Z'
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go

--- a/library/general/replicasknative/suite.yaml
+++ b/library/general/replicasknative/suite.yaml
@@ -1,0 +1,21 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: replicalimits
+tests:
+- name: block-endpoint-default-role
+  template: template.yaml
+  constraint: samples/replicasknative/constraint.yaml
+  cases:
+  - name: example-allowed
+    object: samples/replicasknative/example_allowed.yaml
+    assertions:
+    - violations: no
+  - name: example-disallowed
+    object: samples/replicasknative/example_disallowed.yaml
+    assertions:
+    - violations: yes
+  - name: example-empty-annotations
+    object: samples/replicasknative/example_empty_annotations.yaml
+    assertions:
+    - violations: yes    

--- a/library/general/replicasknative/template.yaml
+++ b/library/general/replicasknative/template.yaml
@@ -6,7 +6,7 @@ metadata:
     metadata.gatekeeper.sh/title: "Knative Replica Limits"
     metadata.gatekeeper.sh/version: 1.0.0
     description: >-
-      Requires that knative service objects with the field `annotations.xxxScale` specify a number of replicas within defined ranges.
+      Requires that knative service objects with the field `annotations.{max,min,initial}Scale` specify a number of replicas within defined ranges.
 spec:
   crd:
     spec:

--- a/library/general/replicasknative/template.yaml
+++ b/library/general/replicasknative/template.yaml
@@ -1,0 +1,79 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sknativereplica
+  annotations:
+    metadata.gatekeeper.sh/title: "Knative Replica Limits"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Requires that knative service objects with the field `annotations.xxxScale` specify a number of replicas within defined ranges.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sKnativeReplica
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            replicas:
+              type: integer
+              description: Allowed values for numbers of replicas. 
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sknativereplica
+
+        missing(obj, field) = true {
+            not obj[field]
+        }
+
+        missing(obj, field) = true {
+            obj[field] == ""
+        }
+
+        violation[{"msg": msg}] {
+            service := input.review.object
+            missing(service.spec.template.metadata.annotations, "autoscaling.knative.dev/maxScale")
+            msg := sprintf("Knative service serving %v has no maxScale value defined", [service.metadata.name])
+        }
+
+        violation[{"msg": msg}] {
+            service := input.review.object
+            missing(service.spec.template.metadata, "annotations")
+            msg := sprintf("Knative service serving %v has no annotations defined", [service.metadata.name])
+        }
+
+        violation[{"msg": msg}] {
+            replicas := input.parameters.replicas
+            service := input.review.object
+            max_scale := service.spec.template.metadata.annotations["autoscaling.knative.dev/maxScale"]
+            to_number(replicas) < to_number(max_scale)
+            msg := sprintf("maxScale value %v cannot be greater than %v replicas", [max_scale, replicas])
+        }
+
+        violation[{"msg": msg}] {
+            replicas := input.parameters.replicas
+            service := input.review.object
+            min_scale := service.spec.template.metadata.annotations["autoscaling.knative.dev/minScale"]
+            to_number(replicas) < to_number(min_scale)
+            msg := sprintf("minScale value %v cannot be greater than %v replicas", [min_scale, replicas])
+        }
+
+        violation[{"msg": msg}] {
+            replicas := input.parameters.replicas
+            service := input.review.object
+            max_scale := service.spec.template.metadata.annotations["autoscaling.knative.dev/maxScale"]
+            min_scale := service.spec.template.metadata.annotations["autoscaling.knative.dev/minScale"]
+            to_number(max_scale) < to_number(min_scale)
+            msg := sprintf("minScale value %v cannot be greater than %v maxScale", [min_scale, max_scale])
+        }
+
+        violation[{"msg": msg}] {
+            replicas := input.parameters.replicas
+            service := input.review.object
+            initial_scale := service.spec.template.metadata.annotations["autoscaling.knative.dev/initialScale"]
+            to_number(replicas) < to_number(initial_scale)
+            msg := sprintf("intialScale value %v cannot be greater than %v replicas", [initial_scale, replicas])
+        }

--- a/src/general/replicasknative/constraint.tmpl
+++ b/src/general/replicasknative/constraint.tmpl
@@ -6,7 +6,7 @@ metadata:
     metadata.gatekeeper.sh/title: "Knative Replica Limits"
     metadata.gatekeeper.sh/version: 1.0.0
     description: >-
-      Requires that knative service objects with the field `annotations.xxxScale` specify a number of replicas within defined ranges.
+      Requires that knative service objects with the field `annotations.{max,min,initial}Scale` specify a number of replicas within defined max values.
 spec:
   crd:
     spec:
@@ -19,7 +19,7 @@ spec:
           properties:
             replicas:
               type: integer
-              description: Allowed value for max numbers of replicas. 
+              description: Allowed max value for number of replicas. 
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/src/general/replicasknative/constraint.tmpl
+++ b/src/general/replicasknative/constraint.tmpl
@@ -1,0 +1,26 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sknativereplica
+  annotations:
+    metadata.gatekeeper.sh/title: "Knative Replica Limits"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Requires that knative service objects with the field `annotations.xxxScale` specify a number of replicas within defined ranges.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sKnativeReplica
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            replicas:
+              type: integer
+              description: Allowed value for max numbers of replicas. 
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/replicasknative/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}      

--- a/src/general/replicasknative/src.rego
+++ b/src/general/replicasknative/src.rego
@@ -1,0 +1,54 @@
+package k8sknativereplica
+
+missing(obj, field) = true {
+    not obj[field]
+}
+
+missing(obj, field) = true {
+    obj[field] == ""
+}
+
+violation[{"msg": msg}] {
+    service := input.review.object
+    missing(service.spec.template.metadata.annotations, "autoscaling.knative.dev/maxScale")
+    msg := sprintf("Knative service serving %v has no maxScale value defined", [service.metadata.name])
+}
+
+violation[{"msg": msg}] {
+    service := input.review.object
+    missing(service.spec.template.metadata, "annotations")
+    msg := sprintf("Knative service serving %v has no annotations defined", [service.metadata.name])
+}
+
+violation[{"msg": msg}] {
+    replicas := input.parameters.replicas
+    service := input.review.object
+    max_scale := service.spec.template.metadata.annotations["autoscaling.knative.dev/maxScale"]
+    to_number(replicas) < to_number(max_scale)
+    msg := sprintf("maxScale value %v cannot be greater than %v replicas", [max_scale, replicas])
+}
+
+violation[{"msg": msg}] {
+    replicas := input.parameters.replicas
+    service := input.review.object
+    min_scale := service.spec.template.metadata.annotations["autoscaling.knative.dev/minScale"]
+    to_number(replicas) < to_number(min_scale)
+    msg := sprintf("minScale value %v cannot be greater than %v replicas", [min_scale, replicas])
+}
+
+violation[{"msg": msg}] {
+    replicas := input.parameters.replicas
+    service := input.review.object
+    max_scale := service.spec.template.metadata.annotations["autoscaling.knative.dev/maxScale"]
+    min_scale := service.spec.template.metadata.annotations["autoscaling.knative.dev/minScale"]
+    to_number(max_scale) < to_number(min_scale)
+    msg := sprintf("minScale value %v cannot be greater than %v maxScale", [min_scale, max_scale])
+}
+
+violation[{"msg": msg}] {
+    replicas := input.parameters.replicas
+    service := input.review.object
+    initial_scale := service.spec.template.metadata.annotations["autoscaling.knative.dev/initialScale"]
+    to_number(replicas) < to_number(initial_scale)
+    msg := sprintf("intialScale value %v cannot be greater than %v replicas", [initial_scale, replicas])
+}

--- a/src/general/replicasknative/src_test.rego
+++ b/src/general/replicasknative/src_test.rego
@@ -6,6 +6,18 @@ test_replicas_no_violation {
     count(results) == 0
 }
 
+test_replicas_no_annotations {
+    input := { "review": review_annotations , "parameters": {"replicas": "10"}}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_replicas_empty_maxScale {
+    input := { "review": review(2, "", 1) , "parameters": {"replicas": "10"}}
+    results := violation with input as input
+    count(results) == 0
+}
+
 test_replicas_maxScale_greater_than_replicas{
     input := { "review": review(2, 11, 1) , "parameters": {"replicas": "10"}}
     results := violation with input as input
@@ -19,7 +31,7 @@ test_replicas_minScale_greater_than_maxScale {
 }
 
 test_replicas_minScale_greater_than_replicas {
-    input := { "review": {"object": { "spec": { "template": { "metadata": { "annotations": {"autoscaling.knative.dev/minScale": 12}}}}}} , "parameters": {"replicas": "10"}}
+    input := { "review": review_minScale(12) , "parameters": {"replicas": "10"}}
     results := violation with input as input
     count(results) == 1
 }
@@ -48,3 +60,32 @@ review(minScale, maxScale, initialScale) = output {
   }
 } 
 
+review_minScale(minScale) = output {
+  output = {
+    "object": {
+      "spec": {
+        "template": {
+            "metadata": {
+               "annotations": {
+                 "autoscaling.knative.dev/minScale": minScale
+               }
+            }
+        }
+      }
+    }
+  }
+} 
+
+review_annotations = output {
+  output = {
+    "object": {
+      "spec": {
+        "template": {
+            "metadata": {
+                
+            }
+        }
+      }
+    }
+  }
+} 

--- a/src/general/replicasknative/src_test.rego
+++ b/src/general/replicasknative/src_test.rego
@@ -1,0 +1,50 @@
+package k8sknativereplica
+
+test_replicas_no_violation {
+    input := { "review": review(2, 9, 1) , "parameters": {"replicas": "10"}}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_replicas_maxScale_greater_than_replicas{
+    input := { "review": review(2, 11, 1) , "parameters": {"replicas": "10"}}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_replicas_minScale_greater_than_maxScale {
+    input := { "review": review(8, 7, 1) , "parameters": {"replicas": "10"}}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_replicas_minScale_greater_than_replicas {
+    input := { "review": {"object": { "spec": { "template": { "metadata": { "annotations": {"autoscaling.knative.dev/minScale": 12}}}}}} , "parameters": {"replicas": "10"}}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_replicas_initialScale_greater_than_replicas {
+    input := { "review": review(2, 8, 11) , "parameters": {"replicas": "10"}}
+    results := violation with input as input
+    count(results) == 1
+}
+
+review(minScale, maxScale, initialScale) = output {
+  output = {
+    "object": {
+      "spec": {
+        "template": {
+            "metadata": {
+               "annotations": {
+                 "autoscaling.knative.dev/minScale": minScale,
+                 "autoscaling.knative.dev/maxScale": maxScale,
+                 "autoscaling.knative.dev/initialScale": initialScale,
+               }
+            }
+        }
+      }
+    }
+  }
+} 
+


### PR DESCRIPTION

This PR adds a library policy to allow max replicas for knative services for the following scenarios:

1. maxScale value must be defined.
2. minScale if defined, cannot be greater than maxScale
3. minScale if defined, cannot be greater than replicas
4. initialScale if defined, cannot be greater than replicas
5. maxScale cannot be greater than replicas
