### PR TITLE
chore(k8spspallowprivilegeescalationcontainer): suite test confirming exemptImages

### DIFF
--- a/artifacthub/library/pod-security-policy/allow-privilege-escalation/1.1.0/samples/psp-allow-privilege-escalation-container/constraint.yaml
+++ b/artifacthub/library/pod-security-policy/allow-privilege-escalation/1.1.0/samples/psp-allow-privilege-escalation-container/constraint.yaml
@@ -8,4 +8,4 @@ spec:
       - apiGroups: [""]
         kinds: ["Pod"]
   parameters:
-    exemptImages: ["nonexistent/*"]
+    exemptImages: ["safeimages.com/*"]

--- a/artifacthub/library/pod-security-policy/allow-privilege-escalation/1.1.0/samples/psp-allow-privilege-escalation-container/example_allowed_exempt.yaml
+++ b/artifacthub/library/pod-security-policy/allow-privilege-escalation/1.1.0/samples/psp-allow-privilege-escalation-container/example_allowed_exempt.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-privilege-escalation-disallowed
+  labels:
+    app: nginx-privilege-escalation
+spec:
+  containers:
+  - name: nginx
+    image: "safeimages.com/nginx"
+    securityContext:
+      allowPrivilegeEscalation: true

--- a/artifacthub/library/pod-security-policy/allow-privilege-escalation/1.1.0/suite.yaml
+++ b/artifacthub/library/pod-security-policy/allow-privilege-escalation/1.1.0/suite.yaml
@@ -23,3 +23,7 @@ tests:
         object: samples/psp-allow-privilege-escalation-container/update.yaml
         assertions:
           - violations: no
+      - name: exempted-path
+        object: samples/psp-allow-privilege-escalation-container/example_allowed_exempt.yaml
+        assertions:
+          - violations: no

--- a/library/pod-security-policy/allow-privilege-escalation/samples/psp-allow-privilege-escalation-container/constraint.yaml
+++ b/library/pod-security-policy/allow-privilege-escalation/samples/psp-allow-privilege-escalation-container/constraint.yaml
@@ -8,4 +8,4 @@ spec:
       - apiGroups: [""]
         kinds: ["Pod"]
   parameters:
-    exemptImages: ["nonexistent/*"]
+    exemptImages: ["safeimages.com/*"]

--- a/library/pod-security-policy/allow-privilege-escalation/samples/psp-allow-privilege-escalation-container/example_allowed_exempt.yaml
+++ b/library/pod-security-policy/allow-privilege-escalation/samples/psp-allow-privilege-escalation-container/example_allowed_exempt.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-privilege-escalation-disallowed
+  labels:
+    app: nginx-privilege-escalation
+spec:
+  containers:
+  - name: nginx
+    image: "safeimages.com/nginx"
+    securityContext:
+      allowPrivilegeEscalation: true

--- a/library/pod-security-policy/allow-privilege-escalation/suite.yaml
+++ b/library/pod-security-policy/allow-privilege-escalation/suite.yaml
@@ -23,3 +23,7 @@ tests:
         object: samples/psp-allow-privilege-escalation-container/update.yaml
         assertions:
           - violations: no
+      - name: exempted-path
+        object: samples/psp-allow-privilege-escalation-container/example_allowed_exempt.yaml
+        assertions:
+          - violations: no

--- a/website/docs/validation/allow-privilege-escalation.md
+++ b/website/docs/validation/allow-privilege-escalation.md
@@ -173,7 +173,7 @@ spec:
       - apiGroups: [""]
         kinds: ["Pod"]
   parameters:
-    exemptImages: ["nonexistent/*"]
+    exemptImages: ["safeimages.com/*"]
 
 ```
 
@@ -260,6 +260,32 @@ Usage
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/allow-privilege-escalation/samples/psp-allow-privilege-escalation-container/disallowed_ephemeral.yaml
+```
+
+</details>
+<details>
+<summary>exempted-path</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-privilege-escalation-disallowed
+  labels:
+    app: nginx-privilege-escalation
+spec:
+  containers:
+  - name: nginx
+    image: "safeimages.com/nginx"
+    securityContext:
+      allowPrivilegeEscalation: true
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/allow-privilege-escalation/samples/psp-allow-privilege-escalation-container/example_allowed_exempt.yaml
 ```
 
 </details>


### PR DESCRIPTION
I recently found (#584) that some K8sNativeValidation implementations of certain templates that iterate over and exempt containers by image had a bug preventing the exemption logic from working.

The k8spspallowprivilegeescalationcontainer turns out not to have this problem, as proved by the passing tests with the addition of an image exemption suite test.