### PR TITLE
chore: update integration test to Gatekeeper 3.13

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gatekeeper: [ "release-3.11", "release-3.12" ]
+        gatekeeper: [ "release-3.13", "release-3.12" ]
     name: "Integration test on Gatekeeper ${{ matrix.gatekeeper }}"
     steps:
       - name: Harden Runner


### PR DESCRIPTION
**What this PR does / why we need it**: update integration test to include Gatekeeper 3.13