### PR TITLE
[RFE] new general policy: deny-networkpolicy-modifications

### DIFF
--- a/library/general/deny-networkpolicy-modifications/samples/networkpolicyenforced/constraint.yaml
+++ b/library/general/deny-networkpolicy-modifications/samples/networkpolicyenforced/constraint.yaml
@@ -1,0 +1,16 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: DenyNetworkPolicyModifications
+metadata:
+  name: denynetworkpolicymodifications
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups:
+          - "*"
+        kinds:
+          - NetworkPolicy
+  parameters:
+    global-policy:
+      allowedGroups: ['network-admins']
+      allowedUsers: ['network-admin']

--- a/library/general/deny-networkpolicy-modifications/samples/networkpolicyenforced/example_allow_by_group_policy.yaml
+++ b/library/general/deny-networkpolicy-modifications/samples/networkpolicyenforced/example_allow_by_group_policy.yaml
@@ -1,0 +1,33 @@
+apiVersion: admission.k8s.io/v1
+kind: AdmissionReview
+request:
+  dryRun: true
+  kind:
+    group: networking.k8s.io
+    kind: NetworkPolicy
+    version: v1
+  namespace: default
+  object:
+    apiVersion: v1
+    kind: NetworkPolicy
+    metadata:
+      name: global-policy
+      namespace: default
+    spec:
+      podSelector: {}
+      policyTypes: []
+  operation: CREATE
+  resource:
+    group: networking.k8s.io
+    resource: NetworkPolicy
+    version: v1
+  requestKind:
+    group: ""
+    version: v1
+  uid: unittest
+  userInfo:
+    groups:
+    - developers
+    - network-admins
+    username: john_does
+    uid: unittest

--- a/library/general/deny-networkpolicy-modifications/samples/networkpolicyenforced/example_allow_by_user_policy.yaml
+++ b/library/general/deny-networkpolicy-modifications/samples/networkpolicyenforced/example_allow_by_user_policy.yaml
@@ -1,0 +1,32 @@
+apiVersion: admission.k8s.io/v1
+kind: AdmissionReview
+request:
+  dryRun: true
+  kind:
+    group: networking.k8s.io
+    kind: NetworkPolicy
+    version: v1
+  namespace: default
+  object:
+    apiVersion: v1
+    kind: NetworkPolicy
+    metadata:
+      name: global-policy
+      namespace: default
+    spec:
+      podSelector: {}
+      policyTypes: []
+  operation: CREATE
+  resource:
+    group: networking.k8s.io
+    resource: NetworkPolicy
+    version: v1
+  requestKind:
+    group: ""
+    version: v1
+  uid: unittest
+  userInfo:
+    groups:
+    - developers
+    username: network-admin
+    uid: unittest

--- a/library/general/deny-networkpolicy-modifications/samples/networkpolicyenforced/example_allow_custom_policy.yaml
+++ b/library/general/deny-networkpolicy-modifications/samples/networkpolicyenforced/example_allow_custom_policy.yaml
@@ -1,0 +1,32 @@
+apiVersion: admission.k8s.io/v1
+kind: AdmissionReview
+request:
+  dryRun: true
+  kind:
+    group: networking.k8s.io
+    kind: NetworkPolicy
+    version: v1
+  namespace: default
+  object:
+    apiVersion: v1
+    kind: NetworkPolicy
+    metadata:
+      name: custom-policy
+      namespace: default
+    spec:
+      podSelector: {}
+      policyTypes: []
+  operation: CREATE
+  resource:
+    group: networking.k8s.io
+    resource: NetworkPolicy
+    version: v1
+  requestKind:
+    group: ""
+    version: v1
+  uid: unittest
+  userInfo:
+    groups:
+    - developers
+    username: john_doe
+    uid: unittest

--- a/library/general/deny-networkpolicy-modifications/samples/networkpolicyenforced/example_deny_global_policy.yaml
+++ b/library/general/deny-networkpolicy-modifications/samples/networkpolicyenforced/example_deny_global_policy.yaml
@@ -1,0 +1,32 @@
+apiVersion: admission.k8s.io/v1
+kind: AdmissionReview
+request:
+  dryRun: true
+  kind:
+    group: networking.k8s.io
+    kind: NetworkPolicy
+    version: v1
+  namespace: default
+  object:
+    apiVersion: v1
+    kind: NetworkPolicy
+    metadata:
+      name: global-policy
+      namespace: default
+    spec:
+      podSelector: {}
+      policyTypes: []
+  operation: CREATE
+  resource:
+    group: networking.k8s.io
+    resource: NetworkPolicy
+    version: v1
+  requestKind:
+    group: ""
+    version: v1
+  uid: unittest
+  userInfo:
+    groups:
+    - developers
+    username: john_doe
+    uid: unittest

--- a/library/general/deny-networkpolicy-modifications/suite.yaml
+++ b/library/general/deny-networkpolicy-modifications/suite.yaml
@@ -1,0 +1,25 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: denynetworkpolicymodifications
+tests:
+- name: allow-user-policies 
+  template: template.yaml
+  constraint: samples/networkpolicyenforced/constraint.yaml
+  cases:
+  - name: example-allow-custom-policy
+    object: samples/networkpolicyenforced/example_allow_custom_policy.yaml
+    assertions:
+    - violations: no
+  - name: example-deny-global-policy
+    object: samples/networkpolicyenforced/example_deny_global_policy.yaml
+    assertions:
+    - violations: yes
+  - name: example-allow-by-username-policy
+    object: samples/networkpolicyenforced/example_allow_by_user_policy.yaml
+    assertions:
+    - violations: no
+  - name: example-allow-by-group-policy
+    object: samples/networkpolicyenforced/example_allow_by_group_policy.yaml
+    assertions:
+    - violations: no

--- a/library/general/deny-networkpolicy-modifications/template.yaml
+++ b/library/general/deny-networkpolicy-modifications/template.yaml
@@ -1,0 +1,57 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: denynetworkpolicymodifications
+  annotations:
+    metadata.gatekeeper.sh/title: "Deny Global/Admin Network Policies from modification"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: "Deny updating the NetworkPolicies that are used on Global or Administrative level even if the users fulfill kubernetes RBAC access to them. This policy is ignored in audit mode."
+spec:
+  crd:
+    spec:
+      names:
+        kind: DenyNetworkPolicyModifications
+      validation:
+        legacySchema: true
+        #  type: object
+        #  properties:
+        #    policyname:
+        #      type: object
+        #      properties:
+        #        allowedGroups:
+        #          description: Groups that should be allowed to bypass the policy.
+        #          type: array
+        #          items:
+        #            type: string
+        #        allowedUsers:
+        #          description: Users that should be allowed to bypass the policy.
+        #          type: array
+        #          items:
+        #            type: string
+  targets:
+    - rego: |
+        package DenyNetworkPolicyModifications
+        privileged(userInfo, allowedUsers, _) {
+          # Allow if the user is in allowedUsers.
+          username := object.get(userInfo, "username", "")
+          allowedUsers[_] == username
+        } 
+        privileged(userInfo, _, allowedGroups) {
+          # Allow if the user's groups intersect allowedGroups.
+          userGroups := object.get(userInfo, "groups", [])
+          groups := {g | g := userGroups[_]}
+          allowed := {g | g := allowedGroups[_]}
+          intersection := groups & allowed
+          count(intersection) > 0
+        }
+        violation[{"msg": msg}] {
+          params := object.get(input, "parameters", {})
+          policyName := input.review.object.metadata.name
+          input.review.kind.kind == "NetworkPolicy"
+          allowedUsers := object.get(params[policyName], "allowedUsers", [])
+          allowedGroups := object.get(params[policyName], "allowedGroups", [])
+          not privileged(input.review.userInfo, allowedUsers, allowedGroups)
+          msg := sprintf("User %v is not allowed to create/modify NetworkPolicy %v", 
+                         [input.review.userInfo.username, policyName])
+        }
+      target: admission.k8s.gatekeeper.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
This ConstraintTemplate will provide multi-tenant NetworkPolicies as known in SDN. This capability is dropped with OVN and default kubernetes RBAC does not provide capability to restrict namespace administrators from modifying or deleting NetworkPolicies that are Cluster or Administrator deployed.

**Special notes for your reviewer**:
The most difficult part on the PR was to figure out how to utilize AdmissionReview objects with UserInfo properly. We clearly lack documentation and samples on that. 

I have been testing the Policy with OCP 4.12, 4.13 4.14 
