### PR TITLE
chore: group github-actions dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,3 +80,7 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore"
+    groups:
+      all:
+        patterns:
+        - "*"


### PR DESCRIPTION
**What this PR does / why we need it**: group github-actions dependabot PRs