### PR TITLE
DEMO (do not merge): Show breakage with no CEL change

### DIFF
--- a/library/pod-security-policy/read-only-root-filesystem/samples/wildcard_support/example_safe_image_prefix.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/samples/wildcard_support/example_safe_image_prefix.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-readonlyrootfilesystem-allowed
+  labels:
+    app: nginx-readonlyrootfilesystem
+spec:
+  containers:
+  - name: nginx
+    image: "safe-images.com/nginx"
+    securityContext:
+      readOnlyRootFilesystem: false

--- a/library/pod-security-policy/read-only-root-filesystem/samples/wildcard_support/example_unsafe_image_prefix.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/samples/wildcard_support/example_unsafe_image_prefix.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-readonlyrootfilesystem-allowed
+  labels:
+    app: nginx-readonlyrootfilesystem
+spec:
+  containers:
+  - name: nginx
+    image: "unsafe-images.com/nginx"
+    securityContext:
+      readOnlyRootFilesystem: false

--- a/library/pod-security-policy/read-only-root-filesystem/samples/wildcard_support/full_wildcard_constraint.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/samples/wildcard_support/full_wildcard_constraint.yaml
@@ -1,0 +1,12 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPReadOnlyRootFilesystem
+metadata:
+  name: psp-readonlyrootfilesystem
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    exemptImages:
+      - "*"

--- a/library/pod-security-policy/read-only-root-filesystem/samples/wildcard_support/prefix_matching_constraint.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/samples/wildcard_support/prefix_matching_constraint.yaml
@@ -1,0 +1,12 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPReadOnlyRootFilesystem
+metadata:
+  name: psp-readonlyrootfilesystem
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    exemptImages:
+      - "safe-images.com/*"

--- a/library/pod-security-policy/read-only-root-filesystem/suite.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/suite.yaml
@@ -25,3 +25,23 @@ tests:
     object: samples/psp-readonlyrootfilesystem/update.yaml
     assertions:
     - violations: no
+- name: full-wildcard
+  template: template.yaml
+  constraint: samples/wildcard_support/full_wildcard_constraint.yaml
+  cases:
+  - name: allow-normally-disallowed
+    object: samples/psp-readonlyrootfilesystem/example_disallowed.yaml
+    assertions:
+    - violations: no
+- name: wildcard-suffix
+  template: template.yaml
+  constraint: samples/wildcard_support/prefix_matching_constraint.yaml
+  cases:
+  - name: image-with-exempt-prefix-readOnlyRootFilesystem-not-required
+    object: samples/wildcard_support/example_safe_image_prefix.yaml
+    assertions:
+    - violations: no
+  - name: image-with-different-prefix-must-set-readOnlyRootFilesystem
+    object: samples/wildcard_support/example_unsafe_image_prefix.yaml
+    assertions:
+    - violations: yes


### PR DESCRIPTION
Despite it being non-sensical to put a `*` in exemptImages (functionally disabling the policy), this is supported in the existing rego implementation of the template.

Thus, not doing it in the CEL implementation is an inconsistency and a breaking change.

This PR upholds the contract by adding support for `*` as an exemptImage.

**What this PR does / why we need it**:

**Which issue(s) does this PR fix** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Library policies?**
Please refer to [How to contribute to the library](https://open-policy-agent.github.io/gatekeeper-library/website/#how-to-contribute-to-the-library) to add new policies or update existing policies.

**Are you updating an existing policy?**
Please run `make generate generate-website-docs generate-artifacthub-artifacts` to generate the templates and docs.
-->

**Special notes for your reviewer**:
