### PR TITLE
[RFE] new general policy: whitelist domain names for routes

### DIFF
--- a/library/general/whitelist-domain-route-modifications/samples/domaintoroutepolicyenforced/constraint.yaml
+++ b/library/general/whitelist-domain-route-modifications/samples/domaintoroutepolicyenforced/constraint.yaml
@@ -1,0 +1,19 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: DenyRoutePerDomainPolicy
+metadata:
+  name: denyrouterperdomainpolicy
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups:
+          - route.openshift.io
+        kinds:
+          - Route
+  parameters:
+    example.com:
+      allowedGroups: ["example.com"]
+      allowedUsers: ["admin"]
+    somedomain.com:
+      allowedGroups: ["somedomain.com"]
+      allowedUsers: ["admin"]

--- a/library/general/whitelist-domain-route-modifications/samples/domaintoroutepolicyenforced/example_allow_by_group_domain.yaml
+++ b/library/general/whitelist-domain-route-modifications/samples/domaintoroutepolicyenforced/example_allow_by_group_domain.yaml
@@ -1,0 +1,39 @@
+apiVersion: admission.k8s.io/v1
+kind: AdmissionReview
+request:
+  dryRun: true
+  kind:
+    group: route.openshift.io
+    kind: Route
+    version: v1
+  namespace: default
+  object:
+    apiVersion: v1
+    kind: route.openshift.io
+    metadata:
+      name: test
+      namespace: default
+    spec:
+      host: host.somedomain.com
+      port:
+        targetPort: http-8080
+      to:
+        kind: Service
+        name: mockbin
+        weight: 100
+      wildcardPolicy: None
+  operation: CREATE
+  resource:
+    group: route.openshift.io
+    resource: Route
+    version: v1
+  requestKind:
+    group: ""
+    version: v1
+  uid: unittest
+  userInfo:
+    groups:
+    - developers
+    - somedomain.com
+    username: john_does
+    uid: unittest

--- a/library/general/whitelist-domain-route-modifications/samples/domaintoroutepolicyenforced/example_allow_by_user_domain.yaml
+++ b/library/general/whitelist-domain-route-modifications/samples/domaintoroutepolicyenforced/example_allow_by_user_domain.yaml
@@ -1,0 +1,38 @@
+apiVersion: admission.k8s.io/v1
+kind: AdmissionReview
+request:
+  dryRun: true
+  kind:
+    group: route.openshift.io
+    kind: Route
+    version: v1
+  namespace: default
+  object:
+    apiVersion: v1
+    kind: Route
+    metadata:
+      name: test
+      namespace: default
+    spec:
+      host: host.somedomain.com
+      port:
+        targetPort: http-8080
+      to:
+        kind: Service
+        name: mockbin
+        weight: 100
+      wildcardPolicy: None
+  operation: CREATE
+  resource:
+    group: route.openshift.io
+    resource: Route
+    version: v1
+  requestKind:
+    group: ""
+    version: v1
+  uid: unittest
+  userInfo:
+    groups:
+    - developers
+    username: network-admin
+    uid: unittest

--- a/library/general/whitelist-domain-route-modifications/samples/domaintoroutepolicyenforced/example_deny_notwhitelisted-domain.yaml
+++ b/library/general/whitelist-domain-route-modifications/samples/domaintoroutepolicyenforced/example_deny_notwhitelisted-domain.yaml
@@ -1,0 +1,38 @@
+apiVersion: admission.k8s.io/v1
+kind: AdmissionReview
+request:
+  dryRun: true
+  kind:
+    group: route.openshift.io
+    kind: Route
+    version: v1
+  namespace: default
+  object:
+    apiVersion: v1
+    kind: Route
+    metadata:
+      name: test
+      namespace: default
+    spec:
+      host: host.xxx.xxx
+      port:
+        targetPort: http-8080
+      to:
+        kind: Service
+        name: mockbin
+        weight: 100
+      wildcardPolicy: None
+  operation: CREATE
+  resource:
+    group: route.openshift.io
+    resource: Route
+    version: v1
+  requestKind:
+    group: ""
+    version: v1
+  uid: unittest
+  userInfo:
+    groups:
+    - developers
+    username: john_doe
+    uid: unittest

--- a/library/general/whitelist-domain-route-modifications/suite.yaml
+++ b/library/general/whitelist-domain-route-modifications/suite.yaml
@@ -1,0 +1,21 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: denyrouteperdomainpolicy
+tests:
+- name: allow-user-domains
+  template: template.yaml
+  constraint: samples/domaintoroutepolicyenforced/constraint.yaml
+  cases:
+  - name: example-deny-notwhitelisted-domain
+    object: samples/domaintoroutepolicyenforced/example_deny_notwhitelisted-domain.yaml
+    assertions:
+    - violations: yes
+  - name: example-allow-by-username-notwhitelisted-domain
+    object: samples/domaintoroutepolicyenforced/example_allow_by_user_domain.yaml
+    assertions:
+    - violations: no
+  - name: example-allow-by-group-notwhitelisted-domain
+    object: samples/domaintoroutepolicyenforced/example_allow_by_group_domain.yaml
+    assertions:
+    - violations: no

--- a/library/general/whitelist-domain-route-modifications/template.yaml
+++ b/library/general/whitelist-domain-route-modifications/template.yaml
@@ -1,0 +1,69 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: denyrouteperdomainpolicy
+  annotations:
+    metadata.gatekeeper.sh/title: "Deny not whitelisted domains for Route creation or modification"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: "Deny not whitelisted domains for Routes even if the users fulfill kubernetes RBAC access to them. This policy is ignored in audit mode."
+spec:
+  crd:
+    spec:
+      names:
+        kind: DenyRoutePerDomainPolicy
+      validation:
+        legacySchema: true
+        #  type: object
+        #  properties:
+        #    domainname:
+        #      type: object
+        #      properties:
+        #        allowedGroups:
+        #          description: Groups that should be allowed to bypass the policy.
+        #          type: array
+        #          items:
+        #            type: string
+        #        allowedUsers:
+        #          description: Users that should be allowed to bypass the policy.
+        #          type: array
+        #          items:
+        #            type: string
+  targets:
+    - rego: |
+        package DenyRoutePerDomainPolicy
+        privileged(userInfo, allowedUsers, _) {
+          # Allow if the user is in allowedUsers.
+          username := object.get(userInfo, "username", "")
+          allowedUsers[_] == username
+        } 
+        privileged(userInfo, _, allowedGroups) {
+          # Allow if the user's groups intersect allowedGroups.
+          userGroups := object.get(userInfo, "groups", [])
+          groups := {g | g := userGroups[_]}
+          allowed := {g | g := allowedGroups[_]}
+          intersection := groups & allowed
+          count(intersection) > 0
+        }
+        violation[{"msg": msg}] {
+          params := object.get(input, "parameters", {})
+          routeName := input.review.object.spec.host
+          idx := indexof(routeName, ".")
+          domain := substring(routeName, idx + 1, count(routeName))
+          input.review.kind.kind == "Route"
+          not params[domain]
+          msg := sprintf("User %v is not allowed to create/modify Route %v in domain %v",
+                         [input.review.userInfo.username, routeName, domain])
+        }
+        violation[{"msg": msg}] {
+          params := object.get(input, "parameters", {})
+          routeName := input.review.object.spec.host
+          idx := indexof(routeName, ".")
+          domain := substring(routeName, idx + 1, count(routeName))
+          allowedUsers := object.get(params[domain], "allowedUsers", [])
+          allowedGroups := object.get(params[domain], "allowedGroups", [])
+          input.review.kind.kind == "Route"
+          not privileged(input.review.userInfo, allowedUsers, allowedGroups)
+          msg := sprintf("User %v is not allowed to create/modify Route %v in domain %v %v %v",
+                         [input.review.userInfo.username, routeName, domain, allowedUsers, allowedGroups])
+        }
+      target: admission.k8s.gatekeeper.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
This ConstraintTemplate will provide capability to limit the domain names being  useable in Route objects. The default kubernetes RBAC does not provide capability to restrict the `spec.host`field from being evaluated.

**Special notes for your reviewer**:
I have not been able to get the tests working with the Route object as input not even if I only use a fail mechanism in the ConstraintTemplate. I assume, this is related to gator verify as it is verified working in an OpenShift Cluster.

I have been testing the Policy with OCP 4.12, 4.13 4.14