### PR TITLE
Add Percentage Based Checks For PodDisruptionBudget Policy

### DIFF
--- a/artifacthub/library/general/poddisruptionbudget/1.0.3/artifacthub-pkg.yml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.3/artifacthub-pkg.yml
@@ -5,7 +5,7 @@ createdAt: "2023-06-12T20:47:47Z"
 description: |-
     Disallow the following scenarios when deploying PodDisruptionBudgets or resources that implement the replica subresource (e.g. Deployment, ReplicationController, ReplicaSet, StatefulSet): 1. Deployment of PodDisruptionBudgets with .spec.maxUnavailable == 0 2. Deployment of PodDisruptionBudgets with .spec.minAvailable == .spec.replicas of the resource with replica subresource This will prevent PodDisruptionBudgets from blocking voluntary disruptions such as node draining.
     https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-digest: b5f0b45b6b1894cf43f6b40970557afb9549b6541760c9481bc8acfc3c572815
+digest: 5422abc78e79bf29dbb2ec46806c60919f2c2d5a4510cc77f6724fd2328ce63d
 license: Apache-2.0
 homeURL: https://open-policy-agent.github.io/gatekeeper-library/website/poddisruptionbudget
 keywords:

--- a/artifacthub/library/general/poddisruptionbudget/1.0.3/template.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.3/template.yaml
@@ -32,11 +32,13 @@ spec:
       rego: |
         package k8spoddisruptionbudget
 
+        import future.keywords
+
         violation[{"msg": msg}] {
           input.review.kind.kind == "PodDisruptionBudget"
           pdb := input.review.object
 
-          not valid_pdb_max_unavailable(pdb)
+          not valid_pdb_max_unavailable(input.review, pdb)
           msg := sprintf(
             "PodDisruptionBudget <%v> has maxUnavailable of 0, only positive integers are allowed for maxUnavailable",
             [pdb.metadata.name],
@@ -51,7 +53,7 @@ spec:
           labels := { [label, value] | some label; value := obj.spec.selector.matchLabels[label] }
           count(matchLabels - labels) == 0
 
-          not valid_pdb_max_unavailable(pdb)
+          not valid_pdb_max_unavailable(obj, pdb)
           msg := sprintf(
             "%v <%v> has been selected by PodDisruptionBudget <%v> but has maxUnavailable of 0, only positive integers are allowed for maxUnavailable",
             [obj.kind, obj.metadata.name, pdb.metadata.name],
@@ -73,18 +75,64 @@ spec:
           )
         }
 
-        valid_pdb_min_available(obj, pdb) {
+        min_available(obj, pdb) = new if {
+          # if its a percentage, it will return the number of pods that need
+          # to be available rounded up (that's how Kubernetes calculates it).
+          # if its a number, return that number
+        	endswith(pdb.spec.minAvailable, "%")
+
+        	# convert % to a number, if this is 50%, then 50/100 = 0.5
+        	per := to_number(replace(pdb.spec.minAvailable, "%", "")) / 100
+
+        	# round up to the nearest integer based on replicas
+        	# if replicas is 3, then 3 * 0.5 = 1.5, ceil(1.5) = 2
+        	new := ceil(obj.spec.replicas * per)
+        }
+
+        min_available(_, pdb) = new if {
+        	is_number(pdb.spec.minAvailable)
+        	new := object.get(pdb.spec, "minAvailable", -1)
+        }
+
+        min_available(_, pdb) = new if {
           # default to -1 if minAvailable is not set so valid_pdb_min_available is always true
           # for objects with >= 0 replicas. If minAvailable defaults to >= 0, objects with
           # replicas field might violate this constraint if they are equal to the default set here
-          min_available := object.get(pdb.spec, "minAvailable", -1)
-          obj.spec.replicas > min_available
+        	not pdb.spec.minAvailable
+        	new := -1
         }
 
-        valid_pdb_max_unavailable(pdb) {
+        valid_pdb_min_available(obj, pdb) if {
+        	obj.spec.replicas > min_available(obj, pdb)
+        }
+
+        max_unavailable(obj, pdb) = new if {
+          # if its a percentage, it will return the number of pods that need
+          # to be available rounded down (that's how Kubernetes calculates it).
+          # if its a number, return that number, if unset return default of 1
+        	endswith(pdb.spec.maxUnavailable, "%")
+
+        	# convert % to a number, if this is 50%, then 50/100 = 0.5
+        	per := to_number(replace(pdb.spec.maxUnavailable, "%", "")) / 100
+
+        	# round down to the nearest integer based on replicas
+        	# if replicas is 3, then 3 * 0.5 = 1.5, ceil(1.5) = 2
+        	new := ceil(obj.spec.replicas * per)
+        }
+
+        max_unavailable(_, pdb) = new if {
+        	is_number(pdb.spec.maxUnavailable)
+        	new := object.get(pdb.spec, "maxUnavailable", 1)
+        }
+
+        max_unavailable(_, pdb) = new if {
           # default to 1 if maxUnavailable is not set so valid_pdb_max_unavailable always returns true.
           # If maxUnavailable defaults to 0, it violates this constraint because all pods needs to be
           # available and no pods can be evicted voluntarily
-          max_unavailable := object.get(pdb.spec, "maxUnavailable", 1)
-          max_unavailable > 0
+        	not pdb.spec.maxUnavailable
+        	new := 1
+        }
+
+        valid_pdb_max_unavailable(obj, pdb) if {
+        	max_unavailable(obj, pdb) > 0
         }

--- a/library/general/poddisruptionbudget/template.yaml
+++ b/library/general/poddisruptionbudget/template.yaml
@@ -32,11 +32,13 @@ spec:
       rego: |
         package k8spoddisruptionbudget
 
+        import future.keywords
+
         violation[{"msg": msg}] {
           input.review.kind.kind == "PodDisruptionBudget"
           pdb := input.review.object
 
-          not valid_pdb_max_unavailable(pdb)
+          not valid_pdb_max_unavailable(input.review, pdb)
           msg := sprintf(
             "PodDisruptionBudget <%v> has maxUnavailable of 0, only positive integers are allowed for maxUnavailable",
             [pdb.metadata.name],
@@ -51,7 +53,7 @@ spec:
           labels := { [label, value] | some label; value := obj.spec.selector.matchLabels[label] }
           count(matchLabels - labels) == 0
 
-          not valid_pdb_max_unavailable(pdb)
+          not valid_pdb_max_unavailable(obj, pdb)
           msg := sprintf(
             "%v <%v> has been selected by PodDisruptionBudget <%v> but has maxUnavailable of 0, only positive integers are allowed for maxUnavailable",
             [obj.kind, obj.metadata.name, pdb.metadata.name],
@@ -73,18 +75,64 @@ spec:
           )
         }
 
-        valid_pdb_min_available(obj, pdb) {
+        min_available(obj, pdb) = new if {
+          # if its a percentage, it will return the number of pods that need
+          # to be available rounded up (that's how Kubernetes calculates it).
+          # if its a number, return that number
+        	endswith(pdb.spec.minAvailable, "%")
+
+        	# convert % to a number, if this is 50%, then 50/100 = 0.5
+        	per := to_number(replace(pdb.spec.minAvailable, "%", "")) / 100
+
+        	# round up to the nearest integer based on replicas
+        	# if replicas is 3, then 3 * 0.5 = 1.5, ceil(1.5) = 2
+        	new := ceil(obj.spec.replicas * per)
+        }
+
+        min_available(_, pdb) = new if {
+        	is_number(pdb.spec.minAvailable)
+        	new := object.get(pdb.spec, "minAvailable", -1)
+        }
+
+        min_available(_, pdb) = new if {
           # default to -1 if minAvailable is not set so valid_pdb_min_available is always true
           # for objects with >= 0 replicas. If minAvailable defaults to >= 0, objects with
           # replicas field might violate this constraint if they are equal to the default set here
-          min_available := object.get(pdb.spec, "minAvailable", -1)
-          obj.spec.replicas > min_available
+        	not pdb.spec.minAvailable
+        	new := -1
         }
 
-        valid_pdb_max_unavailable(pdb) {
+        valid_pdb_min_available(obj, pdb) if {
+        	obj.spec.replicas > min_available(obj, pdb)
+        }
+
+        max_unavailable(obj, pdb) = new if {
+          # if its a percentage, it will return the number of pods that need
+          # to be available rounded down (that's how Kubernetes calculates it).
+          # if its a number, return that number, if unset return default of 1
+        	endswith(pdb.spec.maxUnavailable, "%")
+
+        	# convert % to a number, if this is 50%, then 50/100 = 0.5
+        	per := to_number(replace(pdb.spec.maxUnavailable, "%", "")) / 100
+
+        	# round down to the nearest integer based on replicas
+        	# if replicas is 3, then 3 * 0.5 = 1.5, ceil(1.5) = 2
+        	new := ceil(obj.spec.replicas * per)
+        }
+
+        max_unavailable(_, pdb) = new if {
+        	is_number(pdb.spec.maxUnavailable)
+        	new := object.get(pdb.spec, "maxUnavailable", 1)
+        }
+
+        max_unavailable(_, pdb) = new if {
           # default to 1 if maxUnavailable is not set so valid_pdb_max_unavailable always returns true.
           # If maxUnavailable defaults to 0, it violates this constraint because all pods needs to be
           # available and no pods can be evicted voluntarily
-          max_unavailable := object.get(pdb.spec, "maxUnavailable", 1)
-          max_unavailable > 0
+        	not pdb.spec.maxUnavailable
+        	new := 1
+        }
+
+        valid_pdb_max_unavailable(obj, pdb) if {
+        	max_unavailable(obj, pdb) > 0
         }

--- a/src/general/poddisruptionbudget/src.rego
+++ b/src/general/poddisruptionbudget/src.rego
@@ -1,10 +1,12 @@
 package k8spoddisruptionbudget
 
+import future.keywords
+
 violation[{"msg": msg}] {
   input.review.kind.kind == "PodDisruptionBudget"
   pdb := input.review.object
 
-  not valid_pdb_max_unavailable(pdb)
+  not valid_pdb_max_unavailable(input.review, pdb)
   msg := sprintf(
     "PodDisruptionBudget <%v> has maxUnavailable of 0, only positive integers are allowed for maxUnavailable",
     [pdb.metadata.name],
@@ -19,7 +21,7 @@ violation[{"msg": msg}] {
   labels := { [label, value] | some label; value := obj.spec.selector.matchLabels[label] }
   count(matchLabels - labels) == 0
 
-  not valid_pdb_max_unavailable(pdb)
+  not valid_pdb_max_unavailable(obj, pdb)
   msg := sprintf(
     "%v <%v> has been selected by PodDisruptionBudget <%v> but has maxUnavailable of 0, only positive integers are allowed for maxUnavailable",
     [obj.kind, obj.metadata.name, pdb.metadata.name],
@@ -41,18 +43,64 @@ violation[{"msg": msg}] {
   )
 }
 
-valid_pdb_min_available(obj, pdb) {
+min_available(obj, pdb) = new if {
+  # if its a percentage, it will return the number of pods that need
+  # to be available rounded up (that's how Kubernetes calculates it).
+  # if its a number, return that number
+	endswith(pdb.spec.minAvailable, "%")
+
+	# convert % to a number, if this is 50%, then 50/100 = 0.5
+	per := to_number(replace(pdb.spec.minAvailable, "%", "")) / 100
+
+	# round up to the nearest integer based on replicas
+	# if replicas is 3, then 3 * 0.5 = 1.5, ceil(1.5) = 2
+	new := ceil(obj.spec.replicas * per)
+}
+
+min_available(_, pdb) = new if {
+	is_number(pdb.spec.minAvailable)
+	new := object.get(pdb.spec, "minAvailable", -1)
+}
+
+min_available(_, pdb) = new if {
   # default to -1 if minAvailable is not set so valid_pdb_min_available is always true
   # for objects with >= 0 replicas. If minAvailable defaults to >= 0, objects with
   # replicas field might violate this constraint if they are equal to the default set here
-  min_available := object.get(pdb.spec, "minAvailable", -1)
-  obj.spec.replicas > min_available
+	not pdb.spec.minAvailable
+	new := -1
 }
 
-valid_pdb_max_unavailable(pdb) {
+valid_pdb_min_available(obj, pdb) if {
+	obj.spec.replicas > min_available(obj, pdb)
+}
+
+max_unavailable(obj, pdb) = new if {
+  # if its a percentage, it will return the number of pods that need
+  # to be available rounded down (that's how Kubernetes calculates it).
+  # if its a number, return that number, if unset return default of 1
+	endswith(pdb.spec.maxUnavailable, "%")
+
+	# convert % to a number, if this is 50%, then 50/100 = 0.5
+	per := to_number(replace(pdb.spec.maxUnavailable, "%", "")) / 100
+
+	# round down to the nearest integer based on replicas
+	# if replicas is 3, then 3 * 0.5 = 1.5, ceil(1.5) = 2
+	new := ceil(obj.spec.replicas * per)
+}
+
+max_unavailable(_, pdb) = new if {
+	is_number(pdb.spec.maxUnavailable)
+	new := object.get(pdb.spec, "maxUnavailable", 1)
+}
+
+max_unavailable(_, pdb) = new if {
   # default to 1 if maxUnavailable is not set so valid_pdb_max_unavailable always returns true.
   # If maxUnavailable defaults to 0, it violates this constraint because all pods needs to be
   # available and no pods can be evicted voluntarily
-  max_unavailable := object.get(pdb.spec, "maxUnavailable", 1)
-  max_unavailable > 0
+	not pdb.spec.maxUnavailable
+	new := 1
+}
+
+valid_pdb_max_unavailable(obj, pdb) if {
+	max_unavailable(obj, pdb) > 0
 }

--- a/src/general/poddisruptionbudget/src_test.rego
+++ b/src/general/poddisruptionbudget/src_test.rego
@@ -13,6 +13,12 @@ test_input_pdb_0_max_unavailable {
   count(results) == 1
 }
 
+test_input_pdb_0_max_unavailable_percent {
+  inp := {"review": input_pdb_max_unavailable("0%")}
+  results := violation with input as inp
+  count(results) == 1
+}
+
 test_input_pdb_1_max_unavailable {
   inp := {"review": input_pdb_max_unavailable(1)}
   results := violation with input as inp
@@ -26,9 +32,23 @@ test_input_deployment_1_replica_pdb_1_min_available {
   count(results) == 1
 }
 
+test_input_deployment_1_replica_pdb_1_min_available_percent {
+  inp := {"review": input_deployment(1)}
+  inv := inv_pdb_min_available("100%")
+  results := violation with input as inp with data.inventory as inv
+  count(results) == 1
+}
+
 test_input_deployment_2_replicas_pdb_1_min_available {
   inp := {"review": input_deployment(2)}
   inv := inv_pdb_min_available(1)
+  results := violation with input as inp with data.inventory as inv
+  count(results) == 0
+}
+
+test_input_deployment_2_replicas_pdb_1_min_available_percent {
+  inp := {"review": input_deployment(2)}
+  inv := inv_pdb_min_available("50%")
   results := violation with input as inp with data.inventory as inv
   count(results) == 0
 }
@@ -40,9 +60,23 @@ test_input_deployment_pdb_0_max_unavailable {
   count(results) == 1
 }
 
+test_input_deployment_pdb_0_max_unavailable_percent {
+  inp := {"review": input_deployment(2)}
+  inv := inv_pdb_max_unavailable("0%")
+  results := violation with input as inp with data.inventory as inv
+  count(results) == 1
+}
+
 test_input_deployment_pdb_1_max_unavailable {
   inp := {"review": input_deployment(2)}
   inv := inv_pdb_max_unavailable(1)
+  results := violation with input as inp with data.inventory as inv
+  count(results) == 0
+}
+
+test_input_deployment_pdb_1_max_unavailable_percent {
+  inp := {"review": input_deployment(2)}
+  inv := inv_pdb_max_unavailable("50%")
   results := violation with input as inp with data.inventory as inv
   count(results) == 0
 }

--- a/website/docs/validation/poddisruptionbudget.md
+++ b/website/docs/validation/poddisruptionbudget.md
@@ -45,11 +45,13 @@ spec:
       rego: |
         package k8spoddisruptionbudget
 
+        import future.keywords
+
         violation[{"msg": msg}] {
           input.review.kind.kind == "PodDisruptionBudget"
           pdb := input.review.object
 
-          not valid_pdb_max_unavailable(pdb)
+          not valid_pdb_max_unavailable(input.review, pdb)
           msg := sprintf(
             "PodDisruptionBudget <%v> has maxUnavailable of 0, only positive integers are allowed for maxUnavailable",
             [pdb.metadata.name],
@@ -64,7 +66,7 @@ spec:
           labels := { [label, value] | some label; value := obj.spec.selector.matchLabels[label] }
           count(matchLabels - labels) == 0
 
-          not valid_pdb_max_unavailable(pdb)
+          not valid_pdb_max_unavailable(obj, pdb)
           msg := sprintf(
             "%v <%v> has been selected by PodDisruptionBudget <%v> but has maxUnavailable of 0, only positive integers are allowed for maxUnavailable",
             [obj.kind, obj.metadata.name, pdb.metadata.name],
@@ -86,20 +88,66 @@ spec:
           )
         }
 
-        valid_pdb_min_available(obj, pdb) {
+        min_available(obj, pdb) = new if {
+          # if its a percentage, it will return the number of pods that need
+          # to be available rounded up (that's how Kubernetes calculates it).
+          # if its a number, return that number
+        	endswith(pdb.spec.minAvailable, "%")
+
+        	# convert % to a number, if this is 50%, then 50/100 = 0.5
+        	per := to_number(replace(pdb.spec.minAvailable, "%", "")) / 100
+
+        	# round up to the nearest integer based on replicas
+        	# if replicas is 3, then 3 * 0.5 = 1.5, ceil(1.5) = 2
+        	new := ceil(obj.spec.replicas * per)
+        }
+
+        min_available(_, pdb) = new if {
+        	is_number(pdb.spec.minAvailable)
+        	new := object.get(pdb.spec, "minAvailable", -1)
+        }
+
+        min_available(_, pdb) = new if {
           # default to -1 if minAvailable is not set so valid_pdb_min_available is always true
           # for objects with >= 0 replicas. If minAvailable defaults to >= 0, objects with
           # replicas field might violate this constraint if they are equal to the default set here
-          min_available := object.get(pdb.spec, "minAvailable", -1)
-          obj.spec.replicas > min_available
+        	not pdb.spec.minAvailable
+        	new := -1
         }
 
-        valid_pdb_max_unavailable(pdb) {
+        valid_pdb_min_available(obj, pdb) if {
+        	obj.spec.replicas > min_available(obj, pdb)
+        }
+
+        max_unavailable(obj, pdb) = new if {
+          # if its a percentage, it will return the number of pods that need
+          # to be available rounded down (that's how Kubernetes calculates it).
+          # if its a number, return that number, if unset return default of 1
+        	endswith(pdb.spec.maxUnavailable, "%")
+
+        	# convert % to a number, if this is 50%, then 50/100 = 0.5
+        	per := to_number(replace(pdb.spec.maxUnavailable, "%", "")) / 100
+
+        	# round down to the nearest integer based on replicas
+        	# if replicas is 3, then 3 * 0.5 = 1.5, ceil(1.5) = 2
+        	new := ceil(obj.spec.replicas * per)
+        }
+
+        max_unavailable(_, pdb) = new if {
+        	is_number(pdb.spec.maxUnavailable)
+        	new := object.get(pdb.spec, "maxUnavailable", 1)
+        }
+
+        max_unavailable(_, pdb) = new if {
           # default to 1 if maxUnavailable is not set so valid_pdb_max_unavailable always returns true.
           # If maxUnavailable defaults to 0, it violates this constraint because all pods needs to be
           # available and no pods can be evicted voluntarily
-          max_unavailable := object.get(pdb.spec, "maxUnavailable", 1)
-          max_unavailable > 0
+        	not pdb.spec.maxUnavailable
+        	new := 1
+        }
+
+        valid_pdb_max_unavailable(obj, pdb) if {
+        	max_unavailable(obj, pdb) > 0
         }
 
 ```


### PR DESCRIPTION
**What this PR does / why we need it**: 

This adds support for percentage based values in the `PodDisruptionBudget` policy, allowing for more holistic coverage of PDBs. 

Here are some examples of a blocking `PodDisruptionBudget`.

```yaml
apiVersion: v1/policy
kind: PodDisruptionBudget
metadata:
  name: test
spec:
  selector:
    matchLabels:
      app: test
  maxUnavailable: 30%
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
spec:
  replicas: 3
```

And then a passing `PodDisruptionBudget`


```yaml
apiVersion: v1/policy
kind: PodDisruptionBudget
metadata:
  name: test
spec:
  selector:
    matchLabels:
      app: test
  maxUnavailable: 50%
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
spec:
  replicas: 3
```

**Which issue(s) does this PR fix** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

Fixes #343

**Special notes for your reviewer**: 

I've never contributed and may have missed something, please let me know if I need to correct or add to tests. 
