### PR TITLE
bump mutation cr from alpha to v1

### DIFF
--- a/mutation/pod-security-policy/allow-privilege-escalation/samples/mutation.yaml
+++ b/mutation/pod-security-policy/allow-privilege-escalation/samples/mutation.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspdefaultallowprivilegeescalation
@@ -15,7 +15,7 @@ spec:
     assign:
       value: false
 ---
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspdefaultallowprivilegeescalation-init
@@ -32,7 +32,7 @@ spec:
     assign:
       value: false
 ---
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspdefaultallowprivilegeescalation-ephemeral

--- a/mutation/pod-security-policy/capabilities/samples/mutation-assign.yaml
+++ b/mutation/pod-security-policy/capabilities/samples/mutation-assign.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspcapabilities

--- a/mutation/pod-security-policy/capabilities/samples/mutation-modifyset.yaml
+++ b/mutation/pod-security-policy/capabilities/samples/mutation-modifyset.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: ModifySet
 metadata:
   name: k8spspcapabilities

--- a/mutation/pod-security-policy/read-only-root-filesystem/samples/mutation.yaml
+++ b/mutation/pod-security-policy/read-only-root-filesystem/samples/mutation.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspreadonlyrootfs

--- a/mutation/pod-security-policy/seccomp/samples/mutation.yaml
+++ b/mutation/pod-security-policy/seccomp/samples/mutation.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: AssignMetadata
 metadata:
   name: k8spspseccomp

--- a/mutation/pod-security-policy/selinux/samples/mutation.yaml
+++ b/mutation/pod-security-policy/selinux/samples/mutation.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspselinux

--- a/mutation/pod-security-policy/users/samples/mutation-fsGroup.yaml
+++ b/mutation/pod-security-policy/users/samples/mutation-fsGroup.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspfsGroup

--- a/mutation/pod-security-policy/users/samples/mutation-mustRunAsNonRoot.yaml
+++ b/mutation/pod-security-policy/users/samples/mutation-mustRunAsNonRoot.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spsprunasnonroot
@@ -15,7 +15,7 @@ spec:
     assign:
       value: true
 ---
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spsprunasnonroot-init

--- a/mutation/pod-security-policy/users/samples/mutation-runAsGroup.yaml
+++ b/mutation/pod-security-policy/users/samples/mutation-runAsGroup.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spsprunasgroup
@@ -15,7 +15,7 @@ spec:
     assign:
       value: 2000
 ---
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spsprunasgroup-init

--- a/mutation/pod-security-policy/users/samples/mutation-runAsUser.yaml
+++ b/mutation/pod-security-policy/users/samples/mutation-runAsUser.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spsprunasuser
@@ -15,7 +15,7 @@ spec:
     assign:
       value: 1000
 ---
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spsprunasuser-init

--- a/mutation/pod-security-policy/users/samples/mutation-supplementalGroups.yaml
+++ b/mutation/pod-security-policy/users/samples/mutation-supplementalGroups.yaml
@@ -1,4 +1,4 @@
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspsupplementalgroups

--- a/website/docs/mutation-examples/allow-privilege-escalation.md
+++ b/website/docs/mutation-examples/allow-privilege-escalation.md
@@ -11,7 +11,7 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-
 ```
 ## Mutation Examples
 ```yaml
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspdefaultallowprivilegeescalation
@@ -28,7 +28,7 @@ spec:
     assign:
       value: false
 ---
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspdefaultallowprivilegeescalation-init
@@ -45,7 +45,7 @@ spec:
     assign:
       value: false
 ---
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspdefaultallowprivilegeescalation-ephemeral

--- a/website/docs/mutation-examples/capabilities.md
+++ b/website/docs/mutation-examples/capabilities.md
@@ -11,7 +11,7 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-
 ```
 ## Mutation Examples
 ```yaml
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: ModifySet
 metadata:
   name: k8spspcapabilities

--- a/website/docs/mutation-examples/read-only-root-filesystem.md
+++ b/website/docs/mutation-examples/read-only-root-filesystem.md
@@ -11,7 +11,7 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-
 ```
 ## Mutation Examples
 ```yaml
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspreadonlyrootfs

--- a/website/docs/mutation-examples/seccomp.md
+++ b/website/docs/mutation-examples/seccomp.md
@@ -11,7 +11,7 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-
 ```
 ## Mutation Examples
 ```yaml
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: AssignMetadata
 metadata:
   name: k8spspseccomp

--- a/website/docs/mutation-examples/selinux.md
+++ b/website/docs/mutation-examples/selinux.md
@@ -11,7 +11,7 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-
 ```
 ## Mutation Examples
 ```yaml
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspselinux

--- a/website/docs/mutation-examples/users.md
+++ b/website/docs/mutation-examples/users.md
@@ -11,7 +11,7 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-
 ```
 ## Mutation Examples
 ```yaml
-apiVersion: mutations.gatekeeper.sh/v1alpha1
+apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
   name: k8spspsupplementalgroups


### PR DESCRIPTION
**What this PR does / why we need it**:
the sample mutate assign api is too old

**Which issue(s) does this PR fix** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #444

<!--
**Are you making changes to Gatekeeper Library policies?**
Please refer to [How to contribute to the library](https://open-policy-agent.github.io/gatekeeper-library/website/#how-to-contribute-to-the-library) to add new policies or update existing policies.

**Are you updating an existing policy?**
Please run `make generate generate-website-docs generate-artifacthub-artifacts` to generate the templates and docs.
-->
already run

**Special notes for your reviewer**:
I fail to find the test framework for mutate