### PR TITLE
chore: group docusaurus npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,6 +73,10 @@ updates:
         update-types:
         - "version-update:semver-major"
         - "version-update:semver-minor"
+    groups:
+      all:
+        patterns:
+        - "*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
**What this PR does / why we need it**: We should updates all the docusaurus modules at once.
