### PR TITLE
chore: update golangci-lint v1.55.2

### DIFF
--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -30,5 +30,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.54.2
+          version: v1.55.2
           working-directory: scripts/${{ matrix.folder }}


### PR DESCRIPTION
**What this PR does / why we need it**: update golangci-lint v1.55.2
