### PR TITLE
fix: api groups in constraint 1.22

### DIFF
--- a/artifacthub/library/general/verifydeprecatedapi/1.0.0/samples/verify-1.22/constraint.yaml
+++ b/artifacthub/library/general/verifydeprecatedapi/1.0.0/samples/verify-1.22/constraint.yaml
@@ -25,9 +25,9 @@ spec:
         kinds: ["IngressClass"]
       - apiGroups: ["rbac.authorization.k8s.io"]
         kinds: ["ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding"]
-      - apiGroups: ["scheduling.k8s.io/v1beta1"]
+      - apiGroups: ["scheduling.k8s.io"]
         kinds: ["PriorityClass"]
-      - apiGroups: ["storage.k8s.io/v1beta1"]
+      - apiGroups: ["storage.k8s.io"]
         kinds: ["CSIDriver", "CSINode", "StorageClass", "VolumeAttachment"]
   parameters:
     kvs:

--- a/library/general/verifydeprecatedapi/samples/verify-1.22/constraint.yaml
+++ b/library/general/verifydeprecatedapi/samples/verify-1.22/constraint.yaml
@@ -25,9 +25,9 @@ spec:
         kinds: ["IngressClass"]
       - apiGroups: ["rbac.authorization.k8s.io"]
         kinds: ["ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding"]
-      - apiGroups: ["scheduling.k8s.io/v1beta1"]
+      - apiGroups: ["scheduling.k8s.io"]
         kinds: ["PriorityClass"]
-      - apiGroups: ["storage.k8s.io/v1beta1"]
+      - apiGroups: ["storage.k8s.io"]
         kinds: ["CSIDriver", "CSINode", "StorageClass", "VolumeAttachment"]
   parameters:
     kvs:

--- a/website/docs/validation/verifydeprecatedapi.md
+++ b/website/docs/validation/verifydeprecatedapi.md
@@ -238,9 +238,9 @@ spec:
         kinds: ["IngressClass"]
       - apiGroups: ["rbac.authorization.k8s.io"]
         kinds: ["ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding"]
-      - apiGroups: ["scheduling.k8s.io/v1beta1"]
+      - apiGroups: ["scheduling.k8s.io"]
         kinds: ["PriorityClass"]
-      - apiGroups: ["storage.k8s.io/v1beta1"]
+      - apiGroups: ["storage.k8s.io"]
         kinds: ["CSIDriver", "CSINode", "StorageClass", "VolumeAttachment"]
   parameters:
     kvs:


### PR DESCRIPTION
**What this PR does / why we need it**:
The example for the verifydeprecatedapi-1.22 constraint should say "scheduling.k8s.io" instead of "scheduling.k8s.io/v1beta1" for the apiGroup match kind. Otherwise, the constraint will not properly match the deprecated API resources.

**Which issue(s) does this PR fix** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Library policies?**
Please refer to [How to contribute to the library](https://open-policy-agent.github.io/gatekeeper-library/website/#how-to-contribute-to-the-library) to add new policies or update existing policies.

**Are you updating an existing policy?**
Please run `make generate generate-website-docs generate-artifacthub-artifacts` to generate the templates and docs.
-->

**Special notes for your reviewer**:
