### PR TITLE
feat: Change template annotation to use k8s-style casing

### DIFF
--- a/artifacthub/library/general/horizontalpodautoscaler/1.0.0/template.yaml
+++ b/artifacthub/library/general/horizontalpodautoscaler/1.0.0/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Horizontal Pod Autoscaler"
     metadata.gatekeeper.sh/version: 1.0.0
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/artifacthub/library/general/poddisruptionbudget/1.0.1/template.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.1/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Pod Disruption Budget"
     metadata.gatekeeper.sh/version: 1.0.1
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/artifacthub/library/general/poddisruptionbudget/1.0.2/template.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.2/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Pod Disruption Budget"
     metadata.gatekeeper.sh/version: 1.0.2
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/artifacthub/library/general/storageclass/1.0.1/template.yaml
+++ b/artifacthub/library/general/storageclass/1.0.1/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Storage Class"
     metadata.gatekeeper.sh/version: 1.0.1
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/artifacthub/library/general/storageclass/1.1.0/template.yaml
+++ b/artifacthub/library/general/storageclass/1.1.0/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Storage Class"
     metadata.gatekeeper.sh/version: 1.1.0
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/artifacthub/library/general/uniqueingresshost/1.0.1/template.yaml
+++ b/artifacthub/library/general/uniqueingresshost/1.0.1/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Unique Ingress Host"
     metadata.gatekeeper.sh/version: 1.0.1
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/artifacthub/library/general/uniqueingresshost/1.0.2/template.yaml
+++ b/artifacthub/library/general/uniqueingresshost/1.0.2/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Unique Ingress Host"
     metadata.gatekeeper.sh/version: 1.0.2
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/artifacthub/library/general/uniqueserviceselector/1.0.1/template.yaml
+++ b/artifacthub/library/general/uniqueserviceselector/1.0.1/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Unique Service Selector"
     metadata.gatekeeper.sh/version: 1.0.1
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/library/general/horizontalpodautoscaler/template.yaml
+++ b/library/general/horizontalpodautoscaler/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Horizontal Pod Autoscaler"
     metadata.gatekeeper.sh/version: 1.0.0
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/library/general/poddisruptionbudget/template.yaml
+++ b/library/general/poddisruptionbudget/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Pod Disruption Budget"
     metadata.gatekeeper.sh/version: 1.0.2
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/library/general/storageclass/template.yaml
+++ b/library/general/storageclass/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Storage Class"
     metadata.gatekeeper.sh/version: 1.1.0
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/library/general/uniqueingresshost/template.yaml
+++ b/library/general/uniqueingresshost/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Unique Ingress Host"
     metadata.gatekeeper.sh/version: 1.0.2
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/library/general/uniqueserviceselector/template.yaml
+++ b/library/general/uniqueserviceselector/template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Unique Service Selector"
     metadata.gatekeeper.sh/version: 1.0.1
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/scripts/require-sync/main.go
+++ b/scripts/require-sync/main.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/utils/strings/slices"
 )
 
-const syncAnnotation string = "metadata.gatekeeper.sh/requiresSyncData"
+const syncAnnotation string = "metadata.gatekeeper.sh/requires-sync-data"
 
 var (
 	pathFlag = flag.String("path", "", "Path to verify referential templates include sync data.")

--- a/src/general/horizontalpodautoscaler/constraint.tmpl
+++ b/src/general/horizontalpodautoscaler/constraint.tmpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Horizontal Pod Autoscaler"
     metadata.gatekeeper.sh/version: 1.0.0
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/src/general/poddisruptionbudget/constraint.tmpl
+++ b/src/general/poddisruptionbudget/constraint.tmpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Pod Disruption Budget"
     metadata.gatekeeper.sh/version: 1.0.2
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/src/general/storageclass/constraint.tmpl
+++ b/src/general/storageclass/constraint.tmpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Storage Class"
     metadata.gatekeeper.sh/version: 1.1.0
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/src/general/uniqueingresshost/constraint.tmpl
+++ b/src/general/uniqueingresshost/constraint.tmpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Unique Ingress Host"
     metadata.gatekeeper.sh/version: 1.0.2
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/src/general/uniqueserviceselector/constraint.tmpl
+++ b/src/general/uniqueserviceselector/constraint.tmpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Unique Service Selector"
     metadata.gatekeeper.sh/version: 1.0.1
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/website/docs/validation/horizontalpodautoscaler.md
+++ b/website/docs/validation/horizontalpodautoscaler.md
@@ -17,7 +17,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Horizontal Pod Autoscaler"
     metadata.gatekeeper.sh/version: 1.0.0
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/website/docs/validation/poddisruptionbudget.md
+++ b/website/docs/validation/poddisruptionbudget.md
@@ -18,7 +18,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Pod Disruption Budget"
     metadata.gatekeeper.sh/version: 1.0.2
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/website/docs/validation/storageclass.md
+++ b/website/docs/validation/storageclass.md
@@ -17,7 +17,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Storage Class"
     metadata.gatekeeper.sh/version: 1.1.0
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/website/docs/validation/uniqueingresshost.md
+++ b/website/docs/validation/uniqueingresshost.md
@@ -18,7 +18,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Unique Ingress Host"
     metadata.gatekeeper.sh/version: 1.0.2
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {

--- a/website/docs/validation/uniqueserviceselector.md
+++ b/website/docs/validation/uniqueserviceselector.md
@@ -18,7 +18,7 @@ metadata:
   annotations:
     metadata.gatekeeper.sh/title: "Unique Service Selector"
     metadata.gatekeeper.sh/version: 1.0.1
-    metadata.gatekeeper.sh/requiresSyncData: |
+    metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
           {


### PR DESCRIPTION
In https://github.com/open-policy-agent/gatekeeper/pull/2734#discussion_r1199238402 the decision was made to change the sync data anotation casing from `requiresSyncData` to `requires-sync-data`.  This better fits k8s standards.

This PR updates gatekeeper-library templates with the new annotation key.