### PR TITLE
chore: adding namespace quotas policy

### DIFF
--- a/artifacthub/library/general/requirednamespacequotas/1.0.0/artifacthub-pkg.yml
+++ b/artifacthub/library/general/requirednamespacequotas/1.0.0/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+version: 1.0.0
+name: requirednamespacequota
+displayName: Required Namespace Quota
+createdAt: "2025-03-06T09:31:37Z"
+description: Ensures that all namespaces have a ResourceQuota defined.
+digest: dbd1cfe29d0dfd3861731064ffe25eb18e11b602d5931bba4a3294cacae8fa57
+license: Apache-2.0
+homeURL: https://open-policy-agent.github.io/gatekeeper-library/website/requirednamespacequotas
+keywords:
+    - gatekeeper
+    - open-policy-agent
+    - policies
+readme: |-
+    # Required Namespace Quota
+    Ensures that all namespaces have a ResourceQuota defined.
+install: |-
+    ### Usage
+    ```shell
+    kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/artifacthub/library/general/requirednamespacequotas/1.0.0/template.yaml
+    ```
+provider:
+    name: Gatekeeper Library

--- a/artifacthub/library/general/requirednamespacequotas/1.0.0/kustomization.yaml
+++ b/artifacthub/library/general/requirednamespacequotas/1.0.0/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/artifacthub/library/general/requirednamespacequotas/1.0.0/samples/constraint.yaml
+++ b/artifacthub/library/general/requirednamespacequotas/1.0.0/samples/constraint.yaml
@@ -1,0 +1,12 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredNamespaceQuota
+metadata:
+  name: enforce-namespace-quota
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Namespace"]
+  enforcementAction: "warn"
+  parameters:
+    message: "Every namespace must have a ResourceQuota!"

--- a/artifacthub/library/general/requirednamespacequotas/1.0.0/samples/example_allowed.yaml
+++ b/artifacthub/library/general/requirednamespacequotas/1.0.0/samples/example_allowed.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: example-quota
+  namespace: example-namespace
+spec:
+  hard:
+    pods: "10"

--- a/artifacthub/library/general/requirednamespacequotas/1.0.0/samples/example_disallowed.yaml
+++ b/artifacthub/library/general/requirednamespacequotas/1.0.0/samples/example_disallowed.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace-no-quota

--- a/artifacthub/library/general/requirednamespacequotas/1.0.0/samples/example_update_allowed.yaml
+++ b/artifacthub/library/general/requirednamespacequotas/1.0.0/samples/example_update_allowed.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace-updated-with-quota
+  labels:
+    environment: "production"
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: updated-quota
+  namespace: example-namespace-updated-with-quota
+spec:
+  hard:
+    pods: "20"

--- a/artifacthub/library/general/requirednamespacequotas/1.0.0/samples/example_update_disallowed.yaml
+++ b/artifacthub/library/general/requirednamespacequotas/1.0.0/samples/example_update_disallowed.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace-updated-no-quota
+  labels:
+    environment: "test"

--- a/artifacthub/library/general/requirednamespacequotas/1.0.0/suite.yaml
+++ b/artifacthub/library/general/requirednamespacequotas/1.0.0/suite.yaml
@@ -1,0 +1,25 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: requirednamespacequota
+tests:
+- name: required-namespace-quota
+  template: template.yaml
+  constraint: samples/constraint.yaml
+  cases:
+  - name: allowed
+    object: samples/example_allowed.yaml
+    assertions:
+    - violations: no
+  - name: disallowed
+    object: samples/example_disallowed.yaml
+    assertions:
+    - violations: yes
+  - name: update_allowed
+    object: samples/example_update_allowed.yaml
+    assertions:
+    - violations: no
+  - name: update_disallowed
+    object: samples/example_update_disallowed.yaml
+    assertions:
+    - violations: yes

--- a/artifacthub/library/general/requirednamespacequotas/1.0.0/template.yaml
+++ b/artifacthub/library/general/requirednamespacequotas/1.0.0/template.yaml
@@ -1,0 +1,41 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: requirednamespacequota
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Namespace Quota"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Ensures that all namespaces have a ResourceQuota defined.
+spec:
+  crd:
+    spec:
+      names:
+        kind: RequiredNamespaceQuota
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package requirednamespacequota
+
+        import rego.v1
+
+        # Enforce that every namespace must have a ResourceQuota
+        violation[{"msg": msg}] if {
+            input.review.kind.kind == "Namespace"
+            ns := input.review.object.metadata.name
+            not has_quota
+            msg := sprintf("Namespace %v must have a ResourceQuota", [ns])
+        }
+
+        # Check if a namespace has a ResourceQuota
+        has_quota if {
+            some quota in input.review.related
+            quota.kind == "ResourceQuota"
+            quota.metadata.namespace == input.review.object.metadata.name
+        }

--- a/library/general/requirednamespacequotas/kustomization.yaml
+++ b/library/general/requirednamespacequotas/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/requirednamespacequotas/samples/constraint.yaml
+++ b/library/general/requirednamespacequotas/samples/constraint.yaml
@@ -1,0 +1,12 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredNamespaceQuota
+metadata:
+  name: enforce-namespace-quota
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Namespace"]
+  enforcementAction: "warn"
+  parameters:
+    message: "Every namespace must have a ResourceQuota!"

--- a/library/general/requirednamespacequotas/samples/example_allowed.yaml
+++ b/library/general/requirednamespacequotas/samples/example_allowed.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: example-quota
+  namespace: example-namespace
+spec:
+  hard:
+    pods: "10"

--- a/library/general/requirednamespacequotas/samples/example_disallowed.yaml
+++ b/library/general/requirednamespacequotas/samples/example_disallowed.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace-no-quota

--- a/library/general/requirednamespacequotas/samples/example_update_allowed.yaml
+++ b/library/general/requirednamespacequotas/samples/example_update_allowed.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace-updated-with-quota
+  labels:
+    environment: "production"
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: updated-quota
+  namespace: example-namespace-updated-with-quota
+spec:
+  hard:
+    pods: "20"

--- a/library/general/requirednamespacequotas/samples/example_update_disallowed.yaml
+++ b/library/general/requirednamespacequotas/samples/example_update_disallowed.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace-updated-no-quota
+  labels:
+    environment: "test"

--- a/library/general/requirednamespacequotas/suite.yaml
+++ b/library/general/requirednamespacequotas/suite.yaml
@@ -1,0 +1,25 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: requirednamespacequota
+tests:
+- name: required-namespace-quota
+  template: template.yaml
+  constraint: samples/constraint.yaml
+  cases:
+  - name: allowed
+    object: samples/example_allowed.yaml
+    assertions:
+    - violations: no
+  - name: disallowed
+    object: samples/example_disallowed.yaml
+    assertions:
+    - violations: yes
+  - name: update_allowed
+    object: samples/example_update_allowed.yaml
+    assertions:
+    - violations: no
+  - name: update_disallowed
+    object: samples/example_update_disallowed.yaml
+    assertions:
+    - violations: yes

--- a/library/general/requirednamespacequotas/template.yaml
+++ b/library/general/requirednamespacequotas/template.yaml
@@ -1,0 +1,41 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: requirednamespacequota
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Namespace Quota"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Ensures that all namespaces have a ResourceQuota defined.
+spec:
+  crd:
+    spec:
+      names:
+        kind: RequiredNamespaceQuota
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package requirednamespacequota
+
+        import rego.v1
+
+        # Enforce that every namespace must have a ResourceQuota
+        violation[{"msg": msg}] if {
+            input.review.kind.kind == "Namespace"
+            ns := input.review.object.metadata.name
+            not has_quota
+            msg := sprintf("Namespace %v must have a ResourceQuota", [ns])
+        }
+
+        # Check if a namespace has a ResourceQuota
+        has_quota if {
+            some quota in input.review.related
+            quota.kind == "ResourceQuota"
+            quota.metadata.namespace == input.review.object.metadata.name
+        }

--- a/src/general/requirednamespacequotas/constraint.tmpl
+++ b/src/general/requirednamespacequotas/constraint.tmpl
@@ -1,0 +1,24 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: requirednamespacequota
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Namespace Quota"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Ensures that all namespaces have a ResourceQuota defined.
+spec:
+  crd:
+    spec:
+      names:
+        kind: RequiredNamespaceQuota
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/requirednamespacequotas/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/general/requirednamespacequotas/src.rego
+++ b/src/general/requirednamespacequotas/src.rego
@@ -1,0 +1,18 @@
+package requirednamespacequota
+
+import rego.v1
+
+# Enforce that every namespace must have a ResourceQuota
+violation[{"msg": msg}] if {
+    input.review.kind.kind == "Namespace"
+    ns := input.review.object.metadata.name
+    not has_quota
+    msg := sprintf("Namespace %v must have a ResourceQuota", [ns])
+}
+
+# Check if a namespace has a ResourceQuota
+has_quota if {
+    some quota in input.review.related
+    quota.kind == "ResourceQuota"
+    quota.metadata.namespace == input.review.object.metadata.name
+}

--- a/src/general/requirednamespacequotas/src_test.rego
+++ b/src/general/requirednamespacequotas/src_test.rego
@@ -1,0 +1,35 @@
+package requirednamespacequota
+
+import rego.v1
+
+# ✅ Test Case 1: Namespace has a ResourceQuota (should NOT violate)
+test_namespace_with_quota if{
+    test_input := {
+        "review": {
+            "kind": { "kind": "Namespace" },
+            "object": { "metadata": { "name": "test-namespace" } },
+            "related": [
+                {
+                    "kind": "ResourceQuota",
+                    "metadata": { "namespace": "test-namespace" }
+                }
+            ]
+        }
+    }
+    
+    count(violation) == 0 with input as test_input
+}
+
+# ❌ Test Case 2: Namespace without a ResourceQuota (should violate)
+test_namespace_without_quota if{
+    test_input := {
+        "review": {
+            "kind": { "kind": "Namespace" },
+            "object": { "metadata": { "name": "test-namespace" } },
+            "related": []
+        }
+    }
+    
+    count(violation) > 0 with input as test_input
+}
+

--- a/website/docs/validation/requirednamespacequotas.md
+++ b/website/docs/validation/requirednamespacequotas.md
@@ -1,0 +1,188 @@
+---
+id: requirednamespacequotas
+title: Required Namespace Quota
+---
+
+# Required Namespace Quota
+
+## Description
+Ensures that all namespaces have a ResourceQuota defined.
+
+## Template
+```yaml
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: requirednamespacequota
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Namespace Quota"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Ensures that all namespaces have a ResourceQuota defined.
+spec:
+  crd:
+    spec:
+      names:
+        kind: RequiredNamespaceQuota
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package requirednamespacequota
+
+        import rego.v1
+
+        # Enforce that every namespace must have a ResourceQuota
+        violation[{"msg": msg}] if {
+            input.review.kind.kind == "Namespace"
+            ns := input.review.object.metadata.name
+            not has_quota
+            msg := sprintf("Namespace %v must have a ResourceQuota", [ns])
+        }
+
+        # Check if a namespace has a ResourceQuota
+        has_quota if {
+            some quota in input.review.related
+            quota.kind == "ResourceQuota"
+            quota.metadata.namespace == input.review.object.metadata.name
+        }
+
+```
+
+### Usage
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/requirednamespacequotas/template.yaml
+```
+## Examples
+<details>
+<summary>required-namespace-quota</summary>
+
+<details>
+<summary>constraint</summary>
+
+```yaml
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredNamespaceQuota
+metadata:
+  name: enforce-namespace-quota
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Namespace"]
+  enforcementAction: "warn"
+  parameters:
+    message: "Every namespace must have a ResourceQuota!"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/requirednamespacequotas/samples/constraint.yaml
+```
+
+</details>
+
+<details>
+<summary>allowed</summary>
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: example-quota
+  namespace: example-namespace
+spec:
+  hard:
+    pods: "10"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/requirednamespacequotas/samples/example_allowed.yaml
+```
+
+</details>
+<details>
+<summary>disallowed</summary>
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace-no-quota
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/requirednamespacequotas/samples/example_disallowed.yaml
+```
+
+</details>
+<details>
+<summary>update_allowed</summary>
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace-updated-with-quota
+  labels:
+    environment: "production"
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: updated-quota
+  namespace: example-namespace-updated-with-quota
+spec:
+  hard:
+    pods: "20"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/requirednamespacequotas/samples/example_update_allowed.yaml
+```
+
+</details>
+<details>
+<summary>update_disallowed</summary>
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace-updated-no-quota
+  labels:
+    environment: "test"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/requirednamespacequotas/samples/example_update_disallowed.yaml
+```
+
+</details>
+
+
+</details>

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -43,6 +43,7 @@ module.exports = {
             'validation/replicalimits',
             'validation/requiredannotations',
             'validation/requiredlabels',
+            'validation/requirednamespacequotas',
             'validation/requiredprobes',
             'validation/storageclass',
             'validation/uniqueingresshost',


### PR DESCRIPTION
**What this PR does / why we need it**:

Implementing a required ResourceQuota policy on namespaces to enforce setting ResourceQuotas for better overall resource control. This is a general purpose policy, which we didn't find in the actual library, but may be handy for others to use.

**Which issue(s) does this PR fix** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Library policies?**
Please refer to [How to contribute to the library](https://open-policy-agent.github.io/gatekeeper-library/website/#how-to-contribute-to-the-library) to add new policies or update existing policies.

**Are you updating an existing policy?**
Please run `make generate generate-website-docs generate-artifacthub-artifacts` to generate the templates and docs.
-->

**Special notes for your reviewer**:
