### PR TITLE
Rego v1 and Regal compliance

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,0 +1,42 @@
+rules:
+  custom:
+    prefer-value-in-head:
+      level: error
+      only-scalars: true
+  idiomatic:
+    directory-package-mismatch:
+      level: ignore
+    no-defined-entrypoint:
+      level: ignore
+  imports:
+    prefer-package-imports:
+      level: ignore
+  style:
+    avoid-get-and-list-prefix:
+      level: ignore
+    external-reference:
+      level: ignore
+    file-length:
+      ignore:
+        files:
+          - "*_test.rego"
+    line-length:
+      ignore:
+        files:
+          - "*_test.rego"
+      non-breakable-word-threshold: 80
+    prefer-snake-case:
+      ignore:
+        files:
+          - "*_test.rego"
+  testing:
+    print-or-trace-call:
+      level: ignore
+    test-outside-test-package:
+      level: ignore
+
+ignore:
+  files:
+    - src/general
+    - src/pod-security-policy
+    - src/rego

--- a/src/v1/general/allowedrepos/constraint.tmpl
+++ b/src/v1/general/allowedrepos/constraint.tmpl
@@ -1,0 +1,30 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sallowedrepos
+  annotations:
+    metadata.gatekeeper.sh/title: "Allowed Repositories"
+    metadata.gatekeeper.sh/version: 1.0.2
+    description: >-
+      Requires container images to begin with a string from the specified list.
+      To prevent bypasses, ensure a '/' is added when specifying DockerHub repositories or custom registries.
+      If exact matches or glob-like syntax are preferred, use the k8sallowedreposv2 policy.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAllowedRepos
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            repos:
+              description: The list of prefixes a container image is allowed to have.
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/allowedrepos/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/allowedrepos/src.rego
+++ b/src/v1/general/allowedrepos/src.rego
@@ -1,0 +1,14 @@
+package k8sallowedrepos
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+	not strings.any_prefix_match(container.image, input.parameters.repos)
+
+	msg := sprintf(
+		"%s <%v> has an invalid image repo <%v>, allowed repos are %v",
+		[trim_suffix(type, "s"), container.name, container.image, input.parameters.repos],
+	)
+}

--- a/src/v1/general/allowedrepos/src_test.rego
+++ b/src/v1/general/allowedrepos/src_test.rego
@@ -1,0 +1,130 @@
+package k8sallowedrepos
+
+import rego.v1
+
+test_input_allowed_container if {
+	inp := {"review": input_review(input_container_allowed), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_container_x2 if {
+	inp := {"review": input_review(input_container_allowed), "parameters": {"repos": ["other", "allowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_dual_container if {
+	inp := {"review": input_review(input_container_dual_allowed), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_denied_container if {
+	inp := {"review": input_review(input_container_denied), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_container_x2 if {
+	inp := {"review": input_review(input_container_denied), "parameters": {"repos": ["other", "allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_dual_container if {
+	inp := {"review": input_review(input_container_dual_denied), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_denied_mixed_container if {
+	inp := {"review": input_review(array.concat(input_container_allowed, input_container_denied)), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+# init containers
+test_init_container_input_allowed_container if {
+	inp := {"review": input_init_review(input_container_allowed), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_allowed_container_x2 if {
+	inp := {"review": input_init_review(input_container_allowed), "parameters": {"repos": ["other", "allowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_allowed_dual_container if {
+	inp := {"review": input_init_review(input_container_dual_allowed), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_denied_container if {
+	inp := {"review": input_init_review(input_container_denied), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_denied_container_x2 if {
+	inp := {"review": input_init_review(input_container_denied), "parameters": {"repos": ["other", "allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_denied_dual_container if {
+	inp := {"review": input_init_review(input_container_dual_denied), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_init_container_input_denied_mixed_container if {
+	inp := {"review": input_init_review(array.concat(input_container_allowed, input_container_denied)), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+input_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers},
+}}
+
+input_init_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"initContainers": containers},
+}}
+
+input_container_allowed := [{
+	"name": "nginx",
+	"image": "allowed/nginx",
+}]
+
+input_container_denied := [{
+	"name": "nginx",
+	"image": "denied/nginx",
+}]
+
+input_container_dual_allowed := [
+	{
+		"name": "nginx",
+		"image": "allowed/nginx",
+	},
+	{
+		"name": "other",
+		"image": "allowed/other",
+	},
+]
+
+input_container_dual_denied := [
+	{
+		"name": "nginx",
+		"image": "denied/nginx",
+	},
+	{
+		"name": "other",
+		"image": "denied/other",
+	},
+]

--- a/src/v1/general/allowedreposv2/constraint.tmpl
+++ b/src/v1/general/allowedreposv2/constraint.tmpl
@@ -1,0 +1,32 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sallowedreposv2
+  annotations:
+    metadata.gatekeeper.sh/title: "Allowed Images"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      This policy enforces that container images must begin with a string from a specified list.
+      The updated version, K8sAllowedReposv2, introduces support for exact match and glob-like syntax to enhance security:
+      1. Exact Match: By default, if the * character is not specified, the policy strictly checks for an exact match of the full registry, repository, and/or the image name.
+      2. Glob-like Syntax: Adding * at the end of a prefix allows prefix-based matching (e.g., registry.example.com/project/*). Only the * wildcard at the end of a string is supported.
+      3. Security Note: To avoid bypasses scenarios, ensure prefixes include a trailing / where appropriate (e.g., registry.example.com/project/*).
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAllowedReposv2
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedImages:
+              description: A list of allowed container image prefixes. Supports exact matches and prefixes ending with '*'.
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/allowedreposv2/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/allowedreposv2/src.rego
+++ b/src/v1/general/allowedreposv2/src.rego
@@ -1,0 +1,27 @@
+package k8sallowedreposv2
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+	not image_matches(container.image, input.parameters.allowedImages)
+
+	msg := sprintf(
+		"%s <%v> has an invalid image <%v>, allowed images are %v",
+		[trim_suffix(type, "s"), container.name, container.image, input.parameters.allowedImages],
+	)
+}
+
+image_matches(image, images) if {
+	some i_image in images # Iterate through all images in the allowed list
+	not endswith(i_image, "*") # Check for exact match if the image does not end with *
+	i_image == image
+}
+
+image_matches(image, images) if {
+	some i_image in images # Iterate through all images in the allowed list
+	endswith(i_image, "*") # Check for prefix match if the image ends with *
+	prefix := trim_suffix(i_image, "*")
+	startswith(image, prefix)
+}

--- a/src/v1/general/allowedreposv2/src_test.rego
+++ b/src/v1/general/allowedreposv2/src_test.rego
@@ -1,0 +1,130 @@
+package k8sallowedreposv2
+
+import rego.v1
+
+test_input_allowed_container if {
+	inp := {"review": input_review(input_container_allowed), "parameters": {"allowedImages": ["allowed/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_container_x2 if {
+	inp := {"review": input_review(input_container_allowed), "parameters": {"allowedImages": ["other", "allowed/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_dual_container if {
+	inp := {"review": input_review(input_container_dual_allowed), "parameters": {"allowedImages": ["allowed/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_denied_container if {
+	inp := {"review": input_review(input_container_denied), "parameters": {"allowedImages": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_container_x2 if {
+	inp := {"review": input_review(input_container_denied), "parameters": {"allowedImages": ["other", "allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_dual_container if {
+	inp := {"review": input_review(input_container_dual_denied), "parameters": {"allowedImages": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_denied_mixed_container if {
+	inp := {"review": input_review(array.concat(input_container_allowed, input_container_denied)), "parameters": {"allowedImages": ["allowed/nginx*"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+# init containers
+test_init_container_input_allowed_container if {
+	inp := {"review": input_init_review(input_container_allowed), "parameters": {"allowedImages": ["allowed/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_allowed_container_x2 if {
+	inp := {"review": input_init_review(input_container_allowed), "parameters": {"allowedImages": ["other", "allowed/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_allowed_dual_container if {
+	inp := {"review": input_init_review(input_container_dual_allowed), "parameters": {"allowedImages": ["allowed/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_denied_container if {
+	inp := {"review": input_init_review(input_container_denied), "parameters": {"allowedImages": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_denied_container_x2 if {
+	inp := {"review": input_init_review(input_container_denied), "parameters": {"allowedImages": ["other", "allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_denied_dual_container if {
+	inp := {"review": input_init_review(input_container_dual_denied), "parameters": {"allowedImages": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_init_container_input_denied_mixed_container if {
+	inp := {"review": input_init_review(array.concat(input_container_allowed, input_container_denied)), "parameters": {"allowedImages": ["allowed/nginx"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+input_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers},
+}}
+
+input_init_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"initContainers": containers},
+}}
+
+input_container_allowed := [{
+	"name": "nginx",
+	"image": "allowed/nginx",
+}]
+
+input_container_denied := [{
+	"name": "nginx",
+	"image": "denied/nginx",
+}]
+
+input_container_dual_allowed := [
+	{
+		"name": "nginx",
+		"image": "allowed/nginx",
+	},
+	{
+		"name": "other",
+		"image": "allowed/other",
+	},
+]
+
+input_container_dual_denied := [
+	{
+		"name": "nginx",
+		"image": "denied/nginx",
+	},
+	{
+		"name": "other",
+		"image": "denied/other",
+	},
+]

--- a/src/v1/general/automount-serviceaccount-token/constraint.tmpl
+++ b/src/v1/general/automount-serviceaccount-token/constraint.tmpl
@@ -1,0 +1,26 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspautomountserviceaccounttokenpod
+  annotations:
+    metadata.gatekeeper.sh/title: "Automount Service Account Token for Pod"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Controls the ability of any Pod to enable automountServiceAccountToken.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPAutomountServiceAccountTokenPod
+      validation:
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls the ability of any Pod to enable automountServiceAccountToken.
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/automount-serviceaccount-token/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/general/automount-serviceaccount-token/lib_exclude_update.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/automount-serviceaccount-token/lib_exclude_update.rego
+++ b/src/v1/general/automount-serviceaccount-token/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/general/automount-serviceaccount-token/src.rego
+++ b/src/v1/general/automount-serviceaccount-token/src.rego
@@ -1,0 +1,28 @@
+package k8sautomountserviceaccounttoken
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+
+violation contains {"msg": msg} if {
+	# spec.automountServiceAccountToken and spec.containers.volumeMounts fields are immutable.
+	not is_update(input.review)
+	mount_service_account_token(input.review.object.spec)
+
+	msg := sprintf("Automounting service account token is disallowed, pod: %v", [input.review.object.metadata.name])
+}
+
+mount_service_account_token(spec) if spec.automountServiceAccountToken == true
+
+# if there is no automountServiceAccountToken spec, check on volumeMount in containers. Service Account token is
+# mounted on /var/run/secrets/kubernetes.io/serviceaccount
+# https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#serviceaccount-admission-controller
+mount_service_account_token(spec) if {
+	not "automountServiceAccountToken" in object.keys(spec)
+
+	# Ephemeral containers not checked as it is not possible to set field.
+	some type in ["containers", "initContainers"]
+	some container in input.review.object.spec[type]
+
+	"/var/run/secrets/kubernetes.io/serviceaccount" == container.volumeMounts[_].mountPath
+}

--- a/src/v1/general/automount-serviceaccount-token/src_test.rego
+++ b/src/v1/general/automount-serviceaccount-token/src_test.rego
@@ -1,0 +1,62 @@
+package k8sautomountserviceaccounttoken
+
+import rego.v1
+
+test_input_pod_not_automountserviceaccounttoken_allowed if {
+	inp := {"review": input_review_disabled_automountserviceaccounttoken}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_pod_automountserviceaccounttoken_not_allowed if {
+	inp := {"review": input_review_enabled_automountserviceaccounttoken}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_pod_automountserviceaccounttoken_not_defined if {
+	inp := {"review": input_review_no_automountserviceaccounttoken_defined_and_enabled_volumemount}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_update if {
+	inp := {"review": object.union(input_review_enabled_automountserviceaccounttoken, {"operation": "UPDATE"})}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review_disabled_automountserviceaccounttoken := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"automountServiceAccountToken": false,
+		"containers": input_containers_one,
+	},
+}}
+
+input_review_enabled_automountserviceaccounttoken := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"automountServiceAccountToken": true,
+		"containers": input_containers_one,
+	},
+}}
+
+input_review_no_automountserviceaccounttoken_defined_and_enabled_volumemount := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_volumemount},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "nginx",
+}]
+
+input_containers_volumemount := [{
+	"name": "nginx",
+	"image": "nginx",
+	"volumeMounts": [{
+		"name": "serviceaccount-vm",
+		"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+	}],
+}]

--- a/src/v1/general/block-endpoint-edit-default-role/constraint.tmpl
+++ b/src/v1/general/block-endpoint-edit-default-role/constraint.tmpl
@@ -1,0 +1,26 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblockendpointeditdefaultrole
+  annotations:
+    metadata.gatekeeper.sh/title: "Block Endpoint Edit Default Role"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Many Kubernetes installations by default have a system:aggregate-to-edit
+      ClusterRole which does not properly restrict access to editing Endpoints.
+      This ConstraintTemplate forbids the system:aggregate-to-edit ClusterRole
+      from granting permission to create/patch/update Endpoints.
+
+      ClusterRole/system:aggregate-to-edit should not allow
+      Endpoint edit permissions due to CVE-2021-25740, Endpoint & EndpointSlice
+      permissions allow cross-Namespace forwarding,
+      https://github.com/kubernetes/kubernetes/issues/103675
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockEndpointEditDefaultRole
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/block-endpoint-edit-default-role/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/block-endpoint-edit-default-role/src.rego
+++ b/src/v1/general/block-endpoint-edit-default-role/src.rego
@@ -1,0 +1,23 @@
+package k8sblockendpointeditdefaultrole
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	input.review.object.metadata.name == "system:aggregate-to-edit"
+	some rule in input.review.object.rules
+	endpoint_rule(rule)
+
+	# regal ignore:line-length
+	msg := "ClusterRole system:aggregate-to-edit should not allow endpoint edit permissions. For k8s version < 1.22, the Cluster Role should be annotated with rbac.authorization.kubernetes.io/autoupdate=false to prevent autoreconciliation back to default permissions for this role."
+}
+
+endpoint_rule(rule) if {
+	"endpoints" in rule.resources
+	has_edit_verb(rule.verbs)
+}
+
+has_edit_verb(verbs) if "create" in verbs
+
+has_edit_verb(verbs) if "patch" in verbs
+
+has_edit_verb(verbs) if "update" in verbs

--- a/src/v1/general/block-endpoint-edit-default-role/src_test.rego
+++ b/src/v1/general/block-endpoint-edit-default-role/src_test.rego
@@ -1,0 +1,94 @@
+package k8sblockendpointeditdefaultrole
+
+import rego.v1
+
+test_input_no_endpoints_edit_role_allow if {
+	inp := {"review": input_review_withoutendpoints}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_endpoints_create_role_not_allow if {
+	inp := {"review": input_review_with_endpoints_create}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_endpoints_update_role_not_allow if {
+	inp := {"review": input_review_with_endpoints_update}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_endpoints_patch_role_not_allow if {
+	inp := {"review": input_review_with_endpoints_patch}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_endpoints_delete_role_allow if {
+	inp := {"review": input_review_with_endpoints_delete}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review_withoutendpoints := {"object": {
+	"metadata": {
+		"annotations": {"rbac.authorization.kubernetes.io/autoupdate": "false"},
+		"name": "system:aggregate-to-edit",
+	},
+	"rules": [
+		input_rule(["pods"], ["create"]),
+		input_rule(["services"], ["delete"]),
+	],
+}}
+
+input_review_with_endpoints_create := {"object": {
+	"metadata": {
+		"annotations": {"rbac.authorization.kubernetes.io/autoupdate": "false"},
+		"name": "system:aggregate-to-edit",
+	},
+	"rules": [
+		input_rule(["pods", "endpoints"], ["create"]),
+		input_rule(["services"], ["delete"]),
+	],
+}}
+
+input_review_with_endpoints_update := {"object": {
+	"metadata": {
+		"annotations": {"rbac.authorization.kubernetes.io/autoupdate": "false"},
+		"name": "system:aggregate-to-edit",
+	},
+	"rules": [
+		input_rule(["pods", "endpoints"], ["update"]),
+		input_rule(["services"], ["delete"]),
+	],
+}}
+
+input_review_with_endpoints_patch := {"object": {
+	"metadata": {
+		"annotations": {"rbac.authorization.kubernetes.io/autoupdate": "false"},
+		"name": "system:aggregate-to-edit",
+	},
+	"rules": [
+		input_rule(["pods", "endpoints"], ["patch"]),
+		input_rule(["services"], ["delete"]),
+	],
+}}
+
+input_review_with_endpoints_delete := {"object": {
+	"metadata": {
+		"annotations": {"rbac.authorization.kubernetes.io/autoupdate": "false"},
+		"name": "system:aggregate-to-edit",
+	},
+	"rules": [
+		input_rule(["pods"], ["create"]),
+		input_rule(["services", "endpoints"], ["delete"]),
+	],
+}}
+
+input_rule(resources, verbs) := {
+	"apiGroups": [""],
+	"resources": resources,
+	"verbs": verbs,
+}

--- a/src/v1/general/block-loadbalancer-services/constraint.tmpl
+++ b/src/v1/general/block-loadbalancer-services/constraint.tmpl
@@ -1,0 +1,20 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblockloadbalancer
+  annotations:
+    metadata.gatekeeper.sh/title: "Block Services with type LoadBalancer"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Disallows all Services with type LoadBalancer.
+
+      https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockLoadBalancer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/block-loadbalancer-services/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/block-loadbalancer-services/src.rego
+++ b/src/v1/general/block-loadbalancer-services/src.rego
@@ -1,0 +1,9 @@
+package k8sblockloadbalancer
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	input.review.kind.kind == "Service"
+	input.review.object.spec.type == "LoadBalancer"
+	msg := "User is not allowed to create service of type LoadBalancer"
+}

--- a/src/v1/general/block-loadbalancer-services/src_test.rego
+++ b/src/v1/general/block-loadbalancer-services/src_test.rego
@@ -1,0 +1,35 @@
+package k8sblockloadbalancer
+
+import rego.v1
+
+test_block_load_balancer if {
+	inp := {"review": {
+		"kind": {"kind": "Service"},
+		"object": {
+			"spec": {"type": "LoadBalancer"},
+			"ports": {
+				"protocol": "TCP",
+				"port": 80,
+				"targetPort": 80,
+			},
+		},
+	}}
+	result := violation with input as inp
+	count(result) == 1
+}
+
+test_allow_other_service_types if {
+	inp := {"review": {
+		"kind": {"kind": "Service"},
+		"object": {
+			"spec": {"type": "NodePort"},
+			"ports": {
+				"port": 80,
+				"targetPort": 9376,
+				"nodePort": 30007,
+			},
+		},
+	}}
+	result := violation with input as inp
+	count(result) == 0
+}

--- a/src/v1/general/block-nodeport-services/constraint.tmpl
+++ b/src/v1/general/block-nodeport-services/constraint.tmpl
@@ -1,0 +1,20 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblocknodeport
+  annotations:
+    metadata.gatekeeper.sh/title: "Block NodePort"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Disallows all Services with type NodePort.
+
+      https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockNodePort
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/block-nodeport-services/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/block-nodeport-services/src.rego
+++ b/src/v1/general/block-nodeport-services/src.rego
@@ -1,0 +1,9 @@
+package k8sblocknodeport
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	input.review.kind.kind == "Service"
+	input.review.object.spec.type == "NodePort"
+	msg := "User is not allowed to create service of type NodePort"
+}

--- a/src/v1/general/block-nodeport-services/src_test.rego
+++ b/src/v1/general/block-nodeport-services/src_test.rego
@@ -1,0 +1,35 @@
+package k8sblocknodeport
+
+import rego.v1
+
+test_block_node_port if {
+	inp := {"review": {
+		"kind": {"kind": "Service"},
+		"object": {
+			"spec": {"type": "NodePort"},
+			"ports": {
+				"port": 80,
+				"targetPort": 80,
+				"nodePort": 30007,
+			},
+		},
+	}}
+	result := violation with input as inp
+	count(result) == 1
+}
+
+test_allow_other_service_types if {
+	inp := {"review": {
+		"kind": {"kind": "Service"},
+		"object": {
+			"spec": {"type": "LoadBalancer"},
+			"ports": {
+				"protocol": "TCP",
+				"port": 80,
+				"targetPort": 9376,
+			},
+		},
+	}}
+	result := violation with input as inp
+	count(result) == 0
+}

--- a/src/v1/general/block-wildcard-ingress/constraint.tmpl
+++ b/src/v1/general/block-wildcard-ingress/constraint.tmpl
@@ -1,0 +1,18 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblockwildcardingress
+  annotations:
+    metadata.gatekeeper.sh/title: "Block Wildcard Ingress"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Users should not be able to create Ingresses with a blank or wildcard (*) hostname since that would enable them to intercept traffic for other services in the cluster, even if they don't have access to those services.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockWildcardIngress
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/block-wildcard-ingress/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/block-wildcard-ingress/src.rego
+++ b/src/v1/general/block-wildcard-ingress/src.rego
@@ -1,0 +1,23 @@
+# regal ignore:prefer-snake-case
+package K8sBlockWildcardIngress
+
+import rego.v1
+
+contains_wildcard("")
+
+contains_wildcard(hostname) if contains(hostname, "*")
+
+violation contains {"msg": msg} if {
+	input.review.kind.kind == "Ingress"
+
+	some rule in input.review.object.spec.rules
+
+	# object.get is required to detect omitted host fields
+	hostname := object.get(rule, "host", "")
+	contains_wildcard(hostname)
+	msg := sprintf(
+		# regal ignore:line-length
+		"Hostname '%v' is not allowed since it counts as a wildcard, which can be used to intercept traffic from other applications.",
+		[hostname],
+	)
+}

--- a/src/v1/general/block-wildcard-ingress/src_test.rego
+++ b/src/v1/general/block-wildcard-ingress/src_test.rego
@@ -1,0 +1,43 @@
+package K8sBlockWildcardIngress
+
+import rego.v1
+
+test_input_ingress_allowed_host if {
+	inp := {"review": input_review(input_ingress_allowed_host)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_ingress_disallowed_wildcard_host if {
+	inp := {"review": input_review(input_ingress_disallowed_wildcard_host)}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_ingress_disallowed_empty_host if {
+	inp := {"review": input_review(input_ingress_disallowed_empty_host)}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_ingress_no_rules if {
+	inp := {"review": input_review(input_ingress_no_rules)}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+input_review(rules) := {
+	"kind": {"kind": "Ingress"},
+	"object": {"spec": {"rules": rules}},
+}
+
+input_ingress_allowed_host := [{"host": "foo.bar.com"}]
+
+input_ingress_disallowed_wildcard_host := [
+	{"host": "foo.bar.com"},
+	{"host": "*.foo.com"},
+]
+
+input_ingress_disallowed_empty_host := [{"host": ""}]
+
+input_ingress_no_rules := [{}]

--- a/src/v1/general/containerlimits/constraint.tmpl
+++ b/src/v1/general/containerlimits/constraint.tmpl
@@ -1,0 +1,45 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8scontainerlimits
+  annotations:
+    metadata.gatekeeper.sh/title: "Container Limits"
+    metadata.gatekeeper.sh/version: 1.1.0
+    description: >-
+      Requires containers to have memory and CPU limits set and constrains
+      limits to be within the specified maximum values.
+
+      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sContainerLimits
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            cpu:
+              description: "The maximum allowed cpu limit on a Pod, exclusive. Set to -1 to disable."
+              type: string
+            memory:
+              description: "The maximum allowed memory limit on a Pod, exclusive."
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/containerlimits/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/general/containerlimits/lib_exempt_container.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/containerlimits/lib_exempt_container.rego
+++ b/src/v1/general/containerlimits/lib_exempt_container.rego
@@ -1,0 +1,20 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
+	some exemption in exempt_images
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/general/containerlimits/src_test.rego
+++ b/src/v1/general/containerlimits/src_test.rego
@@ -1,0 +1,242 @@
+package k8scontainerlimits
+
+import rego.v1
+
+test_input_no_violations_int if {
+	inp := {"review": review([ctr("a", 10, 20)]), "parameters": {"memory": 20, "cpu": 40}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_str if {
+	inp := {"review": review([ctr("a", "10", "20")]), "parameters": {"memory": "20", "cpu": "40"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_str_small if {
+	inp := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_cpu_scale if {
+	inp := {"review": review([ctr("a", "1", "2m")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_violations_int if {
+	inp := {"review": review([ctr("a", 10, 20)]), "parameters": {"memory": 5, "cpu": 10}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_violations_mem_int_v_str if {
+	inp := {"review": review([ctr("a", 10, "4")]), "parameters": {"memory": "1000m", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_str if {
+	inp := {"review": review([ctr("a", "10", "20")]), "parameters": {"memory": "5", "cpu": "10"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_violations_str_small if {
+	inp := {"review": review([ctr("a", "5", "6")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_violations_cpu_scale if {
+	inp := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "2", "cpu": "4m"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_parse_cpu if {
+	inp := {"review": review([ctr("a", "1", "212asdf")]), "parameters": {"memory": "2", "cpu": "4m"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_parse_cpu_skip if {
+	inp := {"review": review([ctr("a", "1", "212asdf")]), "parameters": {"memory": "2", "cpu": "-1"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_no_parse_ram if {
+	inp := {"review": review([ctr("a", "1asdf", "2")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_1_bad_cpu if {
+	inp := {"review": review([ctr("a", "1", "2"), ctr("b", "1", "8")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_2_bad_cpu if {
+	inp := {"review": review([ctr("a", "1", "9"), ctr("b", "1", "8")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_1_bad_ram if {
+	inp := {"review": review([ctr("a", "1", "2"), ctr("b", "8", "2")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_2_bad_ram if {
+	inp := {"review": review([ctr("a", "9", "2"), ctr("b", "8", "2")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_no_ram_limit if {
+	inp := {"review": review([{"name": "a", "resources": {"limits": {"cpu": 1}}}]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_cpu_limit if {
+	inp := {"review": review([{"name": "a", "resources": {"limits": {"memory": 1}}}]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_limit if {
+	inp := {"review": review([{"name": "a", "resources": {}}]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_resources if {
+	inp := {"review": review([{"name": "a"}]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_containers_checked if {
+	inp := {"review": init_review([ctr("a", "5", "5"), ctr("b", "5", "5")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 4
+}
+
+# MEM SCALE TESTS
+test_input_no_violations_mem_K if {
+	inp := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "1k", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_violations_mem_m if {
+	inp := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "1m", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_K if {
+	inp := {"review": review([ctr("a", "1k", "2")]), "parameters": {"memory": "1", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_M if {
+	inp := {"review": review([ctr("a", "1M", "2")]), "parameters": {"memory": "1k", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_G if {
+	inp := {"review": review([ctr("a", "1G", "2")]), "parameters": {"memory": "1M", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_T if {
+	inp := {"review": review([ctr("a", "1T", "2")]), "parameters": {"memory": "1G", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_P if {
+	inp := {"review": review([ctr("a", "1P", "2")]), "parameters": {"memory": "1T", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_E if {
+	inp := {"review": review([ctr("a", "1E", "2")]), "parameters": {"memory": "1P", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ki if {
+	inp := {"review": review([ctr("a", "1Ki", "2")]), "parameters": {"memory": "1", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Mi if {
+	inp := {"review": review([ctr("a", "1Mi", "2")]), "parameters": {"memory": "1Ki", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Gi if {
+	inp := {"review": review([ctr("a", "1Gi", "2")]), "parameters": {"memory": "1Mi", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_decimal_mem_Gi if {
+	inp := {"review": review([ctr("a", "1Gi", "2")]), "parameters": {"memory": "1.5Mi", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ti if {
+	inp := {"review": review([ctr("a", "1Ti", "2")]), "parameters": {"memory": "1Gi", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Pi if {
+	inp := {"review": review([ctr("a", "1Pi", "2")]), "parameters": {"memory": "1Ti", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ei if {
+	inp := {"review": review([ctr("a", "1Ei", "2")]), "parameters": {"memory": "1Pi", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ei_with_exemption if {
+	inp := {"review": review([ctr("a", "1Ei", "2")]), "parameters": {"exemptImages": ["nginx"], "memory": "1Pi", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers},
+}}
+
+init_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"initContainers": containers},
+}}
+
+ctr(name, mem, cpu) := {
+	"name": name,
+	"image": "nginx",
+	"resources": {"limits": {"memory": mem, "cpu": cpu}},
+}

--- a/src/v1/general/containerrequests/constraint.tmpl
+++ b/src/v1/general/containerrequests/constraint.tmpl
@@ -1,0 +1,45 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8scontainerrequests
+  annotations:
+    metadata.gatekeeper.sh/title: "Container Requests"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Requires containers to have memory and CPU requests set and constrains
+      requests to be within the specified maximum values.
+
+      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sContainerRequests
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            cpu:
+              description: "The maximum allowed cpu request on a Pod, exclusive."
+              type: string
+            memory:
+              description: "The maximum allowed memory request on a Pod, exclusive."
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/containerrequests/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/general/containerrequests/lib_exempt_container.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/containerrequests/lib_exempt_container.rego
+++ b/src/v1/general/containerrequests/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/general/containerrequests/src.rego
+++ b/src/v1/general/containerrequests/src.rego
@@ -1,0 +1,188 @@
+package k8scontainerrequests
+
+import rego.v1
+
+import data.lib.exempt_container.is_exempt
+
+missing(obj, field) if not obj[field]
+
+missing(obj, field) if obj[field] == ""
+
+canonify_cpu(orig) := orig * 1000 if is_number(orig)
+
+canonify_cpu(orig) := new if {
+	not is_number(orig)
+	endswith(orig, "m")
+	new := to_number(replace(orig, "m", ""))
+}
+
+canonify_cpu(orig) := new if {
+	not is_number(orig)
+	not endswith(orig, "m")
+	regex.match(`^[0-9]+(\.[0-9]+)?$`, orig)
+	new := to_number(orig) * 1000
+}
+
+# 10 ** 21
+mem_multiple("E") := 1000000000000000000000
+
+# 10 ** 18
+mem_multiple("P") := 1000000000000000000
+
+# 10 ** 15
+mem_multiple("T") := 1000000000000000
+
+# 10 ** 12
+mem_multiple("G") := 1000000000000
+
+# 10 ** 9
+mem_multiple("M") := 1000000000
+
+# 10 ** 6
+mem_multiple("k") := 1000000
+
+# 10 ** 3
+mem_multiple("") := 1000
+
+# Kubernetes accepts millibyte precision when it probably shouldn't.
+# https://github.com/kubernetes/kubernetes/issues/28741
+# 10 ** 0
+mem_multiple("m") := 1
+
+# 1000 * 2 ** 10
+mem_multiple("Ki") := 1024000
+
+# 1000 * 2 ** 20
+mem_multiple("Mi") := 1048576000
+
+# 1000 * 2 ** 30
+mem_multiple("Gi") := 1073741824000
+
+# 1000 * 2 ** 40
+mem_multiple("Ti") := 1099511627776000
+
+# 1000 * 2 ** 50
+mem_multiple("Pi") := 1125899906842624000
+
+# 1000 * 2 ** 60
+mem_multiple("Ei") := 1152921504606846976000
+
+get_suffix(mem) := "" if not is_string(mem)
+
+get_suffix(mem) := suffix if {
+	is_string(mem)
+	count(mem) > 0
+	suffix := substring(mem, count(mem) - 1, -1)
+	mem_multiple(suffix)
+}
+
+get_suffix(mem) := suffix if {
+	is_string(mem)
+	count(mem) > 1
+	suffix := substring(mem, count(mem) - 2, -1)
+	mem_multiple(suffix)
+}
+
+get_suffix(mem) := "" if {
+	is_string(mem)
+	count(mem) > 1
+	not mem_multiple(substring(mem, count(mem) - 1, -1))
+	not mem_multiple(substring(mem, count(mem) - 2, -1))
+}
+
+get_suffix(mem) := "" if {
+	is_string(mem)
+	count(mem) == 1
+	not mem_multiple(substring(mem, count(mem) - 1, -1))
+}
+
+get_suffix(mem) := "" if {
+	is_string(mem)
+	count(mem) == 0
+}
+
+canonify_mem(orig) := orig * 1000 if is_number(orig)
+
+canonify_mem(orig) := new if {
+	not is_number(orig)
+	suffix := get_suffix(orig)
+	raw := replace(orig, suffix, "")
+	regex.match(`^[0-9]+(\.[0-9]+)?$`, raw)
+	new := to_number(raw) * mem_multiple(suffix)
+}
+
+violation contains {"msg": msg} if {
+	general_violation[{"msg": msg, "field": "containers"}]
+}
+
+violation contains {"msg": msg} if {
+	general_violation[{"msg": msg, "field": "initContainers"}]
+}
+
+# Ephemeral containers not checked as it is not possible to set field.
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	cpu_orig := container.resources.requests.cpu
+	not canonify_cpu(cpu_orig)
+	msg := sprintf("container <%v> cpu request <%v> could not be parsed", [container.name, cpu_orig])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	mem_orig := container.resources.requests.memory
+	not canonify_mem(mem_orig)
+	msg := sprintf("container <%v> memory request <%v> could not be parsed", [container.name, mem_orig])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	not container.resources
+	msg := sprintf("container <%v> has no resource requests", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	not container.resources.requests
+	msg := sprintf("container <%v> has no resource requests", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	missing(container.resources.requests, "cpu")
+	msg := sprintf("container <%v> has no cpu request", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	missing(container.resources.requests, "memory")
+	msg := sprintf("container <%v> has no memory request", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	cpu := canonify_cpu(container.resources.requests.cpu)
+	max_cpu := canonify_cpu(input.parameters.cpu)
+	cpu > max_cpu
+	msg := sprintf(
+		"container <%v> cpu request <%v> is higher than the maximum allowed of <%v>",
+		[container.name, container.resources.requests.cpu, input.parameters.cpu],
+	)
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	mem := canonify_mem(container.resources.requests.memory)
+	max_mem := canonify_mem(input.parameters.memory)
+	mem > max_mem
+	msg := sprintf(
+		"container <%v> memory request <%v> is higher than the maximum allowed of <%v>",
+		[container.name, container.resources.requests.memory, input.parameters.memory],
+	)
+}
+
+non_exempt_containers contains [field, container] if {
+	some field, containers in input.review.object.spec
+	some container in containers
+	not is_exempt(container)
+}

--- a/src/v1/general/containerrequests/src_test.rego
+++ b/src/v1/general/containerrequests/src_test.rego
@@ -1,0 +1,237 @@
+package k8scontainerrequests
+
+import rego.v1
+
+test_input_no_violations_int if {
+	inp := {"review": review([ctr("a", 10, 20)]), "parameters": {"memory": 20, "cpu": 40}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_str if {
+	inp := {"review": review([ctr("a", "10", "20")]), "parameters": {"memory": "20", "cpu": "40"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_str_small if {
+	inp := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_cpu_scale if {
+	inp := {"review": review([ctr("a", "1", "2m")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_violations_int if {
+	inp := {"review": review([ctr("a", 10, 20)]), "parameters": {"memory": 5, "cpu": 10}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_violations_mem_int_v_str if {
+	inp := {"review": review([ctr("a", 10, "4")]), "parameters": {"memory": "1000m", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_str if {
+	inp := {"review": review([ctr("a", "10", "20")]), "parameters": {"memory": "5", "cpu": "10"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_violations_str_small if {
+	inp := {"review": review([ctr("a", "5", "6")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_violations_cpu_scale if {
+	inp := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "2", "cpu": "4m"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_parse_cpu if {
+	inp := {"review": review([ctr("a", "1", "212asdf")]), "parameters": {"memory": "2", "cpu": "4m"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_parse_ram if {
+	inp := {"review": review([ctr("a", "1asdf", "2")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_1_bad_cpu if {
+	inp := {"review": review([ctr("a", "1", "2"), ctr("b", "1", "8")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_2_bad_cpu if {
+	inp := {"review": review([ctr("a", "1", "9"), ctr("b", "1", "8")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_1_bad_ram if {
+	inp := {"review": review([ctr("a", "1", "2"), ctr("b", "8", "2")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_2_bad_ram if {
+	inp := {"review": review([ctr("a", "9", "2"), ctr("b", "8", "2")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_no_ram_request if {
+	inp := {"review": review([{"name": "a", "resources": {"requests": {"cpu": 1}}}]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_cpu_request if {
+	inp := {"review": review([{"name": "a", "resources": {"requests": {"memory": 1}}}]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_request if {
+	inp := {"review": review([{"name": "a", "resources": {}}]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_resources if {
+	inp := {"review": review([{"name": "a"}]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_containers_checked if {
+	inp := {"review": init_review([ctr("a", "5", "5"), ctr("b", "5", "5")]), "parameters": {"memory": "2", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 4
+}
+
+# MEM SCALE TESTS
+test_input_no_violations_mem_K if {
+	inp := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "1k", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_violations_mem_m if {
+	inp := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "1m", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_K if {
+	inp := {"review": review([ctr("a", "1k", "2")]), "parameters": {"memory": "1", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_M if {
+	inp := {"review": review([ctr("a", "1M", "2")]), "parameters": {"memory": "1k", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_G if {
+	inp := {"review": review([ctr("a", "1G", "2")]), "parameters": {"memory": "1M", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_T if {
+	inp := {"review": review([ctr("a", "1T", "2")]), "parameters": {"memory": "1G", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_P if {
+	inp := {"review": review([ctr("a", "1P", "2")]), "parameters": {"memory": "1T", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_E if {
+	inp := {"review": review([ctr("a", "1E", "2")]), "parameters": {"memory": "1P", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ki if {
+	inp := {"review": review([ctr("a", "1Ki", "2")]), "parameters": {"memory": "1", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Mi if {
+	inp := {"review": review([ctr("a", "1Mi", "2")]), "parameters": {"memory": "1Ki", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Gi if {
+	inp := {"review": review([ctr("a", "1Gi", "2")]), "parameters": {"memory": "1Mi", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_decimal_mem_Gi if {
+	inp := {"review": review([ctr("a", "1Gi", "2")]), "parameters": {"memory": "1.5Mi", "cpu": "4"}}
+	results := violation with input as inp
+
+	count(results) == 1
+}
+
+test_input_violations_mem_Ti if {
+	inp := {"review": review([ctr("a", "1Ti", "2")]), "parameters": {"memory": "1Gi", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Pi if {
+	inp := {"review": review([ctr("a", "1Pi", "2")]), "parameters": {"memory": "1Ti", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ei if {
+	inp := {"review": review([ctr("a", "1Ei", "2")]), "parameters": {"memory": "1Pi", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ei_with_exemption if {
+	inp := {"review": review([ctr("a", "1Ei", "2")]), "parameters": {"exemptImages": ["nginx"], "memory": "1Pi", "cpu": "4"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers},
+}}
+
+init_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"initContainers": containers},
+}}
+
+ctr(name, mem, cpu) := {
+	"name": name,
+	"image": "nginx",
+	"resources": {"requests": {"memory": mem, "cpu": cpu}},
+}

--- a/src/v1/general/containerresourceratios/constraint.tmpl
+++ b/src/v1/general/containerresourceratios/constraint.tmpl
@@ -1,0 +1,48 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8scontainerratios
+  annotations:
+    metadata.gatekeeper.sh/title: "Container Ratios"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Sets a maximum ratio for container resource limits to requests.
+
+      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sContainerRatios
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            ratio:
+              type: string
+              description: >-
+                The maximum allowed ratio of `resources.limits` to
+                `resources.requests` on a container.
+            cpuRatio:
+              type: string
+              description: >-
+                The maximum allowed ratio of `resources.limits.cpu` to
+                `resources.requests.cpu` on a container. If not specified,
+                equal to `ratio`.
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/containerresourceratios/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/general/containerresourceratios/lib_exempt_container.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/containerresourceratios/lib_exempt_container.rego
+++ b/src/v1/general/containerresourceratios/lib_exempt_container.rego
@@ -1,0 +1,20 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
+	some exemption in exempt_images
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/general/containerresourceratios/src.rego
+++ b/src/v1/general/containerresourceratios/src.rego
@@ -1,0 +1,242 @@
+package k8scontainerratios
+
+import rego.v1
+
+import data.lib.exempt_container.is_exempt
+
+missing(obj, field) if {
+	not obj[field]
+}
+
+missing(obj, field) if {
+	obj[field] == ""
+}
+
+canonify_cpu(orig) := new if {
+	is_number(orig)
+	new := orig * 1000
+}
+
+canonify_cpu(orig) := new if {
+	not is_number(orig)
+	endswith(orig, "m")
+	new := to_number(replace(orig, "m", ""))
+}
+
+canonify_cpu(orig) := new if {
+	not is_number(orig)
+	not endswith(orig, "m")
+	regex.match(`^[0-9]+$`, orig)
+	new := to_number(orig) * 1000
+}
+
+canonify_cpu(orig) := new if {
+	not is_number(orig)
+	not endswith(orig, "m")
+	regex.match(`^[0-9]+[.][0-9]+$`, orig)
+	new := to_number(orig) * 1000
+}
+
+# 10 ** 21
+mem_multiple("E") := 1000000000000000000000
+
+# 10 ** 18
+mem_multiple("P") := 1000000000000000000
+
+# 10 ** 15
+mem_multiple("T") := 1000000000000000
+
+# 10 ** 12
+mem_multiple("G") := 1000000000000
+
+# 10 ** 9
+mem_multiple("M") := 1000000000
+
+# 10 ** 6
+mem_multiple("k") := 1000000
+
+# 10 ** 3
+mem_multiple("") := 1000
+
+# Kubernetes accepts millibyte precision when it probably shouldn't.
+# https://github.com/kubernetes/kubernetes/issues/28741
+# 10 ** 0
+mem_multiple("m") := 1
+
+# 1000 * 2 ** 10
+mem_multiple("Ki") := 1024000
+
+# 1000 * 2 ** 20
+mem_multiple("Mi") := 1048576000
+
+# 1000 * 2 ** 30
+mem_multiple("Gi") := 1073741824000
+
+# 1000 * 2 ** 40
+mem_multiple("Ti") := 1099511627776000
+
+# 1000 * 2 ** 50
+mem_multiple("Pi") := 1125899906842624000
+
+# 1000 * 2 ** 60
+mem_multiple("Ei") := 1152921504606846976000
+
+get_suffix(mem) := "" if not is_string(mem)
+
+get_suffix(mem) := suffix if {
+	is_string(mem)
+	count(mem) > 0
+	suffix := substring(mem, count(mem) - 1, -1)
+	mem_multiple(suffix)
+}
+
+get_suffix(mem) := suffix if {
+	is_string(mem)
+	count(mem) > 1
+	suffix := substring(mem, count(mem) - 2, -1)
+	mem_multiple(suffix)
+}
+
+get_suffix(mem) := "" if {
+	is_string(mem)
+	count(mem) > 1
+	not mem_multiple(substring(mem, count(mem) - 1, -1))
+	not mem_multiple(substring(mem, count(mem) - 2, -1))
+}
+
+get_suffix(mem) := "" if {
+	is_string(mem)
+	count(mem) == 1
+	not mem_multiple(substring(mem, count(mem) - 1, -1))
+}
+
+get_suffix(mem) := "" if {
+	is_string(mem)
+	count(mem) == 0
+}
+
+canonify_mem(orig) := orig * 1000 if {
+	is_number(orig)
+}
+
+canonify_mem(orig) := new if {
+	not is_number(orig)
+	suffix := get_suffix(orig)
+	raw := replace(orig, suffix, "")
+	regex.match(`^[0-9]+(\.[0-9]+)?$`, raw)
+	new := to_number(raw) * mem_multiple(suffix)
+}
+
+violation contains {"msg": msg} if {
+	general_violation[{"msg": msg, "field": "containers"}]
+}
+
+violation contains {"msg": msg} if {
+	general_violation[{"msg": msg, "field": "initContainers"}]
+}
+
+# Ephemeral containers not checked as it is not possible to set field.
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	cpu_orig := container.resources.limits.cpu
+	not canonify_cpu(cpu_orig)
+	msg := sprintf("container <%v> cpu limit <%v> could not be parsed", [container.name, cpu_orig])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	mem_orig := container.resources.limits.memory
+	not canonify_mem(mem_orig)
+	msg := sprintf("container <%v> memory limit <%v> could not be parsed", [container.name, mem_orig])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	cpu_orig := container.resources.requests.cpu
+	not canonify_cpu(cpu_orig)
+	msg := sprintf("container <%v> cpu request <%v> could not be parsed", [container.name, cpu_orig])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	mem_orig := container.resources.requests.memory
+	not canonify_mem(mem_orig)
+	msg := sprintf("container <%v> memory request <%v> could not be parsed", [container.name, mem_orig])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	not container.resources
+	msg := sprintf("container <%v> has no resource limits", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	not container.resources.limits
+	msg := sprintf("container <%v> has no resource limits", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	missing(container.resources.limits, "cpu")
+	msg := sprintf("container <%v> has no cpu limit", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	missing(container.resources.limits, "memory")
+	msg := sprintf("container <%v> has no memory limit", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	not container.resources.requests
+	msg := sprintf("container <%v> has no resource requests", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	missing(container.resources.requests, "cpu")
+	msg := sprintf("container <%v> has no cpu request", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	missing(container.resources.requests, "memory")
+	msg := sprintf("container <%v> has no memory request", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	cpu_limits_orig := container.resources.limits.cpu
+	cpu_limits := canonify_cpu(cpu_limits_orig)
+	cpu_requests_orig := container.resources.requests.cpu
+	cpu_requests := canonify_cpu(cpu_requests_orig)
+	cpu_ratio := object.get(input.parameters, "cpuRatio", input.parameters.ratio)
+	to_number(cpu_limits) > to_number(cpu_ratio) * to_number(cpu_requests)
+	msg := sprintf(
+		"container <%v> cpu limit <%v> is higher than the maximum allowed ratio of <%v>",
+		[container.name, cpu_limits_orig, cpu_ratio],
+	)
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	mem_limits_orig := container.resources.limits.memory
+	mem_requests_orig := container.resources.requests.memory
+	mem_limits := canonify_mem(mem_limits_orig)
+	mem_requests := canonify_mem(mem_requests_orig)
+	mem_ratio := input.parameters.ratio
+	to_number(mem_limits) > to_number(mem_ratio) * to_number(mem_requests)
+	msg := sprintf(
+		"container <%v> memory limit <%v> is higher than the maximum allowed ratio of <%v>",
+		[container.name, mem_limits_orig, mem_ratio],
+	)
+}
+
+non_exempt_containers contains [field, container] if {
+	some field, containers in input.review.object.spec
+	some container in containers
+	not is_exempt(container)
+}

--- a/src/v1/general/containerresourceratios/src_test.rego
+++ b/src/v1/general/containerresourceratios/src_test.rego
@@ -1,0 +1,327 @@
+package k8scontainerratios
+
+import rego.v1
+
+test_input_no_violations_int if {
+	inp := {"review": review([ctr("a", 10, 20, 5, 10)]), "parameters": {"ratio": 2}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_input_no_violations_str if {
+	inp := {"review": review([ctr("a", "10", "20", "5", "10")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_input_no_violations_str_small if {
+	inp := {"review": review([ctr("a", "1", "2", "1", "1")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_input_no_violations_cpu_scale if {
+	inp := {"review": review([ctr("a", "2", "4m", "1", "2m")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_input_no_violations_cpu_decimal if {
+	inp := {"review": review([ctr("a", "2", "3", "1", "1.5")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_input_violations_int if {
+	inp := {"review": review([ctr("a", 20, 40, 5, 10)]), "parameters": {"ratio": 2}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_input_violations_mem_int_v_str if {
+	inp := {"review": review([ctr("a", 1, "3", "1m", "1.5")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_input_violations_str if {
+	inp := {"review": review([ctr("a", "10", "20", "2", "4")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_input_violations_str_small if {
+	inp := {"review": review([ctr("a", "5", "6", "1", "1")]), "parameters": {"ratio": "3"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_violations_cpu_scale if {
+	inp := {"review": review([ctr("a", "1", "2", "1", "4m")]), "parameters": {"ratio": "10"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_cpu_decimal if {
+	inp := {"review": review([ctr("a", "1", "2", "1", "0.5")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_no_parse_cpu_limits if {
+	inp := {"review": review([ctr("a", "1", "212asdf", "2", "2")]), "parameters": {"raio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_parse_cpu_requests if {
+	inp := {"review": review([ctr("a", "1", "2", "2", "212asdf")]), "parameters": {"raio": "4"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_no_parse_cpu_requests_and_limits if {
+	inp := {"review": review([ctr("a", "1", "212asdf", "2", "212asdf")]), "parameters": {"raio": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_no_parse_ram_limits if {
+	inp := {"review": review([ctr("a", "1asdf", "2", "1", "2")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_parse_ram_requests if {
+	inp := {"review": review([ctr("a", "1", "2", "1asdf", "2")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_parse_ram_requests_and_limits if {
+	inp := {"review": review([ctr("a", "1asdf", "2", "1asdf", "2")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_1_bad_cpu if {
+	inp := {"review": review([ctr("a", "1", "2", "1", "2"), ctr("b", "1", "8", "1", "2")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_2_bad_cpu if {
+	inp := {"review": review([ctr("a", "1", "9", "1", "3"), ctr("b", "1", "8", "1", "2")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_1_bad_ram if {
+	inp := {"review": review([ctr("a", "1", "2", "1", "2"), ctr("b", "8", "2", "2", "2")]), "parameters": {"ratio": "1"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_2_bad_ram if {
+	inp := {"review": review([ctr("a", "9", "2", "3", "2"), ctr("b", "8", "2", "2", "2")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_no_ram_limit if {
+	inp := {"review": review([{"name": "a", "resources": {"limits": {"cpu": 1}}}]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_no_cpu_limit if {
+	inp := {"review": review([{"name": "a", "resources": {"limits": {"memory": 1}}}]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_no_limit if {
+	inp := {"review": review([{"name": "a", "resources": {}}]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_no_ram_request if {
+	inp := {"review": review([{"name": "a", "resources": {"requests": {"cpu": 1}}}]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_no_cpu_request if {
+	inp := {"review": review([{"name": "a", "resources": {"requests": {"memory": 1}}}]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_no_resources if {
+	inp := {"review": review([{"name": "a"}]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_init_containers_checked if {
+	inp := {"review": init_review([ctr("a", "5", "5", "1", "1"), ctr("b", "5", "5", "1", "1")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 4
+}
+
+# MEM SCALE TESTS
+test_input_no_violations_mem_K if {
+	inp := {"review": review([ctr("a", "1k", "2", "1k", "2")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_violations_mem_K if {
+	inp := {"review": review([ctr("a", "4k", "2", "1k", "2")]), "parameters": {"ratio": "2"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_m if {
+	inp := {"review": review([ctr("a", "1", "2", "1m", "2")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_M if {
+	inp := {"review": review([ctr("a", "1M", "2", "1k", "2")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_G if {
+	inp := {"review": review([ctr("a", "1G", "2", "1M", "1")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_T if {
+	inp := {"review": review([ctr("a", "1T", "2", "1G", "1")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_P if {
+	inp := {"review": review([ctr("a", "1P", "2", "1T", "2")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_E if {
+	inp := {"review": review([ctr("a", "1E", "2", "1P", "2")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ki if {
+	inp := {"review": review([ctr("a", "1Ki", "2", "1", "2")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Mi if {
+	inp := {"review": review([ctr("a", "1Mi", "2", "1Ki", "1")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Gi if {
+	inp := {"review": review([ctr("a", "1Gi", "2", "1Mi", "2")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ti if {
+	inp := {"review": review([ctr("a", "1Ti", "2", "1Gi", "1")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Pi if {
+	inp := {"review": review([ctr("a", "1Pi", "2", "1Ti", "1")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ei if {
+	inp := {"review": review([ctr("a", "1Ei", "2", "1Pi", "1")]), "parameters": {"ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_mem_Ei_with_exemption if {
+	inp := {"review": review([ctr("a", "1Ei", "2", "1Pi", "1")]), "parameters": {"exemptImages": ["nginx"], "ratio": "4"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+## cpuRatio tests
+
+test_input_no_violations_int_cpu_ratio_1 if {
+	inp := {"review": review([ctr("a", 5, 10, 5, 10)]), "parameters": {"ratio": 1, "cpuRatio": 1}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_input_violations_int_cpu_ratio_1 if {
+	inp := {"review": review([ctr("a", 30, 15, 5, 10)]), "parameters": {"ratio": 10, "cpuRatio": 1}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_input_no_violation_int_cpu_ratio_2 if {
+	inp := {"review": review([ctr("a", 5, 20, 5, 10)]), "parameters": {"ratio": 1, "cpuRatio": 2}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_input_violation_int_cpu_ratio_2 if {
+	inp := {"review": review([ctr("a", 5, 21, 5, 10)]), "parameters": {"ratio": 1, "cpuRatio": 2}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_input_violation_int_cpu_ratio_2_with_exemption if {
+	inp := {"review": review([ctr("a", 5, 21, 5, 10)]), "parameters": {"exemptImages": ["nginx"], "ratio": 1, "cpuRatio": 2}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers},
+}}
+
+init_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"initContainers": containers},
+}}
+
+ctr(name, mem_limits, cpu_limits, mem_requests, cpu_requests) := {"name": name, "image": "nginx", "resources": {
+	"limits": {"memory": mem_limits, "cpu": cpu_limits},
+	"requests": {"memory": mem_requests, "cpu": cpu_requests},
+}}

--- a/src/v1/general/containerresources/constraint.tmpl
+++ b/src/v1/general/containerresources/constraint.tmpl
@@ -1,0 +1,54 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredresources
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Resources"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Requires containers to have defined resources set.
+
+      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredResources
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            limits:
+              type: array
+              description: "A list of limits that should be enforced (`cpu`, `memory`, or both)."
+              items:
+                type: string
+                enum:
+                - cpu
+                - memory
+            requests:
+              type: array
+              description: "A list of requests that should be enforced (`cpu`, `memory`, or both)."
+              items:
+                type: string
+                enum:
+                - cpu
+                - memory
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/containerresources/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/general/containerresources/lib_exempt_container.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/containerresources/lib_exempt_container.rego
+++ b/src/v1/general/containerresources/lib_exempt_container.rego
@@ -1,0 +1,20 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
+	some exemption in exempt_images
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/general/containerresources/src.rego
+++ b/src/v1/general/containerresources/src.rego
@@ -1,0 +1,37 @@
+package k8srequiredresources
+
+import rego.v1
+
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg} if {
+	general_violation[{"msg": msg, "field": "containers"}]
+}
+
+violation contains {"msg": msg} if {
+	general_violation[{"msg": msg, "field": "initContainers"}]
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	provided := {key | some key in object.keys(container.resources.limits)}
+	required := {resource_type | some resource_type in input.parameters.limits}
+	missing := required - provided
+	count(missing) > 0
+	msg := sprintf("container <%v> does not have <%v> limits defined", [container.name, missing])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	provided := {key | some key in object.keys(container.resources.requests)}
+	required := {resource_type | some resource_type in input.parameters.requests}
+	missing := required - provided
+	count(missing) > 0
+	msg := sprintf("container <%v> does not have <%v> requests defined", [container.name, missing])
+}
+
+non_exempt_containers contains [field, container] if {
+	some field, containers in input.review.object.spec
+	some container in containers
+	not is_exempt(container)
+}

--- a/src/v1/general/containerresources/src_test.rego
+++ b/src/v1/general/containerresources/src_test.rego
@@ -1,0 +1,349 @@
+package k8srequiredresources
+
+import rego.v1
+
+# "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}
+test_without_resources_violations if {
+	inp := {"review": review([ctr_without_resources("test")]), "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_requests_cpu_violations if {
+	inp := {"review": review([ctr_requests_cpu("test", 1)]), "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_requests_memory_violations if {
+	inp := {"review": review([ctr_requests_memory("test", 1)]), "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_requests_violations if {
+	inp := {"review": review([ctr_requests("test", 1)]), "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_limits_cpu_violations if {
+	inp := {"review": review([ctr_limits_cpu("test", 1)]), "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_limits_memory_violations if {
+	inp := {"review": review([ctr_limits_memory("test", 1)]), "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_limits_violations if {
+	inp := {"review": review([ctr_limits("test", 1)]), "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_with_resources_no_violations if {
+	inp := {"review": review([ctr_with_resources("test", 1)]), "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+# "parameters": {"limits": ["memory"], "requests": ["cpu"]}
+test_without_resources_with_empty_requests_memory_no_violations if {
+	inp := {"review": review([ctr_without_resources("test")]), "parameters": {"limits": ["memory"], "requests": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_requests_cpu_with_empty_requests_memory_no_violations if {
+	inp := {"review": review([ctr_requests_cpu("test", 1)]), "parameters": {"limits": ["memory"], "requests": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_requests_memory_with_empty_requests_memory_no_violations if {
+	inp := {"review": review([ctr_requests_memory("test", 1)]), "parameters": {"limits": ["memory"], "requests": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_requests_with_empty_requests_memory_no_violations if {
+	inp := {"review": review([ctr_requests("test", 1)]), "parameters": {"limits": ["memory"], "requests": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_limits_cpu_with_empty_requests_memory_no_violations if {
+	inp := {"review": review([ctr_limits_cpu("test", 1)]), "parameters": {"limits": ["memory"], "requests": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 2
+}
+
+test_limits_memory_with_empty_requests_memory_no_violations if {
+	inp := {"review": review([ctr_limits_memory("test", 1)]), "parameters": {"limits": ["memory"], "requests": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_limits_with_empty_requests_memory_no_violations if {
+	inp := {"review": review([ctr_limits("test", 1)]), "parameters": {"limits": ["memory"], "requests": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_with_resources_with_empty_requests_memory_no_violations if {
+	inp := {"review": review([ctr_with_resources("test", 1)]), "parameters": {"limits": ["memory"], "requests": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+# "parameters": {"limits": ["cpu"]}
+test_without_resources_with_empty_requests_and_limits_memory_no_violations if {
+	inp := {"review": review([ctr_without_resources("test")]), "parameters": {"limits": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_requests_cpu_with_empty_requests_and_limits_memory_no_violations if {
+	inp := {"review": review([ctr_requests_cpu("test", 1)]), "parameters": {"limits": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_requests_memory_with_empty_requests_and_limits_memory_no_violations if {
+	inp := {"review": review([ctr_requests_memory("test", 1)]), "parameters": {"limits": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_requests_with_empty_requests_and_limits_memory_no_violations if {
+	inp := {"review": review([ctr_requests("test", 1)]), "parameters": {"limits": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_limits_cpu_with_empty_requests_and_limits_memory_no_violations if {
+	inp := {"review": review([ctr_limits_cpu("test", 1)]), "parameters": {"limits": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_limits_memory_with_empty_requests_and_limits_memory_no_violations if {
+	inp := {"review": review([ctr_limits_memory("test", 1)]), "parameters": {"limits": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 1
+}
+
+test_limits_with_empty_requests_and_limits_memory_no_violations if {
+	inp := {"review": review([ctr_limits("test", 1)]), "parameters": {"limits": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_with_resources_with_empty_requests_and_limits_memory_no_violations if {
+	inp := {"review": review([ctr_with_resources("test", 1)]), "parameters": {"limits": ["cpu"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+# "parameters": {"limits": [], "requests": []}
+test_without_resources_with_empty_limits_and_requests_no_violations if {
+	inp := {"review": review([ctr_without_resources("test")]), "parameters": {"limits": [], "requests": []}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_requests_cpu_with_empty_limits_and_requests_no_violations if {
+	inp := {"review": review([ctr_requests_cpu("test", 1)]), "parameters": {"limits": [], "requests": []}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_requests_memory_with_empty_limits_and_requests_no_violations if {
+	inp := {"review": review([ctr_requests_memory("test", 1)]), "parameters": {"limits": [], "requests": []}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_requests_with_empty_limits_and_requests_no_violations if {
+	inp := {"review": review([ctr_requests("test", 1)]), "parameters": {"limits": [], "requests": []}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_limits_cpu_with_empty_limits_and_requests_no_violations if {
+	inp := {"review": review([ctr_limits_cpu("test", 1)]), "parameters": {"limits": [], "requests": []}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_limits_memory_with_empty_limits_and_requests_no_violations if {
+	inp := {"review": review([ctr_limits_memory("test", 1)]), "parameters": {"limits": [], "requests": []}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_limits_with_empty_limits_and_requests_no_violations if {
+	inp := {"review": review([ctr_limits("test", 1)]), "parameters": {"limits": [], "requests": []}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_with_resources_with_empty_limits_and_requests_no_violations if {
+	inp := {"review": review([ctr_with_resources("test", 1)]), "parameters": {"limits": [], "requests": []}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+# multiple containers, "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}
+test_multiple_without_resources_violations if {
+	inp := {"review": review([ctr_without_resources("test1"), ctr_without_resources("test2"), ctr_without_resources("test3")]), "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 6
+}
+
+test_multiple_with_resources_no_violations if {
+	inp := {"review": review([ctr_with_resources("test1", 1), ctr_with_resources("test2", 2), ctr_with_resources("test3", 3)]), "parameters": {"limits": ["cpu", "memory"], "requests": ["cpu", "memory"]}}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+# multiple containers
+test_multiple_with_init_violations_1 if {
+	inp := {
+		"review": review_with_init(
+			[
+				ctr_without_resources("test1"),
+				ctr_with_resources("test2", 2),
+				ctr_limits_memory("test3", 3),
+			],
+			[
+				ctr_requests("test4", 1),
+				ctr_requests_memory("test5", 2),
+				ctr_limits_cpu("test6", 3),
+			],
+		),
+		"parameters": {"requests": [
+			"cpu",
+			"memory",
+		]},
+	}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 4
+}
+
+test_multiple_with_init_no_violations if {
+	inp := {
+		"review": review_with_init(
+			[
+				ctr_with_resources("test1", 1),
+				ctr_requests("test2", 2),
+			],
+			[
+				ctr_with_resources("test3", 1),
+				ctr_requests("test4", 2),
+			],
+		),
+		"parameters": {"requests": [
+			"cpu",
+			"memory",
+		]},
+	}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 0
+}
+
+test_multiple_with_init_violations_2 if {
+	inp := {
+		"review": review_with_init(
+			[
+				ctr_without_resources("test1"),
+				ctr_limits_memory("test2", 2),
+				ctr_limits("test3", 3),
+			],
+			[
+				ctr_requests_cpu("test4", 1),
+				ctr_with_resources("test5", 2),
+				ctr_limits_cpu("test6", 3),
+			],
+		),
+		"parameters": {
+			"limits": ["memory"],
+			"requests": [
+				"cpu",
+				"memory",
+			],
+		},
+	}
+	results := violation with input as inp
+	trace(sprintf("results - <%v>", [results]))
+	count(results) == 8
+}
+
+review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers},
+}}
+
+review_with_init(containers, init_containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers, "initContainers": init_containers},
+}}
+
+ctr_without_resources(name) := {"name": name, "image": "nginx", "resources": {}}
+
+ctr_requests_cpu(name, val) := {"name": name, "image": "nginx", "resources": {"requests": {"cpu": val}}}
+
+ctr_requests_memory(name, val) := {"name": name, "image": "nginx", "resources": {"requests": {"memory": val}}}
+
+ctr_requests(name, val) := {"name": name, "image": "nginx", "resources": {"requests": {"cpu": val, "memory": val}}}
+
+ctr_limits_cpu(name, val) := {"name": name, "image": "nginx", "resources": {"limits": {"cpu": val}}}
+
+ctr_limits_memory(name, val) := {"name": name, "image": "nginx", "resources": {"limits": {"memory": val}}}
+
+ctr_limits(name, val) := {"name": name, "image": "nginx", "resources": {"limits": {"cpu": val, "memory": val}}}
+
+ctr_with_resources(name, val) := {"name": name, "image": "nginx", "resources": {
+	"limits": {"cpu": val, "memory": val},
+	"requests": {"cpu": val, "memory": val},
+}}

--- a/src/v1/general/disallowanonymous/constraint.tmpl
+++ b/src/v1/general/disallowanonymous/constraint.tmpl
@@ -1,0 +1,36 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdisallowanonymous
+  annotations:
+    metadata.gatekeeper.sh/title: "Disallow Anonymous Access"
+    metadata.gatekeeper.sh/version: 1.1.0
+    description: Disallows associating ClusterRole and Role resources to the system:anonymous user and system:unauthenticated group.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDisallowAnonymous
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedRoles:
+              description: >-
+                The list of ClusterRoles and Roles that may be associated
+                with the `system:unauthenticated` group and `system:anonymous`
+                user.
+              type: array
+              items:
+                type: string
+            disallowAuthenticated:
+              description: >-
+                A boolean indicating whether `system:authenticated` should also
+                be disallowed by this policy.
+              type: boolean
+              default: false
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/disallowanonymous/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/disallowanonymous/src.rego
+++ b/src/v1/general/disallowanonymous/src.rego
@@ -1,0 +1,27 @@
+package k8sdisallowanonymous
+
+import rego.v1
+
+violation contains {"msg": message(group)} if {
+	not input.review.object.roleRef.name in allowed_roles
+	some group in ["system:unauthenticated", "system:anonymous"]
+	some subject in input.review.object.subjects
+	subject.name == group
+}
+
+violation contains {"msg": message("system:authenticated")} if {
+	not input.review.object.roleRef.name in allowed_roles
+	input.parameters.disallowAuthenticated
+	some subject in input.review.object.subjects
+	subject.name == "system:authenticated"
+}
+
+default allowed_roles := []
+
+allowed_roles := input.parameters.allowedRoles
+
+message(name) := sprintf("%v is not allowed as a subject name in %v %v", [
+	name,
+	input.review.object.kind,
+	input.review.object.metadata.name,
+])

--- a/src/v1/general/disallowanonymous/src_test.rego
+++ b/src/v1/general/disallowanonymous/src_test.rego
@@ -1,0 +1,288 @@
+package k8sdisallowanonymous
+
+import rego.v1
+
+test_blank_subject_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_non_anonymous_user_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "user-1", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_anonymous_user_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_anonymous_user_clusterrolebinding_no_param if {
+	inp := {"review": clusterrolebinding([{"name": "system:anonymous", "kind": "User"}], "role-2")}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_role_anonymous_user_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_subjects_anonymous_user_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:anonymous", "kind": "User"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_role_multiple_subjects_anonymous_user_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:anonymous", "kind": "User"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_role_multiple_subjects_anonymous_user_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:anonymous", "kind": "User"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-3"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_multiple_role_multiple_subjects_anonymous_user_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:anonymous", "kind": "User"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_unauthenticated_group_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_unauthenticated_group_clusterrolebinding_no_param if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}], "role-2")}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_role_unauthenticated_group_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_subjects_unauthenticated_group_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_role_multiple_subjects_unauthenticated_group_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_role_multiple_subjects_unauthenticated_group_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-3"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_multiple_role_multiple_subjects_unauthenticated_group_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_subjects_mix_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_allowed_role_multiple_subjects_mix_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_role_multiple_subjects_mix_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-3"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_allowed_multiple_role_multiple_subjects_mix_clusterrolebinding if {
+	inp := {"review": clusterrolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_blank_subject_rolebinding if {
+	inp := {"review": rolebinding([{}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_non_anonymous_rolebinding if {
+	inp := {"review": rolebinding([{"name": "user-1", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_anonymous_user_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_anonymous_user_rolebinding_no_param if {
+	inp := {"review": rolebinding([{"name": "system:anonymous", "kind": "User"}], "role-2")}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_role_anonymous_user_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_subjects_anonymous_user_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:anonymous", "kind": "User"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_role_multiple_subjects_anonymous_user_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:anonymous", "kind": "User"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_role_multiple_subjects_anonymous_user_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:anonymous", "kind": "User"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-3"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_multiple_role_multiple_subjects_anonymous_user_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:anonymous", "kind": "User"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_unauthenticated_group_rolebinding_no_param if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}], "role-2")}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_unauthenticated_group_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_role_unauthenticated_group_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_subjects_unauthenticated_group_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_role_multiple_subjects_unauthenticated_group_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_role_multiple_subjects_unauthenticated_group_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-3"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_allowed_multiple_role_multiple_subjects_unauthenticated_group_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:authenticated", "kind": "Group"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_subjects_mix_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-1"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_allowed_role_multiple_subjects_mix_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_multiple_role_multiple_subjects_mix_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-3"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_allowed_multiple_role_multiple_subjects_mix_rolebinding if {
+	inp := {"review": rolebinding([{"name": "system:unauthenticated", "kind": "Group"}, {"name": "system:anonymous", "kind": "User"}], "role-2"), "parameters": {"allowedRoles": ["role-1", "role-2"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+authenticated_rolebinding := rolebinding([{"name": "system:authenticated", "kind": "Group"}], "role-2")
+
+test_authenticated_with_disallow_authenticated_true if {
+	inp := {"review": authenticated_rolebinding, "parameters": {"allowedRoles": [], "disallowAuthenticated": true}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_authenticated_with_disallow_authenticated_false if {
+	inp := {"review": authenticated_rolebinding, "parameters": {"allowedRoles": [], "disallowAuthenticated": false}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_authenticated_with_disallow_authenticated_undefined if {
+	inp := {"review": authenticated_rolebinding, "parameters": {"allowedRoles": []}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+clusterrolebinding(subjects, roleref_name) := {"object": {
+	"kind": "ClusterRoleBinding",
+	"metadata": {"name": "cluster-role-binding"},
+	"roleRef": {
+		"apiGroup": "rbac.authorization.k8s.io",
+		"kind": "ClusterRole",
+		"name": roleref_name,
+	},
+	"subjects": subjects,
+}}
+
+rolebinding(subjects, roleref_name) := {"object": {
+	"kind": "RoleBinding",
+	"metadata": {
+		"name": "role-binding",
+		"namespace": "namespace-1",
+	},
+	"roleRef": {
+		"apiGroup": "rbac.authorization.k8s.io",
+		"kind": "ClusterRole",
+		"name": roleref_name,
+	},
+	"subjects": subjects,
+}}

--- a/src/v1/general/disallowedrepos/constraint.tmpl
+++ b/src/v1/general/disallowedrepos/constraint.tmpl
@@ -1,0 +1,28 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdisallowedrepos
+  annotations:
+    metadata.gatekeeper.sh/title: "Disallowed Repositories"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Disallowed container repositories that begin with a string from the specified list.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDisallowedRepos
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            repos:
+              description: The list of prefixes a container image is not allowed to have.
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/disallowedrepos/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/disallowedrepos/src.rego
+++ b/src/v1/general/disallowedrepos/src.rego
@@ -1,0 +1,14 @@
+package k8sdisallowedrepos
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+	strings.any_prefix_match(container.image, input.parameters.repos)
+
+	msg := sprintf(
+		"%s <%v> has an invalid image repo <%v>, disallowed repos are %v",
+		[trim_suffix(type, "s"), container.name, container.image, input.parameters.repos],
+	)
+}

--- a/src/v1/general/disallowedrepos/src_test.rego
+++ b/src/v1/general/disallowedrepos/src_test.rego
@@ -1,0 +1,130 @@
+package k8sdisallowedrepos
+
+import rego.v1
+
+test_input_allowed_container if {
+	inp := {"review": input_review(input_container_allowed), "parameters": {"repos": ["disallowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_container_x2 if {
+	inp := {"review": input_review(input_container_allowed), "parameters": {"repos": ["other", "disallowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_dual_container if {
+	inp := {"review": input_review(input_container_dual_allowed), "parameters": {"repos": ["disallowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_denied_container if {
+	inp := {"review": input_review(input_container_denied), "parameters": {"repos": ["disallowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_container_x2 if {
+	inp := {"review": input_review(input_container_denied), "parameters": {"repos": ["other", "disallowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_dual_container if {
+	inp := {"review": input_review(input_container_dual_denied), "parameters": {"repos": ["disallowed"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_denied_mixed_container if {
+	inp := {"review": input_review(array.concat(input_container_allowed, input_container_denied)), "parameters": {"repos": ["disallowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+# init containers
+test_input_allowed_initcontainer if {
+	inp := {"review": input_init_review(input_container_allowed), "parameters": {"repos": ["disallowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_initcontainer_x2 if {
+	inp := {"review": input_init_review(input_container_allowed), "parameters": {"repos": ["other", "disallowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_dual_initcontainer if {
+	inp := {"review": input_init_review(input_container_dual_allowed), "parameters": {"repos": ["disallowed"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_denied_initcontainer if {
+	inp := {"review": input_init_review(input_container_denied), "parameters": {"repos": ["disallowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_initcontainer_x2 if {
+	inp := {"review": input_init_review(input_container_denied), "parameters": {"repos": ["other", "disallowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_dual_initcontainer if {
+	inp := {"review": input_init_review(input_container_dual_denied), "parameters": {"repos": ["disallowed"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_denied_mixed_initcontainer if {
+	inp := {"review": input_init_review(array.concat(input_container_allowed, input_container_denied)), "parameters": {"repos": ["allowed"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+input_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers},
+}}
+
+input_init_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"initContainers": containers},
+}}
+
+input_container_allowed := [{
+	"name": "nginx",
+	"image": "allowed/nginx",
+}]
+
+input_container_denied := [{
+	"name": "nginx",
+	"image": "disallowed/nginx",
+}]
+
+input_container_dual_allowed := [
+	{
+		"name": "nginx",
+		"image": "allowed/nginx",
+	},
+	{
+		"name": "other",
+		"image": "allowed/other",
+	},
+]
+
+input_container_dual_denied := [
+	{
+		"name": "nginx",
+		"image": "disallowed/nginx",
+	},
+	{
+		"name": "other",
+		"image": "disallowed/other",
+	},
+]

--- a/src/v1/general/disallowedtags/constraint.tmpl
+++ b/src/v1/general/disallowedtags/constraint.tmpl
@@ -1,0 +1,44 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdisallowedtags
+  annotations:
+    metadata.gatekeeper.sh/title: "Disallow tags"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Requires container images to have an image tag different from the ones in
+      the specified list.
+
+      https://kubernetes.io/docs/concepts/containers/images/#image-names
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDisallowedTags
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            tags:
+              type: array
+              description: Disallowed container image tags.
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/disallowedtags/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/general/containerlimits/lib_exempt_container.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+

--- a/src/v1/general/disallowedtags/lib_exempt_container.rego
+++ b/src/v1/general/disallowedtags/lib_exempt_container.rego
@@ -1,0 +1,20 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
+	some exemption in exempt_images
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/general/disallowedtags/src.rego
+++ b/src/v1/general/disallowedtags/src.rego
@@ -1,0 +1,30 @@
+package k8sdisallowedtags
+
+import rego.v1
+
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg} if {
+	some container in input_containers
+	tags := [tag_with_prefix |
+		some tag in input.parameters.tags
+		tag_with_prefix := concat(":", ["", tag])
+	]
+	strings.any_suffix_match(container.image, tags)
+	msg := sprintf(
+		"container <%v> uses a disallowed tag <%v>; disallowed tags are %v",
+		[container.name, container.image, input.parameters.tags],
+	)
+}
+
+violation contains {"msg": msg} if {
+	some container in input_containers
+	not contains(container.image, ":")
+	msg := sprintf("container <%v> didn't specify an image tag <%v>", [container.name, container.image])
+}
+
+input_containers contains container if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+	not is_exempt(container)
+}

--- a/src/v1/general/disallowedtags/src_test.rego
+++ b/src/v1/general/disallowedtags/src_test.rego
@@ -1,0 +1,182 @@
+package k8sdisallowedtags
+
+import rego.v1
+
+test_input_allowed_container if {
+	inp := {"review": input_review(input_container_allowed), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_dual_container if {
+	inp := {"review": input_review(input_container_dual_allowed), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_denied_container_emtpy if {
+	inp := {"review": input_review(input_container_denied_empty), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_container_latest if {
+	inp := {"review": input_review(input_container_denied_latest), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_container_testing if {
+	inp := {"review": input_review(input_container_denied_testing), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_dual_container_empty_tag if {
+	inp := {"review": input_review(array.concat(input_container_denied_empty, input_container_denied_latest)), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_denied_dual_container_2tags if {
+	inp := {"review": input_review(array.concat(input_container_denied_testing, input_container_denied_latest)), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_denied_mixed_container_empty if {
+	inp := {"review": input_review(array.concat(input_container_allowed, input_container_denied_empty)), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_mixed_container_latest if {
+	inp := {"review": input_review(array.concat(input_container_allowed, input_container_denied_latest)), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+# init containers
+test_init_container_input_allowed_container if {
+	inp := {"review": input_init_review(input_container_allowed), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_allowed_dual_container if {
+	inp := {"review": input_init_review(input_container_dual_allowed), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_denied_container_emtpy if {
+	inp := {"review": input_init_review(input_container_denied_empty), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_denied_container_latest if {
+	inp := {"review": input_init_review(input_container_denied_latest), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_denied_container_testing if {
+	inp := {"review": input_init_review(input_container_denied_testing), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_denied_dual_container_empty_tag if {
+	inp := {"review": input_init_review(array.concat(input_container_denied_empty, input_container_denied_latest)), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_init_container_input_denied_dual_container_2tags if {
+	inp := {"review": input_init_review(array.concat(input_container_denied_testing, input_container_denied_latest)), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_init_container_input_denied_mixed_container_empty if {
+	inp := {"review": input_init_review(array.concat(input_container_allowed, input_container_denied_empty)), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_denied_mixed_container_latest if {
+	inp := {"review": input_init_review(array.concat(input_container_allowed, input_container_denied_latest)), "parameters": {"tags": ["latest", "testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_mixed_container_with_some_exempt_image if {
+	inp := {"review": input_init_review(array.concat(input_container_exempt, input_container_denied_latest)), "parameters": {"tags": ["latest", "testing"], "exemptImages": ["exempt:latest"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_denied_dual_container_with_all_exempt_image if {
+	inp := {"review": input_init_review(array.concat(input_container_exempt, input_container_denied_latest)), "parameters": {"tags": ["latest", "testing"], "exemptImages": ["exempt:latest", "exempt:testing"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_allowed_dual_container_with_exempt_image if {
+	inp := {"review": input_init_review(input_container_exempt), "parameters": {"tags": ["latest", "testing"], "exemptImages": ["exempt:latest", "exempt:testing"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers},
+}}
+
+input_init_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"initContainers": containers},
+}}
+
+input_container_allowed := [{
+	"name": "nginx",
+	"image": "nginx:1.0.0",
+}]
+
+input_container_denied_empty := [{
+	"name": "nginx",
+	"image": "nginx",
+}]
+
+input_container_denied_latest := [{
+	"name": "nginx",
+	"image": "nginx:latest",
+}]
+
+input_container_denied_testing := [{
+	"name": "other",
+	"image": "other:testing",
+}]
+
+input_container_dual_allowed := [
+	{
+		"name": "nginx",
+		"image": "nginx:1.0.0",
+	},
+	{
+		"name": "other",
+		"image": "other:2.0.0",
+	},
+]
+
+input_container_exempt := [
+	{
+		"name": "exempt",
+		"image": "exempt:latest",
+	},
+	{
+		"name": "exempt",
+		"image": "exempt:testing",
+	},
+]

--- a/src/v1/general/disallowinteractive/constraint.tmpl
+++ b/src/v1/general/disallowinteractive/constraint.tmpl
@@ -1,0 +1,39 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdisallowinteractivetty
+  annotations:
+    metadata.gatekeeper.sh/title: "Disallow Interactive TTY Containers"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Requires that objects have the fields `spec.tty` and `spec.stdin` set to false or unset.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDisallowInteractiveTTY
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls use of fields related to gaining an interactive session. Corresponds to the `tty` and
+            `stdin` fields in the Pod `spec.containers`, `spec.ephemeralContainers`, and `spec.initContainers`.
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+  targets:
+  - target: admission.k8s.gatekeeper.sh
+    rego: |
+{{ file.Read "src/general/disallowinteractive/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+    libs:
+      - |
+{{ file.Read "src/general/disallowinteractive/lib_exempt_container.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/disallowinteractive/lib_exempt_container.rego
+++ b/src/v1/general/disallowinteractive/lib_exempt_container.rego
@@ -1,0 +1,21 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
+	img := container.image
+	some exemption in exempt_images
+	_matches_exemption(img, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/general/disallowinteractive/src.rego
+++ b/src/v1/general/disallowinteractive/src.rego
@@ -1,0 +1,27 @@
+package k8sdisallowinteractivetty
+
+import rego.v1
+
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg, "details": {}} if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+	not is_exempt(container)
+	input_allow_interactive_fields(container)
+
+	msg := sprintf(
+		"Containers using tty or stdin (%v) are not allowed running image: %v",
+		[container.name, container.image],
+	)
+}
+
+input_allow_interactive_fields(c) if {
+	"stdin" in object.keys(c)
+	not c.stdin == false
+}
+
+input_allow_interactive_fields(c) if {
+	"tty" in object.keys(c)
+	not c.tty == false
+}

--- a/src/v1/general/disallowinteractive/src_test.rego
+++ b/src/v1/general/disallowinteractive/src_test.rego
@@ -1,0 +1,143 @@
+package k8sdisallowinteractivetty
+
+import rego.v1
+
+test_input_container_not_tty_allowed if {
+	inp := {"review": input_review}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_stdin_not_allowed if {
+	inp := {"review": input_review_stdin}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_container_tty_not_allowed if {
+	inp := {"review": input_review_tty}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_one_container_with_exemption if {
+	inp := {"review": input_review_stdin, "parameters": {"exemptImages": ["one/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_many_not_stdin_allowed if {
+	inp := {"review": input_review_many}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_container_many_mixed_stdin_not_allowed if {
+	inp := {"review": input_review_many_mixed}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_container_many_mixed_stdin_not_allowed_one_exempted if {
+	inp := {"review": input_review_many_mixed, "parameters": {"exemptImages": ["one/*"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_container_many_mixed_stdin_not_allowed_all_exempted if {
+	inp := {"review": input_review_many_mixed, "parameters": {"exemptImages": ["one/*", "two/*", "three/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_many_mixed_stdin_not_allowed_two if {
+	inp := {"review": input_review_many_mixed_two}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one},
+}}
+
+input_review_stdin := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one_stdin},
+}}
+
+input_review_tty := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one_tty},
+}}
+
+input_review_many := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"initContainers": input_containers_one,
+	},
+}}
+
+input_review_many_mixed := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"initContainers": input_containers_one_stdin,
+	},
+}}
+
+input_review_many_mixed_two := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many_mixed,
+		"initContainers": input_containers_one_stdin,
+	},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "one/nginx",
+}]
+
+input_containers_one_stdin := [{
+	"name": "nginx",
+	"image": "one/nginx",
+	"stdin": true,
+}]
+
+input_containers_one_tty := [{
+	"name": "nginx",
+	"image": "one/nginx",
+	"tty": true,
+}]
+
+input_containers_many := [
+	{
+		"name": "nginx",
+		"image": "one/nginx",
+		"stdin": false,
+	},
+	{
+		"name": "nginx1",
+		"image": "two/nginx",
+	},
+	{
+		"name": "nginx2",
+		"image": "three/nginx",
+		"stdin": true,
+	},
+]
+
+input_containers_many_mixed := [
+	{
+		"name": "nginx",
+		"image": "one/nginx",
+		"stdin": false,
+	},
+	{
+		"name": "nginx1",
+		"image": "two/nginx",
+		"tty": true,
+	},
+]

--- a/src/v1/general/ephemeralstoragelimit/constraint.tmpl
+++ b/src/v1/general/ephemeralstoragelimit/constraint.tmpl
@@ -1,0 +1,44 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8scontainerephemeralstoragelimit
+  annotations:
+    metadata.gatekeeper.sh/title: "Container ephemeral storage limit"
+    metadata.gatekeeper.sh/version: 1.0.2
+    description: >-
+      Requires containers to have an ephemeral storage limit set and constrains
+      the limit to be within the specified maximum values.
+
+      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sContainerEphemeralStorageLimit
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            ephemeral-storage:
+              description: "The maximum allowed ephemeral storage limit on a Pod, exclusive."
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/ephemeralstoragelimit/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/general/ephemeralstoragelimit/lib_exclude_update.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+        - |
+{{ file.Read "src/general/ephemeralstoragelimit/lib_exempt_container.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/ephemeralstoragelimit/lib_exclude_update.rego
+++ b/src/v1/general/ephemeralstoragelimit/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/general/ephemeralstoragelimit/lib_exempt_container.rego
+++ b/src/v1/general/ephemeralstoragelimit/lib_exempt_container.rego
@@ -1,0 +1,20 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
+	some exemption in exempt_images
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/general/ephemeralstoragelimit/src.rego
+++ b/src/v1/general/ephemeralstoragelimit/src.rego
@@ -1,0 +1,163 @@
+package k8scontainerephemeralstoragelimit
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+import data.lib.exempt_container.is_exempt
+
+missing(obj, field) if {
+	not obj[field]
+}
+
+missing(obj, field) if {
+	obj[field] == ""
+}
+
+# 10 ** 21
+storage_multiple("E") := 1000000000000000000000
+
+# 10 ** 18
+storage_multiple("P") := 1000000000000000000
+
+# 10 ** 15
+storage_multiple("T") := 1000000000000000
+
+# 10 ** 12
+storage_multiple("G") := 1000000000000
+
+# 10 ** 9
+storage_multiple("M") := 1000000000
+
+# 10 ** 6
+storage_multiple("k") := 1000000
+
+# 10 ** 3
+storage_multiple("") := 1000
+
+# Kubernetes accepts millibyte precision when it probably shouldn't.
+# https://github.com/kubernetes/kubernetes/issues/28741
+# 10 ** 0
+storage_multiple("m") := 1
+
+# 1000 * 2 ** 10
+storage_multiple("Ki") := 1024000
+
+# 1000 * 2 ** 20
+storage_multiple("Mi") := 1048576000
+
+# 1000 * 2 ** 30
+storage_multiple("Gi") := 1073741824000
+
+# 1000 * 2 ** 40
+storage_multiple("Ti") := 1099511627776000
+
+# 1000 * 2 ** 50
+storage_multiple("Pi") := 1125899906842624000
+
+# 1000 * 2 ** 60
+storage_multiple("Ei") := 1152921504606846976000
+
+get_suffix(storage) := "" if not is_string(storage)
+
+get_suffix(storage) := suffix if {
+	is_string(storage)
+	count(storage) > 0
+	suffix := substring(storage, count(storage) - 1, -1)
+	storage_multiple(suffix)
+}
+
+get_suffix(storage) := suffix if {
+	is_string(storage)
+	count(storage) > 1
+	suffix := substring(storage, count(storage) - 2, -1)
+	storage_multiple(suffix)
+}
+
+get_suffix(storage) := "" if {
+	is_string(storage)
+	count(storage) > 1
+	not storage_multiple(substring(storage, count(storage) - 1, -1))
+	not storage_multiple(substring(storage, count(storage) - 2, -1))
+}
+
+get_suffix(storage) := "" if {
+	is_string(storage)
+	count(storage) == 1
+	not storage_multiple(substring(storage, count(storage) - 1, -1))
+}
+
+get_suffix(storage) := "" if {
+	is_string(storage)
+	count(storage) == 0
+}
+
+canonify_storage(orig) := new if {
+	is_number(orig)
+	new := orig * 1000
+}
+
+canonify_storage(orig) := new if {
+	not is_number(orig)
+	suffix := get_suffix(orig)
+	raw := replace(orig, suffix, "")
+	regex.match(`^[0-9]+(\.[0-9]+)?$`, raw)
+	new := to_number(raw) * storage_multiple(suffix)
+}
+
+violation contains {"msg": msg} if {
+	# spec.containers.resources.limits["ephemeral-storage"] field is immutable.
+	not is_update(input.review)
+
+	general_violation[{"msg": msg, "field": "containers"}]
+}
+
+violation contains {"msg": msg} if {
+	not is_update(input.review)
+	general_violation[{"msg": msg, "field": "initContainers"}]
+}
+
+# Ephemeral containers not checked as it is not possible to set field.
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	storage_orig := container.resources.limits["ephemeral-storage"]
+	not canonify_storage(storage_orig)
+	msg := sprintf("container <%v> ephemeral-storage limit <%v> could not be parsed", [container.name, storage_orig])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	not container.resources
+	msg := sprintf("container <%v> has no resource limits", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	not container.resources.limits
+	msg := sprintf("container <%v> has no resource limits", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	missing(container.resources.limits, "ephemeral-storage")
+	msg := sprintf("container <%v> has no ephemeral-storage limit", [container.name])
+}
+
+general_violation contains {"msg": msg, "field": field} if {
+	some [field, container] in non_exempt_containers
+	storage_orig := container.resources.limits["ephemeral-storage"]
+	storage := canonify_storage(storage_orig)
+	max_storage_orig := input.parameters["ephemeral-storage"]
+	max_storage := canonify_storage(max_storage_orig)
+	storage > max_storage
+	msg := sprintf(
+		"container <%v> ephemeral-storage limit <%v> is higher than the maximum allowed of <%v>",
+		[container.name, storage_orig, max_storage_orig],
+	)
+}
+
+non_exempt_containers contains [field, container] if {
+	some field, containers in input.review.object.spec
+	some container in containers
+	not is_exempt(container)
+}

--- a/src/v1/general/ephemeralstoragelimit/src_test.rego
+++ b/src/v1/general/ephemeralstoragelimit/src_test.rego
@@ -1,0 +1,196 @@
+package k8scontainerephemeralstoragelimit
+
+import rego.v1
+
+test_input_no_violations_int if {
+	inp := {"review": review([ctr("a", 4096)]), "parameters": {"ephemeral-storage": "8192"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_str if {
+	inp := {"review": review([ctr("a", "1Gi")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_str_small if {
+	inp := {"review": review([ctr("a", "100")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_violations_int if {
+	inp := {"review": review([ctr("a", 4096)]), "parameters": {"ephemeral-storage": "2048"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_str if {
+	inp := {"review": review([ctr("a", "2.5Gi")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_str_small if {
+	inp := {"review": review([ctr("a", "130")]), "parameters": {"ephemeral-storage": 128}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_parse_ephemeral_storage if {
+	inp := {"review": review([ctr("a", "123def")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_1_bad_eph if {
+	inp := {"review": review([ctr("a", "1Gi"), ctr("a", "3Gi")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_2_bad_eph if {
+	inp := {"review": review([ctr("a", "2.5Gi"), ctr("a", "3Gi")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_no_eph_limit if {
+	inp := {"review": review([{"name": "a", "resources": {"limits": {"cpu": 1}}}]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_limit if {
+	inp := {"review": review([{"name": "a", "resources": {}}]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_no_resources if {
+	inp := {"review": review([{"name": "a"}]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_containers_checked if {
+	inp := {"review": init_review([ctr("a", "2.2 Ti")]), "parameters": {"ephemeral-storage": "3Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+# # EPH SCALE TESTS
+test_input_no_violations_eph_k if {
+	inp := {"review": review([ctr("a", "100k")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_violations_eph_m if {
+	inp := {"review": review([ctr("a", "10000m")]), "parameters": {"ephemeral-storage": "9"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_K if {
+	inp := {"review": review([ctr("a", "1k")]), "parameters": {"ephemeral-storage": "999"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_M if {
+	inp := {"review": review([ctr("a", "1M")]), "parameters": {"ephemeral-storage": 999999}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_G if {
+	inp := {"review": review([ctr("a", "1G")]), "parameters": {"ephemeral-storage": "999999999"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_T if {
+	inp := {"review": review([ctr("a", "1T")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_P if {
+	inp := {"review": review([ctr("a", "1P")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_E if {
+	inp := {"review": review([ctr("a", "1E")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_Ki if {
+	inp := {"review": review([ctr("a", "1Ki")]), "parameters": {"ephemeral-storage": "1023"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_Mi if {
+	inp := {"review": review([ctr("a", "1Mi")]), "parameters": {"ephemeral-storage": "0.5Mi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_Gi if {
+	inp := {"review": review([ctr("a", "1Gi")]), "parameters": {"ephemeral-storage": "0.22Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_decimal_eph_Gi if {
+	inp := {"review": review([ctr("a", "1.4Gi")]), "parameters": {"ephemeral-storage": "1Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_Ti if {
+	inp := {"review": review([ctr("a", "1Ti")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_Pi if {
+	inp := {"review": review([ctr("a", "1Pi")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_Ei if {
+	inp := {"review": review([ctr("a", "1Ei")]), "parameters": {"ephemeral-storage": "2Gi"}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_eph_Ei_with_exemption if {
+	inp := {"review": review([ctr("a", "1Ei")]), "parameters": {"exemptImages": ["nginx"], "ephemeral-storage": "1Pi"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_update if {
+	inp := {"review": object.union(review([ctr("a", 4096)]), {"operation": "UPDATE"}), "parameters": {"ephemeral-storage": "2048"}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers},
+}}
+
+init_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"initContainers": containers},
+}}
+
+ctr(name, eph_sto) := {"name": name, "image": "nginx", "resources": {"limits": {"ephemeral-storage": eph_sto}}}

--- a/src/v1/general/externalip/constraint.tmpl
+++ b/src/v1/general/externalip/constraint.tmpl
@@ -1,0 +1,30 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sexternalips
+  annotations:
+    metadata.gatekeeper.sh/title: "External IPs"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Restricts Service externalIPs to an allowed list of IP addresses.
+
+      https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sExternalIPs
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedIPs:
+              type: array
+              description: "An allow-list of external IP addresses."
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/externalip/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/externalip/src.rego
+++ b/src/v1/general/externalip/src.rego
@@ -1,0 +1,13 @@
+package k8sexternalips
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	input.review.kind.kind == "Service"
+	input.review.kind.group == ""
+	allowed_ips := {ip | some ip in input.parameters.allowedIPs}
+	external_ips := {ip | some ip in input.review.object.spec.externalIPs}
+	forbidden_ips := external_ips - allowed_ips
+	count(forbidden_ips) > 0
+	msg := sprintf("service has forbidden external IPs: %v", [forbidden_ips])
+}

--- a/src/v1/general/externalip/src_test.rego
+++ b/src/v1/general/externalip/src_test.rego
@@ -1,0 +1,102 @@
+package k8sexternalips
+
+import rego.v1
+
+test_input_non_svc if {
+	inp := {"review": non_svc, "parameters": {"allowedIPs": ["1.2.3.4"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_external_ip if {
+	inp := {"review": non_externalip_svc, "parameters": {"allowedIPs": ["1.2.3.4"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_externalip if {
+	inp := {"review": externalip_svc(["1.2.3.4"]), "parameters": {"allowedIPs": ["1.2.3.4"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_externalip_multiple if {
+	inp := {"review": externalip_svc(["1.2.3.4", "203.0.113.0"]), "parameters": {"allowedIPs": ["1.1.1.1", "203.0.113.0", "1.2.3.4", "203.0.113.1"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_violations_empty if {
+	inp := {"review": externalip_svc([]), "parameters": {"allowedIPs": []}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_violations_externalip if {
+	inp := {"review": externalip_svc(["203.0.113.0"]), "parameters": {"allowedIPs": ["1.1.1.1", "1.2.3.4"]}}
+	results := violation with input as inp
+	results
+	count(results) == 1
+}
+
+test_input_violations_none_allowed if {
+	inp := {"review": externalip_svc(["203.0.113.0"]), "parameters": {"allowedIPs": []}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_partial if {
+	inp := {"review": externalip_svc(["1.2.3.4", "203.0.113.0"]), "parameters": {"allowedIPs": ["1.1.1.1", "1.2.3.4", "203.0.113.1"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_violations_multiple if {
+	inp := {"review": externalip_svc(["1.2.3.4", "203.0.113.0"]), "parameters": {"allowedIPs": ["1.1.1.1", "203.0.113.1"]}}
+	results := violation with input as inp
+	count(results) == 1 # Multiple failing IPs reported in single error message.
+}
+
+externalip_svc(ips) := {
+	"kind": {
+		"group": "",
+		"version": "v1",
+		"kind": "Service",
+	},
+	"object": {
+		"metadata": {"name": "baz"},
+		"spec": {"externalIPs": ips},
+	},
+}
+
+non_externalip_svc := {
+	"kind": {
+		"group": "",
+		"version": "v1",
+		"kind": "Service",
+	},
+	"object": {
+		"metadata": {"name": "baz"},
+		"spec": {
+			"selector": "MyApp",
+			"ports": [{
+				"name": "http",
+				"protocol": "TCP",
+				"port": 80,
+				"targetPort": 8080,
+			}],
+		},
+	},
+}
+
+non_svc := {
+	"kind": {
+		"group": "",
+		"version": "v1",
+		"kind": "Foo",
+	},
+	"object": {
+		"metadata": {"name": "bar"},
+		"spec": {"externalIPs": ["1.1.1.1"]},
+	},
+}

--- a/src/v1/general/horizontalpodautoscaler/constraint.tmpl
+++ b/src/v1/general/horizontalpodautoscaler/constraint.tmpl
@@ -1,0 +1,60 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8shorizontalpodautoscaler
+  annotations:
+    metadata.gatekeeper.sh/title: "Horizontal Pod Autoscaler"
+    metadata.gatekeeper.sh/version: 1.0.1
+    metadata.gatekeeper.sh/requires-sync-data: |
+      "[
+        [
+          {
+            "groups":["apps"],
+            "versions": ["v1"],
+            "kinds": ["Deployment"]
+          },
+          {
+            "groups":["apps"],
+            "versions": ["v1"],
+            "kinds": ["StatefulSet"]
+          }
+        ]
+      ]"
+    description: >-
+      Disallow the following scenarios when deploying `HorizontalPodAutoscalers`
+      1. Deployment of HorizontalPodAutoscalers with `.spec.minReplicas` or `.spec.maxReplicas` outside the ranges defined in the constraint
+      2. Deployment of HorizontalPodAutoscalers where the difference between `.spec.minReplicas` and `.spec.maxReplicas` is less than the configured `minimumReplicaSpread`
+      3. Deployment of HorizontalPodAutoscalers that do not reference a valid `scaleTargetRef` (e.g. Deployment, ReplicationController, ReplicaSet, StatefulSet).
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sHorizontalPodAutoscaler
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            enforceScaleTargetRef:
+              description: If set to true it validates the HPA scaleTargetRef exists
+              type: boolean
+            minimumReplicaSpread:
+              description: If configured it enforces the minReplicas and maxReplicas in an HPA must have a spread of at least this many replicas
+              type: integer
+            ranges:
+              type: array
+              description: Allowed ranges for numbers of replicas.  Values are inclusive.
+              items:
+                type: object
+                description: A range of allowed replicas.  Values are inclusive.
+                properties:
+                  min_replicas:
+                    description: The minimum number of replicas allowed, inclusive.
+                    type: integer
+                  max_replicas:
+                    description: The maximum number of replicas allowed, inclusive.
+                    type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/horizontalpodautoscaler/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/horizontalpodautoscaler/src.rego
+++ b/src/v1/general/horizontalpodautoscaler/src.rego
@@ -1,0 +1,62 @@
+package k8shorizontalpodautoscaler
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	input.review.kind.kind == "HorizontalPodAutoscaler"
+	hpa := input.review.object
+
+	not input_replica_limit(hpa)
+	msg := sprintf(
+		"The %v <%v> minReplicas %v or maxReplicas %v is not allowed. Allowed ranges: %v",
+		[hpa.kind, hpa.metadata.name, hpa.spec.minReplicas, hpa.spec.maxReplicas, input.parameters.ranges],
+	)
+}
+
+violation contains {"msg": msg} if {
+	input.review.kind.kind == "HorizontalPodAutoscaler"
+	hpa := input.review.object
+
+	not input_replica_spread(hpa)
+
+	msg := sprintf(
+		# regal ignore:line-length
+		"The %v <%v> is configured with minReplicas %v and maxReplicas %v which is a spread of %v replica(s). The spread must be at least %v replica(s)",
+		[
+			hpa.kind,
+			hpa.metadata.name,
+			hpa.spec.minReplicas,
+			hpa.spec.maxReplicas,
+			hpa.spec.maxReplicas - hpa.spec.minReplicas,
+			input.parameters.minimumReplicaSpread,
+		],
+	)
+}
+
+violation contains {"msg": msg} if {
+	input.review.kind.kind == "HorizontalPodAutoscaler"
+	input.parameters.enforceScaleTargetRef
+
+	hpa := input.review.object
+
+	not data.inventory.namespace[hpa.metadata.namespace][hpa.spec.scaleTargetRef.apiVersion][hpa.spec.scaleTargetRef.kind][hpa.spec.scaleTargetRef.name]
+	msg := sprintf(
+		# regal ignore:line-length
+		"The HorizontalPodAutoscaler <%v> has a scaleTargetRef of <%v/%v> but it does not exist. The scaleTargetRef for the HorizontalPodAutoscaler must exist",
+		[hpa.metadata.name, hpa.spec.scaleTargetRef.kind, hpa.spec.scaleTargetRef.name],
+	)
+}
+
+input_replica_limit(hpa) if {
+	some range in input.parameters.ranges
+	value_within_range(range, hpa.spec.minReplicas, hpa.spec.maxReplicas)
+}
+
+value_within_range(range, min_provided, max_provided) if {
+	range.min_replicas <= min_provided
+	range.max_replicas >= max_provided
+}
+
+input_replica_spread(hpa) if {
+	hpa.spec.maxReplicas - hpa.spec.minReplicas >= input.parameters.minimumReplicaSpread
+}

--- a/src/v1/general/horizontalpodautoscaler/src_test.rego
+++ b/src/v1/general/horizontalpodautoscaler/src_test.rego
@@ -1,0 +1,115 @@
+package k8shorizontalpodautoscaler
+
+import rego.v1
+
+namespace := "namespace-1"
+
+valid_scale_target_ref := {
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"name": "deployment-1",
+}
+
+invalid_scale_target_ref := {
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"name": "deployment-invalid",
+}
+
+deployment := {
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"metadata": {
+		"name": "deployment-1",
+		"namespace": "namespace-1",
+	},
+	"spec": {"replicas": 1},
+}
+
+test_input_hpa_min_replicas_outside_range if {
+	inp := {"review": input_hpa(2, 5, valid_scale_target_ref), "parameters": input_parameters_valid_range}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hpa_max_replicas_outside_range if {
+	inp := {"review": input_hpa(4, 7, valid_scale_target_ref), "parameters": input_parameters_valid_range}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hpa_replicas_within_range if {
+	inp := {"review": input_hpa(4, 5, valid_scale_target_ref), "parameters": input_parameters_valid_range}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hpa_replicas_equal_range if {
+	inp := {"review": input_hpa(3, 6, valid_scale_target_ref), "parameters": input_parameters_valid_range}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hpa_replicas_below_min_spread if {
+	inp := {"review": input_hpa(3, 4, valid_scale_target_ref), "parameters": input_parameters_min_spread}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hpa_replicas_above_min_spread if {
+	inp := {"review": input_hpa(3, 6, valid_scale_target_ref), "parameters": input_parameters_min_spread}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hpa_replicas_equal_min_spread if {
+	inp := {"review": input_hpa(4, 6, valid_scale_target_ref), "parameters": input_parameters_min_spread}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hpa_invalid_scale_target if {
+	inp := {"review": input_hpa(3, 6, invalid_scale_target_ref), "parameters": input_parameters_enforce_scale_target_ref}
+	inv := inv_deployment(deployment)
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_hpa_valid_scale_target if {
+	inp := {"review": input_hpa(3, 6, valid_scale_target_ref), "parameters": input_parameters_enforce_scale_target_ref}
+	inv := inv_deployment(deployment)
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+hpa(min_replicas, max_replicas, scale_target_ref) := {
+	"apiVersion": "autoscaling/v1",
+	"kind": "HorizontalPodAutoscaler",
+	"metadata": {
+		"name": "hpa-1",
+		"namespace": "namespace-1",
+	},
+	"spec": {
+		"scaleTargetRef": scale_target_ref,
+		"minReplicas": min_replicas,
+		"maxReplicas": max_replicas,
+	},
+}
+
+input_hpa(min_replicas, max_replicas, scale_target_ref) := {
+	"kind": {"kind": "HorizontalPodAutoscaler"},
+	"object": hpa(min_replicas, max_replicas, scale_target_ref),
+}
+
+inventory(obj) := {"namespace": {namespace: {obj.apiVersion: {obj.kind: {obj.metadata.name: obj}}}}}
+
+inv_deployment(deploy) := inventory(deploy)
+
+input_parameters_valid_range := {"ranges": [{
+	"min_replicas": 3,
+	"max_replicas": 6,
+}]}
+
+input_parameters_min_spread := {"minimumReplicaSpread": 2}
+
+input_parameters_enforce_scale_target_ref := {"enforceScaleTargetRef": true}

--- a/src/v1/general/httpsonly/constraint.tmpl
+++ b/src/v1/general/httpsonly/constraint.tmpl
@@ -1,0 +1,38 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8shttpsonly
+  annotations:
+    metadata.gatekeeper.sh/title: "HTTPS Only"
+    metadata.gatekeeper.sh/version: 1.0.2
+    description: >-
+      Requires Ingress resources to be HTTPS only.  Ingress resources must
+      include the `kubernetes.io/ingress.allow-http` annotation, set to `false`.
+      By default a valid TLS {} configuration is required, this can be made
+      optional by setting the `tlsOptional` parameter to `true`.
+
+      https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sHttpsOnly
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Requires Ingress resources to be HTTPS only.  Ingress resources must
+            include the `kubernetes.io/ingress.allow-http` annotation, set to
+            `false`. By default a valid TLS {} configuration is required, this
+            can be made optional by setting the `tlsOptional` parameter to
+            `true`.
+          properties:
+            tlsOptional:
+              type: boolean
+              description: "When set to `true` the TLS {} is optional, defaults
+              to false."
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/httpsonly/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/httpsonly/src.rego
+++ b/src/v1/general/httpsonly/src.rego
@@ -1,0 +1,35 @@
+package k8shttpsonly
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	not https_complete(ingress)
+	not tls_is_optional
+	msg := sprintf(
+		"Ingress should be https. tls configuration and allow-http=false annotation are required for %v",
+		[ingress.metadata.name],
+	)
+}
+
+violation contains {"msg": msg} if {
+	not annotation_complete(ingress)
+	tls_is_optional
+	msg := sprintf("Ingress should be https. The allow-http=false annotation is required for %v", [ingress.metadata.name])
+}
+
+ingress := input.review.object if {
+	input.review.object.kind == "Ingress"
+	regex.match(`^(extensions|networking.k8s.io)/`, input.review.object.apiVersion)
+}
+
+https_complete(ingress) if {
+	ingress.spec.tls
+	count(ingress.spec.tls) > 0
+	ingress.metadata.annotations["kubernetes.io/ingress.allow-http"] == "false"
+}
+
+annotation_complete(ingress) if {
+	ingress.metadata.annotations["kubernetes.io/ingress.allow-http"] == "false"
+}
+
+tls_is_optional if input.parameters.tlsOptional == true

--- a/src/v1/general/httpsonly/src_test.rego
+++ b/src/v1/general/httpsonly/src_test.rego
@@ -1,0 +1,91 @@
+package k8shttpsonly
+
+import rego.v1
+
+test_http_disallowed if {
+	inp := {"review": review_ingress(annotation("false"), tls)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_boolean_annotation if {
+	inp := {"review": review_ingress(annotation(false), tls)}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_true_annotation if {
+	inp := {"review": review_ingress(annotation("true"), tls)}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_missing_annotation if {
+	inp := {"review": review_ingress({}, tls)}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_empty_tls if {
+	inp := {"review": review_ingress({}, empty_tls)}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_missing_tls if {
+	inp := {"review": review_ingress(annotation("false"), {})}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_missing_all if {
+	inp := {"review": review_ingress({}, {})}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_tls_optional_missing_tls if {
+	inp := {"review": review_ingress(annotation("false"), {}), "parameters": {"tlsOptional": true}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_tls_optional_empty_tls if {
+	inp := {"review": review_ingress(annotation("false"), empty_tls), "parameters": {"tlsOptional": true}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_tls_optional_with_tls if {
+	inp := {"review": review_ingress(annotation("false"), tls), "parameters": {"tlsOptional": true}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_tls_optional_true_annotation if {
+	inp := {"review": review_ingress(annotation("true"), {}), "parameters": {"tlsOptional": true}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_tls_optional_missing_annotation if {
+	inp := {"review": review_ingress({}, {}), "parameters": {"tlsOptional": true}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+review_ingress(annotationVal, tlsVal) := {"object": {
+	"kind": "Ingress",
+	"apiVersion": "extensions/v1beta1",
+	"metadata": {
+		"name": "my-ingress",
+		"annotations": annotationVal,
+	},
+	"spec": tlsVal,
+}}
+
+annotation(val) := {"kubernetes.io/ingress.allow-http": val}
+
+empty_tls := {"tls": []}
+
+tls := {"tls": [{"secretName": "secret-cert"}]}

--- a/src/v1/general/imagedigests/constraint.tmpl
+++ b/src/v1/general/imagedigests/constraint.tmpl
@@ -1,0 +1,41 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8simagedigests
+  annotations:
+    metadata.gatekeeper.sh/title: "Image Digests"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Requires container images to contain a digest.
+
+      https://kubernetes.io/docs/concepts/containers/images/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sImageDigests
+      validation:
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Requires container images to contain a digest.
+
+            https://kubernetes.io/docs/concepts/containers/images/
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/imagedigests/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/general/imagedigests/lib_exempt_container.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/imagedigests/lib_exempt_container.rego
+++ b/src/v1/general/imagedigests/lib_exempt_container.rego
@@ -1,0 +1,21 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
+	img := container.image
+	some exemption in exempt_images
+	_matches_exemption(img, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/general/imagedigests/src.rego
+++ b/src/v1/general/imagedigests/src.rego
@@ -1,0 +1,16 @@
+package k8simagedigests
+
+import rego.v1
+
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg} if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+	not is_exempt(container)
+	not regex.match(`@[a-z0-9]+([+._-][a-z0-9]+)*:[a-zA-Z0-9=_-]+`, container.image)
+	msg := sprintf(
+		"%s <%v> uses an image without a digest <%v>",
+		[trim_suffix(type, "s"), container.name, container.image],
+	)
+}

--- a/src/v1/general/imagedigests/src_test.rego
+++ b/src/v1/general/imagedigests/src_test.rego
@@ -1,0 +1,158 @@
+package k8simagedigests
+
+import rego.v1
+
+test_input_allowed_container if {
+	inp := {"review": input_review(input_container_allowed)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_container_with_tag_and_digest if {
+	inp := {"review": input_review(input_container_allowed_with_tag)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_containers_with_registered_algorithms if {
+	inp := {"review": input_review(input_container_allowed_registered_algorithms)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_allowed_containers_with_unregistered_algorithms if {
+	inp := {"review": input_review(input_container_allowed_unregistered_algorithms)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_denied_container if {
+	inp := {"review": input_review(input_container_denied)}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_dual_container if {
+	inp := {"review": input_review(input_container_dual_denied)}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_denied_mixed_container if {
+	inp := {"review": input_review(array.concat(input_container_allowed, input_container_denied))}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_denied_mixed_container_with_exemption if {
+	inp := {"review": input_review(array.concat(input_container_allowed, input_container_denied)), "parameters": {"exemptImages": ["denied/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+# init containers
+test_input_init_allowed_container if {
+	inp := {"review": input_init_review(input_container_allowed)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_init_allowed_container_with_tag_and_digest if {
+	inp := {"review": input_init_review(input_container_allowed_with_tag)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_init_allowed_containers_with_registered_algorithms if {
+	inp := {"review": input_init_review(input_container_allowed_registered_algorithms)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_init_allowed_containers_with_unregistered_algorithms if {
+	inp := {"review": input_init_review(input_container_allowed_unregistered_algorithms)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_init_denied_container if {
+	inp := {"review": input_init_review(input_container_denied)}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_init_denied_dual_container if {
+	inp := {"review": input_init_review(input_container_dual_denied)}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_init_denied_mixed_container if {
+	inp := {"review": input_init_review(array.concat(input_container_allowed, input_container_denied))}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_init_denied_mixed_container_with_exemption if {
+	inp := {"review": input_init_review(array.concat(input_container_allowed, input_container_denied)), "parameters": {"exemptImages": ["denied/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": containers},
+}}
+
+input_init_review(containers) := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"initContainers": containers},
+}}
+
+input_container_allowed := [{
+	"name": "image-with-sha256",
+	"image": "allowed/nginx@sha256:b0ad43f7ee5edbc0effbc14645ae7055e21bc1973aee5150745632a24a752661",
+}]
+
+input_container_allowed_with_tag := [{
+	"name": "image-with-tag-and-sha256",
+	"image": "allowed/nginx:1.19.2@sha256:b0ad43f7ee5edbc0effbc14645ae7055e21bc1973aee5150745632a24a752661",
+}]
+
+input_container_allowed_registered_algorithms := [
+	{
+		"name": "image-with-sha256",
+		"image": "allowed/nginx@sha256:b0ad43f7ee5edbc0effbc14645ae7055e21bc1973aee5150745632a24a752661",
+	},
+	{
+		"name": "image-with-sha512",
+		"image": "allowed/nginx@sha512:4b8bea0e757264767b373ba4963f4e972c428f42bf5335c2abb2e7f15a1b07c8aeddd2e62cacd0f2d669f49d8d975d952031e3041371639ec84baab400ab4802",
+	},
+]
+
+input_container_allowed_unregistered_algorithms := [
+	{
+		"name": "unreg-multihash",
+		"image": "allowed/unreg@multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8",
+	},
+	{
+		"name": "unreg-sha256-with-base64url",
+		"image": "allowed/unreg@sha256+b64u:LCa0a2j_xo_5m0U8HTBBNBNCLXBkg7-g-YpeiGJm564",
+	},
+]
+
+input_container_denied := [{
+	"name": "nginx",
+	"image": "denied/nginx:1.19.2",
+}]
+
+input_container_dual_denied := [
+	{
+		"name": "nginx",
+		"image": "denied/nginx:1.19.2",
+	},
+	{
+		"name": "other",
+		"image": "denied/other",
+	},
+]

--- a/src/v1/general/noupdateserviceaccount/constraint.tmpl
+++ b/src/v1/general/noupdateserviceaccount/constraint.tmpl
@@ -1,0 +1,31 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: noupdateserviceaccount
+  annotations:
+    metadata.gatekeeper.sh/title: "Block updating Service Account"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: "Blocks updating the service account on resources that abstract over Pods. This policy is ignored in audit mode."
+spec:
+  crd:
+    spec:
+      names:
+        kind: NoUpdateServiceAccount
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedGroups:
+              description: Groups that should be allowed to bypass the policy.
+              type: array
+              items:
+                type: string
+            allowedUsers:
+              description: Users that should be allowed to bypass the policy.
+              type: array
+              items:
+                type: string
+  targets:
+  - target: admission.k8s.gatekeeper.sh
+    rego: |
+{{ file.Read "src/general/noupdateserviceaccount/src.rego" | strings.Indent 6 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/noupdateserviceaccount/src.rego
+++ b/src/v1/general/noupdateserviceaccount/src.rego
@@ -1,0 +1,72 @@
+package noupdateserviceaccount
+
+import rego.v1
+
+privileged(user_info, allowed_users, _) if {
+	# Allow if the user is in allowedUsers.
+	# Use object.get so omitted parameters can't cause policy bypass by
+	# evaluating to undefined.
+	username := object.get(user_info, "username", "")
+	username in allowed_users
+}
+
+privileged(user_info, _, allowed_groups) if {
+	# Allow if the user's groups intersect allowedGroups.
+	# Use object.get so omitted parameters can't cause policy bypass by
+	# evaluating to undefined.
+	groups := {g | some g in user_info.groups}
+	allowed := {g | some g in allowed_groups}
+	common := groups & allowed
+	count(common) > 0
+}
+
+get_service_account(obj) := obj.spec.serviceAccountName if obj.kind == "Pod"
+
+get_service_account(obj) := obj.spec.template.spec.serviceAccountName if obj.kind == "ReplicationController"
+
+get_service_account(obj) := obj.spec.template.spec.serviceAccountName if obj.kind == "ReplicaSet"
+
+get_service_account(obj) := obj.spec.template.spec.serviceAccountName if obj.kind == "Deployment"
+
+get_service_account(obj) := obj.spec.template.spec.serviceAccountName if obj.kind == "StatefulSet"
+
+get_service_account(obj) := obj.spec.template.spec.serviceAccountName if obj.kind == "DaemonSet"
+
+get_service_account(obj) := obj.spec.template.spec.serviceAccountName if obj.kind == "Job"
+
+get_service_account(obj) := obj.spec.jobTemplate.spec.template.spec.serviceAccountName if obj.kind == "CronJob"
+
+violation contains {"msg": msg} if {
+	# This policy only applies to updates of existing resources.
+	input.review.operation == "UPDATE"
+
+	# Use object.get so omitted parameters can't cause policy bypass by
+	# evaluating to undefined.
+	params := object.get(input, "parameters", {})
+	allowed_users := object.get(params, "allowedUsers", [])
+	allowed_groups := object.get(params, "allowedGroups", [])
+
+	# Deny unprivileged users and groups from changing serviceAccountName.
+	not privileged(input.review.userInfo, allowed_users, allowed_groups)
+
+	# Extract the service account.
+	old_ksa := get_service_account(input.review.oldObject)
+	new_ksa := get_service_account(input.review.object)
+	old_ksa != new_ksa
+
+	msg := "user does not have permission to modify serviceAccountName"
+}
+
+violation contains {"msg": msg} if {
+	# Defensively require object to have a serviceAccountName.
+	input.review.operation == "UPDATE"
+	not get_service_account(input.review.object)
+	msg := "missing serviceAccountName field in object under review"
+}
+
+violation contains {"msg": msg} if {
+	# Defensively require oldObject to have a serviceAccountName.
+	input.review.operation == "UPDATE"
+	not get_service_account(input.review.oldObject)
+	msg := "missing serviceAccountName field in oldObject under review"
+}

--- a/src/v1/general/noupdateserviceaccount/src_test.rego
+++ b/src/v1/general/noupdateserviceaccount/src_test.rego
@@ -1,0 +1,249 @@
+package noupdateserviceaccount
+
+import rego.v1
+
+# Pod
+pod_spec(sa_name) := {"serviceAccountName": sa_name}
+
+pod(sa_name) := {
+	"kind": "Pod",
+	"spec": pod_spec(sa_name),
+}
+
+test_deny_pod if {
+	inp := {
+		"review": update(pod("sa1"), pod("sa2"), {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	result == policy_violation
+}
+
+# ReplicationController
+rc(sa_name) := {
+	"kind": "ReplicationController",
+	"spec": {"template": {"spec": pod_spec(sa_name)}},
+}
+
+test_deny_rc if {
+	inp := {
+		"review": update(rc("sa1"), rc("sa2"), {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	result == policy_violation
+}
+
+# ReplicaSet
+rs(sa_name) := {
+	"kind": "ReplicaSet",
+	"spec": {"template": {"spec": pod_spec(sa_name)}},
+}
+
+test_deny_rs if {
+	inp := {
+		"review": update(rs("sa1"), rs("sa2"), {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	result == policy_violation
+}
+
+# Deployment
+deploy(sa_name) := {
+	"kind": "Deployment",
+	"spec": {"template": {"spec": pod_spec(sa_name)}},
+}
+
+test_deny_deploy if {
+	inp := {
+		"review": update(deploy("sa1"), deploy("sa2"), {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	result == policy_violation
+}
+
+# StatefulSet
+ss(sa_name) := {
+	"kind": "StatefulSet",
+	"spec": {"template": {"spec": pod_spec(sa_name)}},
+}
+
+test_deny_ss if {
+	inp := {
+		"review": update(ss("sa1"), ss("sa2"), {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	result == policy_violation
+}
+
+# DaemonSet
+ds(sa_name) := {
+	"kind": "DaemonSet",
+	"spec": {"template": {"spec": pod_spec(sa_name)}},
+}
+
+test_deny_ds if {
+	inp := {
+		"review": update(ds("sa1"), ds("sa2"), {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	result == policy_violation
+}
+
+# Job
+job(sa_name) := {
+	"kind": "Job",
+	"spec": {"template": {"spec": pod_spec(sa_name)}},
+}
+
+test_deny_job if {
+	inp := {
+		"review": update(job("sa1"), job("sa2"), {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	result == policy_violation
+}
+
+# CronJob
+cronjob(sa_name) := {
+	"kind": "CronJob",
+	"spec": {"jobTemplate": {"spec": {"template": {"spec": pod_spec(sa_name)}}}},
+}
+
+test_deny_cronjob if {
+	inp := {
+		"review": update(cronjob("sa1"), cronjob("sa2"), {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	result == policy_violation
+}
+
+# Allow unrelated modification
+test_allow_unrelated if {
+	a := deploy("sa")
+	b := {
+		"kind": "Deployment",
+		"spec": {"template": {"spec": {
+			"serviceAccountName": "sa",
+			"containers": [{"name": "newcontainer"}],
+		}}},
+	}
+	inp := {
+		"review": update(a, b, {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	count(result) == 0
+}
+
+# Allow create and delete
+test_allow_create if {
+	inp := {
+		"review": create(deploy("sa1")),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	count(result) == 0
+}
+
+test_allow_delete if {
+	inp := {
+		"review": delete(deploy("sa1")),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	count(result) == 0
+}
+
+# Allowlist users and groups
+test_allow_users if {
+	inp := {
+		"review": update(deploy("sa1"), deploy("sa2"), {"username": "myuser"}),
+		"parameters": allow(["myuser"], []),
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	count(result) == 0
+}
+
+test_allow_groups if {
+	inp := {
+		"review": update(deploy("sa1"), deploy("sa2"), {"groups": ["mygroup"]}),
+		"parameters": allow([], ["mygroup"]),
+	}
+	result := violation with input as inp
+	trace(sprintf("result: %v", [result]))
+	count(result) == 0
+}
+
+# Malformed
+test_deny_missing_old if {
+	inp := {
+		"review": update({}, pod("sa"), {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("%v", [result]))
+	result == missing_old_violation
+}
+
+test_deny_missing_new if {
+	inp := {
+		"review": update(pod("sa"), {}, {}),
+		"parameters": {},
+	}
+	result := violation with input as inp
+	trace(sprintf("%v", [result]))
+	result == missing_new_violation
+}
+
+# Other helpers
+
+update(old, new, user) := {
+	"operation": "UPDATE",
+	"oldObject": old,
+	"object": new,
+	"userInfo": user,
+}
+
+create(obj) := {
+	"operation": "CREATE",
+	"oldObject": null,
+	"object": obj,
+	"userInfo": {},
+}
+
+delete(obj) := {
+	"operation": "DELETE",
+	"oldObject": obj,
+	"object": null,
+	"userInfo": {},
+}
+
+allow(users, groups) := {
+	"allowedUsers": users,
+	"allowedGroups": groups,
+}
+
+missing_old_violation contains {"msg": "missing serviceAccountName field in oldObject under review"}
+
+missing_new_violation contains {"msg": "missing serviceAccountName field in object under review"}
+
+policy_violation contains {"msg": "user does not have permission to modify serviceAccountName"}

--- a/src/v1/general/poddisruptionbudget/constraint.tmpl
+++ b/src/v1/general/poddisruptionbudget/constraint.tmpl
@@ -1,0 +1,33 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spoddisruptionbudget
+  annotations:
+    metadata.gatekeeper.sh/title: "Pod Disruption Budget"
+    metadata.gatekeeper.sh/version: 1.0.4
+    metadata.gatekeeper.sh/requires-sync-data: |
+      "[
+        [
+          {
+            "groups":["policy"],
+            "versions": ["v1"],
+            "kinds": ["PodDisruptionBudget"]
+          }
+        ]
+      ]"
+    description: >-
+      Disallow the following scenarios when deploying PodDisruptionBudgets or resources that implement the replica subresource (e.g. Deployment, ReplicationController, ReplicaSet, StatefulSet):
+      1. Deployment of PodDisruptionBudgets with .spec.maxUnavailable == 0
+      2. Deployment of PodDisruptionBudgets with .spec.minAvailable == .spec.replicas of the resource with replica subresource
+      This will prevent PodDisruptionBudgets from blocking voluntary disruptions such as node draining.
+
+      https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPodDisruptionBudget
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/poddisruptionbudget/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/poddisruptionbudget/src.rego
+++ b/src/v1/general/poddisruptionbudget/src.rego
@@ -1,0 +1,64 @@
+package k8spoddisruptionbudget
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	input.review.kind.kind == "PodDisruptionBudget"
+	pdb := input.review.object
+
+	not valid_pdb_max_unavailable(pdb)
+	msg := sprintf(
+		"PodDisruptionBudget <%v> has maxUnavailable of 0, only positive integers are allowed for maxUnavailable",
+		[pdb.metadata.name],
+	)
+}
+
+violation contains {"msg": msg} if {
+	obj := input.review.object
+	labels := {[label, value] | some label, value in obj.spec.selector.matchLabels}
+
+	some pdb in data.inventory.namespace[obj.metadata.namespace]["policy/v1"].PodDisruptionBudget
+
+	match_labels := {[label, value] | some label, value in pdb.spec.selector.matchLabels}
+	count(match_labels - labels) == 0
+
+	not valid_pdb_max_unavailable(pdb)
+	msg := sprintf(
+		# regal ignore:line-length
+		"%v <%v> has been selected by PodDisruptionBudget <%v> but has maxUnavailable of 0, only positive integers are allowed for maxUnavailable",
+		[obj.kind, obj.metadata.name, pdb.metadata.name],
+	)
+}
+
+violation contains {"msg": msg} if {
+	obj := input.review.object
+	labels := {[label, value] | some label, value in obj.spec.selector.matchLabels}
+
+	some pdb in data.inventory.namespace[obj.metadata.namespace]["policy/v1"].PodDisruptionBudget
+
+	match_labels := {[label, value] | some label, value in pdb.spec.selector.matchLabels}
+	count(match_labels - labels) == 0
+
+	not valid_pdb_min_available(obj, pdb)
+	msg := sprintf(
+		# regal ignore:line-length
+		"%v <%v> has %v replica(s) but PodDisruptionBudget <%v> has minAvailable of %v, PodDisruptionBudget count should always be lower than replica(s), and not used when replica(s) is set to 1",
+		[obj.kind, obj.metadata.name, obj.spec.replicas, pdb.metadata.name, pdb.spec.minAvailable],
+	)
+}
+
+valid_pdb_min_available(obj, pdb) if {
+	# default to -1 if minAvailable is not set so valid_pdb_min_available is always true
+	# for objects with >= 0 replicas. If minAvailable defaults to >= 0, objects with
+	# replicas field might violate this constraint if they are equal to the default set here
+	min_available := object.get(pdb.spec, "minAvailable", -1)
+	obj.spec.replicas > min_available
+}
+
+valid_pdb_max_unavailable(pdb) if {
+	# default to 1 if maxUnavailable is not set so valid_pdb_max_unavailable always returns true.
+	# If maxUnavailable defaults to 0, it violates this constraint because all pods needs to be
+	# available and no pods can be evicted voluntarily
+	max_unavailable := object.get(pdb.spec, "maxUnavailable", 1)
+	max_unavailable > 0
+}

--- a/src/v1/general/poddisruptionbudget/src_test.rego
+++ b/src/v1/general/poddisruptionbudget/src_test.rego
@@ -1,0 +1,111 @@
+package k8spoddisruptionbudget
+
+import rego.v1
+
+namespace := "namespace-1"
+
+match_labels := {"matchLabels": {
+	"key1": "val1",
+	"key2": "val2",
+}}
+
+test_input_pdb_0_max_unavailable if {
+	inp := {"review": input_pdb_max_unavailable(0)}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_pdb_1_max_unavailable if {
+	inp := {"review": input_pdb_max_unavailable(1)}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_deployment_1_replica_pdb_1_min_available if {
+	inp := {"review": input_deployment(1)}
+	inv := inv_pdb_min_available(1)
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_deployment_2_replicas_pdb_1_min_available if {
+	inp := {"review": input_deployment(2)}
+	inv := inv_pdb_min_available(1)
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_input_deployment_pdb_0_max_unavailable if {
+	inp := {"review": input_deployment(2)}
+	inv := inv_pdb_max_unavailable(0)
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_deployment_pdb_1_max_unavailable if {
+	inp := {"review": input_deployment(2)}
+	inv := inv_pdb_max_unavailable(1)
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+pdb_min_available(min_available) := {
+	"apiVersion": "policy/v1",
+	"kind": "PodDisruptionBudget",
+	"metadata": {
+		"name": "pdb-1",
+		"namespace": "namespace-1",
+	},
+	"spec": {
+		"selector": match_labels,
+		"minAvailable": min_available,
+	},
+}
+
+pdb_max_unavailable(max_unavailable) := {
+	"apiVersion": "policy/v1",
+	"kind": "PodDisruptionBudget",
+	"metadata": {
+		"name": "pdb-1",
+		"namespace": "namespace-1",
+	},
+	"spec": {
+		"selector": match_labels,
+		"maxUnavailable": max_unavailable,
+	},
+}
+
+deployment(replicas) := {
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"metadata": {
+		"name": "deployment-1",
+		"namespace": "namespace-1",
+	},
+	"spec": {
+		"replicas": replicas,
+		"selector": match_labels,
+	},
+}
+
+input_pdb_max_unavailable(max_unavailable) := {
+	"kind": {"kind": "PodDisruptionBudget"},
+	"object": pdb_max_unavailable(max_unavailable),
+}
+
+input_deployment(replicas) := {
+	"kind": {"kind": "Deployment"},
+	"object": deployment(replicas),
+}
+
+inventory(obj) := {"namespace": {namespace: {obj.apiVersion: {obj.kind: [obj]}}}}
+
+inv_pdb_min_available(min_available) := output if {
+	pdb = pdb_min_available(min_available)
+	output := inventory(pdb)
+}
+
+inv_pdb_max_unavailable(max_unavailable) := output if {
+	pdb = pdb_max_unavailable(max_unavailable)
+	output := inventory(pdb)
+}

--- a/src/v1/general/replicalimits/constraint.tmpl
+++ b/src/v1/general/replicalimits/constraint.tmpl
@@ -1,0 +1,37 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sreplicalimits
+  annotations:
+    metadata.gatekeeper.sh/title: "Replica Limits"
+    metadata.gatekeeper.sh/version: 1.0.2
+    description: >-
+      Requires that objects with the field `spec.replicas` (Deployments,
+      ReplicaSets, etc.) specify a number of replicas within defined ranges.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sReplicaLimits
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            ranges:
+              type: array
+              description: Allowed ranges for numbers of replicas.  Values are inclusive.
+              items:
+                type: object
+                description: A range of allowed replicas.  Values are inclusive.
+                properties:
+                  min_replicas:
+                    description: The minimum number of replicas allowed, inclusive.
+                    type: integer
+                  max_replicas:
+                    description: The maximum number of replicas allowed, inclusive.
+                    type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/replicalimits/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/replicalimits/src.rego
+++ b/src/v1/general/replicalimits/src.rego
@@ -1,0 +1,17 @@
+package k8sreplicalimits
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	not input_replica_limit(input.review.object.spec)
+	msg := sprintf(
+		"The provided number of replicas is not allowed for %v: %v. Allowed ranges: %v",
+		[input.review.kind.kind, input.review.object.metadata.name, input.parameters],
+	)
+}
+
+input_replica_limit(spec) if {
+	some range in input.parameters.ranges
+	range.min_replicas <= spec.replicas
+	range.max_replicas >= spec.replicas
+}

--- a/src/v1/general/replicalimits/src_test.rego
+++ b/src/v1/general/replicalimits/src_test.rego
@@ -1,0 +1,69 @@
+package k8sreplicalimits
+
+import rego.v1
+
+test_input_empty if {
+	inp := {"review": empty, "parameters": {}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_within_required_replicas if {
+	inp := {"review": review(6), "parameters": input_parameters_valid_range}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_exact_required_replicas_min if {
+	inp := {"review": review(5), "parameters": input_parameters_valid_range}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_exact_required_replicas_max if {
+	inp := {"review": review(35), "parameters": input_parameters_valid_range}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_not_enough_required_replicas if {
+	inp := {"review": review(1), "parameters": input_parameters_valid_range}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_too_many_replicas if {
+	inp := {"review": review(100), "parameters": input_parameters_valid_range}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_zero_replicas if {
+	inp := {"review": review(0), "parameters": input_parameters_zero_range}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+empty := {"object": {"metadata": {"name": "nginx"}}}
+
+review(replicas) := {
+	"kind": {
+		"kind": "Deployment",
+		"version": "v1",
+		"group": "apps",
+	},
+	"object": {
+		"metadata": {"name": "nginx"},
+		"spec": {"replicas": replicas},
+	},
+}
+
+input_parameters_valid_range := {"ranges": [{
+	"min_replicas": 5,
+	"max_replicas": 35,
+}]}
+
+input_parameters_zero_range := {"ranges": [{
+	"min_replicas": 0,
+	"max_replicas": 0,
+}]}

--- a/src/v1/general/requiredannotations/constraint.tmpl
+++ b/src/v1/general/requiredannotations/constraint.tmpl
@@ -1,0 +1,42 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredannotations
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Annotations"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Requires resources to contain specified annotations, with values matching
+      provided regular expressions.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredAnnotations
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+            annotations:
+              type: array
+              description: >-
+                A list of annotations and values the object must specify.
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: >-
+                      The required annotation.
+                  allowedRegex:
+                    type: string
+                    description: >-
+                      If specified, a regular expression the annotation's value
+                      must match. The value must contain at least one match for
+                      the regular expression.
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/requiredannotations/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/requiredannotations/src.rego
+++ b/src/v1/general/requiredannotations/src.rego
@@ -1,0 +1,20 @@
+package k8srequiredannotations
+
+import rego.v1
+
+violation contains {"msg": msg, "details": {"missing_annotations": missing}} if {
+	provided := {key | some key in object.keys(input.review.object.metadata.annotations)}
+	required := {annotation.key | some annotation in input.parameters.annotations}
+	missing := required - provided
+	count(missing) > 0
+	msg := sprintf("you must provide annotation(s): %v", [missing])
+}
+
+violation contains {"msg": msg} if {
+	some key, value in input.review.object.metadata.annotations
+	some expected in input.parameters.annotations
+	expected.key == key
+	expected.allowedRegex != ""
+	not regex.match(expected.allowedRegex, value)
+	msg := sprintf("Annotation <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+}

--- a/src/v1/general/requiredannotations/src_test.rego
+++ b/src/v1/general/requiredannotations/src_test.rego
@@ -1,0 +1,84 @@
+package k8srequiredannotations
+
+import rego.v1
+
+test_input_no_required_annotations if {
+	inp := {"review": review({"some": "annotation"}), "parameters": {}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_required_annotations_none_provided if {
+	inp := {"review": empty, "parameters": {}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_has_annotation if {
+	inp := {"review": review({"some": "annotation"}), "parameters": {"annotations": [lbl("some", "annotation")]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_has_extra_annotation if {
+	inp := {"review": review({"some": "annotation", "new": "thing"}), "parameters": {"annotations": [lbl("some", "annotation")]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_has_extra_annotation_req2 if {
+	inp := {"review": review({"some": "annotation", "new": "thing"}), "parameters": {"annotations": [lbl("some", "annotation"), lbl("new", "thing")]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_missing_annotation if {
+	inp := {"review": review({"some_other": "annotation"}), "parameters": {"annotations": [lbl("some", "annotation")]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_wrong_value if {
+	inp := {"review": review({"some": "annotation2"}), "parameters": {"annotations": [lbl("some", "annotation$")]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_one_missing if {
+	inp := {"review": review({"some": "annotation"}), "parameters": {"annotations": [lbl("some", "annotation"), lbl("other", "annotation")]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_wrong_empty if {
+	inp := {"review": empty, "parameters": {"annotations": [lbl("some", "label$")]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_two_missing if {
+	inp := {"review": empty, "parameters": {"annotations": [lbl("some", "annotation"), lbl("other", "annotation")]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_two_wrong if {
+	inp := {"review": review({"some": "lbe", "other": "lbe"}), "parameters": {"annotations": [lbl("some", "annotation"), lbl("other", "annotation")]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_two_allowed if {
+	inp := {"review": review({"some": "gray", "other": "grey"}), "parameters": {"annotations": [lbl("some", "gr[ae]y"), lbl("other", "gr[ae]y")]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+empty := {"object": {"metadata": {"name": "service"}}}
+
+review(annotations) := {"object": {"metadata": {
+	"name": "service",
+	"annotations": annotations,
+}}}
+
+lbl(k, v) := {"key": k, "allowedRegex": v}

--- a/src/v1/general/requiredlabels/constraint.tmpl
+++ b/src/v1/general/requiredlabels/constraint.tmpl
@@ -1,0 +1,49 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredlabels
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Labels"
+    metadata.gatekeeper.sh/version: 1.1.2
+    description: >-
+      Requires resources to contain specified labels, with values matching
+      provided regular expressions.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredLabels
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+            labels:
+              type: array
+              description: >-
+                A list of labels and values the object must specify.
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: >-
+                      The required label.
+                  allowedRegex:
+                    type: string
+                    description: >-
+                      If specified, a regular expression the annotation's value
+                      must match. The value must contain at least one match for
+                      the regular expression.
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/general/requiredlabels/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/general/requiredlabels/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+

--- a/src/v1/general/requiredlabels/src.rego
+++ b/src/v1/general/requiredlabels/src.rego
@@ -1,0 +1,30 @@
+package k8srequiredlabels
+
+import rego.v1
+
+violation contains {"msg": msg, "details": {"missing_labels": missing}} if {
+	provided := {label | some label in object.keys(input.review.object.metadata.labels)}
+	required := {label.key | some label in input.parameters.labels}
+	missing := required - provided
+	count(missing) > 0
+	def_msg := sprintf("you must provide labels: %v", [missing])
+	msg := get_message(input.parameters, def_msg)
+}
+
+violation contains {"msg": msg} if {
+	some key, value in input.review.object.metadata.labels
+	some expected in input.parameters.labels
+	expected.key == key
+
+	# do not match if allowedRegex is not defined, or is an empty string
+	expected.allowedRegex != ""
+	not regex.match(expected.allowedRegex, value)
+	def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+	msg := get_message(input.parameters, def_msg)
+}
+
+get_message(parameters, _default) := _default if {
+	not parameters.message
+}
+
+get_message(parameters, _) := parameters.message

--- a/src/v1/general/requiredlabels/src_test.rego
+++ b/src/v1/general/requiredlabels/src_test.rego
@@ -1,0 +1,90 @@
+package k8srequiredlabels
+
+import rego.v1
+
+test_input_no_required_labels_some_provided if {
+	inp := {"review": review({"some": "label"}), "parameters": {}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_required_labels_none_provided if {
+	inp := {"review": empty, "parameters": {}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_has_label if {
+	inp := {"review": review({"some": "label"}), "parameters": {"labels": [lbl("some", "label")]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_has_extra_label if {
+	inp := {"review": review({"some": "label", "new": "thing"}), "parameters": {"labels": [lbl("some", "label")]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_has_extra_label_req2 if {
+	inp := {"review": review({"some": "label", "new": "thing"}), "parameters": {"labels": [lbl("some", "label"), lbl("new", "thing")]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_missing_label if {
+	inp := {"review": review({"some_other": "label"}), "parameters": {"labels": [lbl("some", "label")]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_wrong_value if {
+	inp := {"review": review({"some": "label2"}), "parameters": {"labels": [lbl("some", "label$")]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_one_missing if {
+	inp := {"review": review({"some": "label"}), "parameters": {"labels": [lbl("some", "label"), lbl("other", "label")]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_wrong_empty if {
+	inp := {"review": empty, "parameters": {"labels": [lbl("some", "label$")]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_two_missing if {
+	inp := {"review": empty, "parameters": {"labels": [lbl("some", "label"), lbl("other", "label")]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_two_wrong if {
+	inp := {"review": review({"some": "lbe", "other": "lbe"}), "parameters": {"labels": [lbl("some", "label"), lbl("other", "label")]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_two_allowed if {
+	inp := {"review": review({"some": "gray", "other": "grey"}), "parameters": {"labels": [lbl("some", "gr[ae]y"), lbl("other", "gr[ae]y")]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_message if {
+	inp := {"review": review({"some": "label2"}), "parameters": {"message": "WRONG_VALUE", "labels": [lbl("some", "label$")]}}
+	results := violation with input as inp
+	results[_].msg == "WRONG_VALUE"
+}
+
+empty := {"object": {"metadata": {"name": "nginx"}}}
+
+review(labels) := {"object": {"metadata": {
+	"name": "nginx",
+	"labels": labels,
+}}}
+
+lbl(k, v) := {"key": k, "allowedRegex": v}

--- a/src/v1/general/requiredprobes/constraint.tmpl
+++ b/src/v1/general/requiredprobes/constraint.tmpl
@@ -1,0 +1,34 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredprobes
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Probes"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: Requires Pods to have readiness and/or liveness probes.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredProbes
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            probes:
+              description: "A list of probes that are required (ex: `readinessProbe`)"
+              type: array
+              items:
+                type: string
+            probeTypes:
+              description: "The probe must define a field listed in `probeType` in order to satisfy the constraint (ex. `tcpSocket` satisfies `['tcpSocket', 'exec']`)"
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/requiredprobes/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/general/requiredprobes/lib_exclude_update.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/requiredprobes/lib_exclude_update.rego
+++ b/src/v1/general/requiredprobes/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/general/requiredprobes/src.rego
+++ b/src/v1/general/requiredprobes/src.rego
@@ -1,0 +1,33 @@
+package k8srequiredprobes
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+
+probe_type_set := {type | some type in input.parameters.probeTypes}
+
+violation contains {"msg": msg} if {
+	# Probe fields are immutable.
+	not is_update(input.review)
+
+	some container in input.review.object.spec.containers
+	some probe in input.parameters.probes
+	probe_is_missing(container, probe)
+	msg := get_violation_message(container, input.review, probe)
+}
+
+probe_is_missing(ctr, probe) if not ctr[probe]
+
+probe_is_missing(ctr, probe) if probe_field_empty(ctr, probe)
+
+probe_field_empty(ctr, probe) if {
+	probe_fields := object.keys(ctr[probe])
+	diff_fields := probe_type_set - probe_fields
+	count(diff_fields) == count(probe_type_set)
+}
+
+get_violation_message(container, review, probe) := sprintf("Container <%v> in your <%v> <%v> has no <%v>", [
+	container.name, review.kind.kind,
+	review.object.metadata.name,
+	probe,
+])

--- a/src/v1/general/requiredprobes/src_test.rego
+++ b/src/v1/general/requiredprobes/src_test.rego
@@ -1,0 +1,459 @@
+package k8srequiredprobes
+
+import rego.v1
+
+test_one_ctr_no_violations if {
+	inp := {
+		"review": review([{"name": "my-container", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {"tcpSocket": {"port": 80}}}]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_one_ctr_readiness_violation if {
+	inp := {
+		"review": review([{"name": "my-container", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 80}}}]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_one_ctr_liveness_violation if {
+	inp := {
+		"review": review([{"name": "my-container", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}}]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_one_ctr_all_violations if {
+	inp := {
+		"review": review([{"name": "my-container", "image": "my-image:latest"}]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_no_violations if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_two_ctrs_all_violations_in_both if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest"},
+			{"name": "my-container2", "image": "my-image:latest"},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 4
+}
+
+test_two_ctrs_all_violations_in_ctr_one if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest"},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {"tcpSocket": {"port": 80}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_all_violations_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest"},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_readiness_violation_in_ctr_one if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_two_ctrs_readiness_violation_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+			{"name": "my-container2", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 80}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_two_ctrs_readiness_violation_in_both if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 8080}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_liveness_violation_in_ctr_one if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_two_ctrs_liveness_violation_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_two_ctrs_liveness_violation_in_both if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_readiness_in_one_liveness_in_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_liveness_in_one_readiness_in_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 8080}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_readiness_violation_in_ctr_one_all_violations_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest"},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_two_ctrs_liveness_violation_in_ctr_one_all_violations_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest"},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_two_ctrs_readiness_violation_in_ctr_two_all_violations_in_ctr_one if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest"},
+			{"name": "my-container2", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 80}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_two_ctrs_liveness_violation_in_ctr_two_all_violations_in_ctr_one if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest"},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_one_ctr_empty_readiness_violation if {
+	inp := {
+		"review": review([{"name": "my-container", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {"tcpSocket": {"port": 80}}}]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_one_ctr_empty_liveness_violation if {
+	inp := {
+		"review": review([{"name": "my-container", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {}}]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_one_ctr_empty_probes_violations if {
+	inp := {
+		"review": review([{"name": "my-container", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {}}]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_empty_probes_violation_in_both if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 4
+}
+
+test_two_ctrs_empty_probes_violation_in_ctr_one if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {"tcpSocket": {"port": 80}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_empty_probes_violation_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_empty_readiness_violation_in_ctr_one if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 80}}, "readinessProbe": {}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_two_ctrs_empty_readiness_violation_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {"tcpSocket": {"port": 80}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_two_ctrs_empty_readiness_violation_in_both if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_empty_liveness_violation_in_ctr_one if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_two_ctrs_empty_liveness_violation_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_two_ctrs_empty_liveness_violation_in_both if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_empty_readiness_in_ctr_one_empty_liveness_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 8080}}, "livenessProbe": {}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_empty_liveness_in_one_empty_readiness_in_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {"tcpSocket": {"port": 8080}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_two_ctrs_empty_readiness_in_ctr_one_both_empty_probes_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {"tcpSocket": {"port": 80}}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_two_ctrs_empty_liveness_in_ctr_one_both_empty_probes_in_ctr_two if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_two_ctrs_empty_readiness_in_ctr_two_both_empty_probes_in_ctr_one if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {"tcpSocket": {"port": 80}}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_two_ctrs_empty_liveness_in_ctr_two_both_empty_probes_in_ctr_one if {
+	inp := {
+		"review": review([
+			{"name": "my-container1", "image": "my-image:latest", "readinessProbe": {}, "livenessProbe": {}},
+			{"name": "my-container2", "image": "my-image:latest", "readinessProbe": {"tcpSocket": {"port": 80}}, "livenessProbe": {}},
+		]),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_update if {
+	inp := {
+		"review": object.union(review([{"name": "my-container", "image": "my-image:latest", "livenessProbe": {"tcpSocket": {"port": 80}}}]), {"operation": "UPDATE"}),
+		"parameters": parameters,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+review(containers) := {
+	"kind": {"kind": "Pod"},
+	"object": {
+		"metadata": {"name": "some-name"},
+		"spec": {"containers": containers},
+	},
+}
+
+parameters := {"probes": ["readinessProbe", "livenessProbe"], "probeTypes": ["tcpSocket", "httpGet", "exec"]}
+
+kinds := ["Pod"]

--- a/src/v1/general/storageclass/constraint.tmpl
+++ b/src/v1/general/storageclass/constraint.tmpl
@@ -1,0 +1,42 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sstorageclass
+  annotations:
+    metadata.gatekeeper.sh/title: "Storage Class"
+    metadata.gatekeeper.sh/version: 1.1.2
+    metadata.gatekeeper.sh/requires-sync-data: |
+      "[
+        [
+          {
+            "groups":["storage.k8s.io"],
+            "versions": ["v1"],
+            "kinds": ["StorageClass"]
+          }
+        ]
+      ]"
+    description: >-
+      Requires storage classes to be specified when used. Only Gatekeeper 3.9+ and non-ephemeral containers are supported.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sStorageClass
+      validation:
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Requires storage classes to be specified when used.
+          properties:
+            includeStorageClassesInMessage:
+              type: boolean
+              default: true
+            allowedStorageClasses:
+              type: array
+              description: "An optional allow-list of storage classes.  If specified, any storage class not in the `allowedStorageClasses` parameter is disallowed."
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/storageclass/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/storageclass/src.rego
+++ b/src/v1/general/storageclass/src.rego
@@ -1,0 +1,126 @@
+package k8sstorageclass
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	not data.inventory.cluster["storage.k8s.io/v1"].StorageClass
+
+	# regal ignore:line-length
+	msg := "StorageClasses not synced. Gatekeeper may be misconfigured. Please have a cluster-admin consult the documentation."
+}
+
+violation contains {"msg": pvc_storageclass_badname_msg} if {
+	is_pvc(input.review.object)
+	not storageclass_allowed(input.review.object.spec.storageClassName)
+}
+
+violation contains {"msg": pvc_storageclass_noname_msg} if {
+	is_pvc(input.review.object)
+	not input.review.object.spec.storageClassName
+}
+
+violation contains {"msg": statefulset_vct_badname_msg(vct)} if {
+	is_statefulset(input.review.object)
+	some vct in input.review.object.spec.volumeClaimTemplates
+	not storageclass_allowed(vct.spec.storageClassName)
+}
+
+violation contains {"msg": statefulset_vct_noname_msg} if {
+	is_statefulset(input.review.object)
+	some vct in input.review.object.spec.volumeClaimTemplates
+	not vct.spec.storageClassName
+}
+
+is_pvc(obj) if {
+	obj.apiVersion == "v1"
+	obj.kind == "PersistentVolumeClaim"
+}
+
+is_statefulset(obj) if {
+	obj.apiVersion == "apps/v1"
+	obj.kind == "StatefulSet"
+}
+
+storageclass_allowed(name) if {
+	data.inventory.cluster["storage.k8s.io/v1"].StorageClass[name]
+
+	# support both direct use of * and as the default value
+	"*" in object.get(input.parameters, "allowedStorageClasses", ["*"])
+}
+
+storageclass_allowed(name) if {
+	data.inventory.cluster["storage.k8s.io/v1"].StorageClass[name]
+	name in input.parameters.allowedStorageClasses
+}
+
+pvc_storageclass_badname_msg := msg if {
+	input.parameters.includeStorageClassesInMessage
+	object.get(input.parameters, "allowedStorageClasses", null) == null
+	args := [
+		input.review.object.spec.storageClassName,
+		concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"].StorageClass[n]]),
+	]
+	msg := sprintf("pvc did not specify a valid storage class name <%v>. Must be one of [%v]", args)
+} else := msg if {
+	input.parameters.includeStorageClassesInMessage
+	object.get(input.parameters, "allowedStorageClasses", null) != null
+
+	isc := object.keys(data.inventory.cluster["storage.k8s.io/v1"].StorageClass)
+	asc := object.get(input.parameters, "allowedStorageClasses", [])
+
+	some sc in (isc & asc)
+	args := [
+		input.review.object.spec.storageClassName,
+		concat(", ", sc),
+	]
+	msg := sprintf("pvc did not specify an allowed and valid storage class name <%v>. Must be one of [%v]", args)
+} else := sprintf(
+	"pvc did not specify a valid storage class name <%v>.",
+	[input.review.object.spec.storageClassName],
+)
+
+pvc_storageclass_noname_msg := sprintf("pvc did not specify a storage class name. Must be one of [%v]", args) if {
+	input.parameters.includeStorageClassesInMessage
+	args := [concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"].StorageClass[n]])]
+} else := sprintf(
+	"pvc did not specify a storage class name.",
+	[],
+)
+
+statefulset_vct_badname_msg(vct) := msg if {
+	input.parameters.includeStorageClassesInMessage
+	object.get(input.parameters, "allowedStorageClasses", null) == null
+	msg := sprintf("statefulset did not specify a valid storage class name <%v>. Must be one of [%v]", [
+		vct.spec.storageClassName,
+		concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"].StorageClass[n]]),
+	])
+}
+
+statefulset_vct_badname_msg(vct) := msg if {
+	input.parameters.includeStorageClassesInMessage
+	object.get(input.parameters, "allowedStorageClasses", null) != null
+
+	isc := {n | some n in object.keys(data.inventory.cluster["storage.k8s.io/v1"].StorageClass)}
+	asc := {n | some n in object.get(input.parameters, "allowedStorageClasses", [])}
+	sc := isc & asc
+
+	msg := sprintf("statefulset did not specify an allowed and valid storage class name <%v>. Must be one of [%v]", [
+		vct.spec.storageClassName,
+		concat(", ", sc),
+	])
+}
+
+statefulset_vct_badname_msg(vct) := msg if {
+	not input.parameters.includeStorageClassesInMessage
+	msg := sprintf("statefulset did not specify a valid storage class name <%v>.", [vct.spec.storageClassName])
+}
+
+default statefulset_vct_noname_msg := "statefulset did not specify a storage class name."
+
+statefulset_vct_noname_msg := msg if {
+	input.parameters.includeStorageClassesInMessage
+	msg := sprintf(
+		"statefulset did not specify a storage class name. Must be one of [%v]",
+		[concat(", ", [n | data.inventory.cluster["storage.k8s.io/v1"].StorageClass[n]])],
+	)
+}

--- a/src/v1/general/storageclass/src_test.rego
+++ b/src/v1/general/storageclass/src_test.rego
@@ -1,0 +1,171 @@
+package k8sstorageclass
+
+import rego.v1
+
+test_input_denied_no_datasync if {
+	inp := {"review": input_review_pvc_name("fast"), "parameters": {"includeStorageClassesInMessage": true}}
+	some result in violation with input as inp with data.inventory as inv_nosync
+
+	contains(result.msg, "misconfigured")
+}
+
+test_input_allowed_pvc_fast if {
+	inp := {"review": input_review_pvc_name("fast"), "parameters": {"includeStorageClassesInMessage": true}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_input_allowed_pvc_slow if {
+	inp := {"review": input_review_pvc_name("slow"), "parameters": {"includeStorageClassesInMessage": true}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_input_denied_pvc_bad_storageclassname if {
+	inp := {"review": input_review_pvc_name("other"), "parameters": {"includeStorageClassesInMessage": true}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_denied_pvc_bad_storageclassname_excludestorageclassesinmessage if {
+	inp := {"review": input_review_pvc_name("other"), "parameters": {"includeStorageClassesInMessage": false}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_denied_pvc_storageclassname_missing if {
+	inp := {"review": input_review_pvc_storageclassname_missing, "parameters": {"includeStorageClassesInMessage": true}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_allowed_pvc_sc if {
+	inp := {"review": input_review_pvc_name("slow"), "parameters": {"includeStorageClassesInMessage": true, "allowedStorageClasses": ["slow"]}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_input_denied_pvc_sc if {
+	inp := {"review": input_review_pvc_name("slow"), "parameters": {"includeStorageClassesInMessage": true, "allowedStorageClasses": ["fast"]}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_allowed_pvc_mixed_sc if {
+	inp := {"review": input_review_pvc_name("slow"), "parameters": {"includeStorageClassesInMessage": true, "allowedStorageClasses": ["fast", "slow"]}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_input_denied_pvc_multiple_sc if {
+	inp := {"review": input_review_pvc_name("slow"), "parameters": {"includeStorageClassesInMessage": true, "allowedStorageClasses": ["other", "fast"]}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_allowed_statefulset_fast if {
+	inp := {"review": input_review_statefulset_name("fast"), "parameters": {"includeStorageClassesInMessage": true}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_input_allowed_statefulset_slow if {
+	inp := {"review": input_review_statefulset_name("slow"), "parameters": {"includeStorageClassesInMessage": true}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_input_denied_statefulset_bad_storageclassname if {
+	inp := {"review": input_review_statefulset_name("other"), "parameters": {"includeStorageClassesInMessage": true}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_denied_statefulset_storageclassname_missing if {
+	inp := {"review": input_review_statefulset_storageclassname_missing, "parameters": {"includeStorageClassesInMessage": true}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_allowed_statefulset_sc if {
+	inp := {"review": input_review_statefulset_name("slow"), "parameters": {"includeStorageClassesInMessage": true, "allowedStorageClasses": ["slow"]}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_input_denied_statefulset_sc if {
+	inp := {"review": input_review_statefulset_name("slow"), "parameters": {"includeStorageClassesInMessage": true, "allowedStorageClasses": ["fast"]}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_input_allowed_statefulset_mixed_sc if {
+	inp := {"review": input_review_statefulset_name("slow"), "parameters": {"includeStorageClassesInMessage": true, "allowedStorageClasses": ["fast", "slow"]}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_input_denied_statefulset_multiple_sc if {
+	inp := {"review": input_review_statefulset_name("slow"), "parameters": {"includeStorageClassesInMessage": true, "allowedStorageClasses": ["other", "fast"]}}
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+input_review_pvc_name(name) := {"object": {
+	"apiVersion": "v1",
+	"kind": "PersistentVolumeClaim",
+	"metadata": {"name": "foo"},
+	"spec": {
+		"accessModes": ["ReadWriteOnce"],
+		"volumeMode": "Filesystem",
+		"resources": {"requests": {"storage": "8Gi"}},
+		"storageClassName": name,
+	},
+}}
+
+input_review_pvc_storageclassname_missing := {"object": {
+	"apiVersion": "v1",
+	"kind": "PersistentVolumeClaim",
+	"metadata": {"name": "foo"},
+	"spec": {
+		"accessModes": ["ReadWriteOnce"],
+		"volumeMode": "Filesystem",
+		"resources": {"requests": {"storage": "8Gi"}},
+	},
+}}
+
+input_review_statefulset_name(name) := {"object": {
+	"apiVersion": "apps/v1",
+	"kind": "StatefulSet",
+	"metadata": {"name": "foo"},
+	"spec": {"volumeClaimTemplates": [{
+		"metadata": {"name": "bar"},
+		"spec": {
+			"accessModes": ["ReadWriteOnce"],
+			"volumeMode": "Filesystem",
+			"resources": {"requests": {"storage": "8Gi"}},
+			"storageClassName": name,
+		},
+	}]},
+}}
+
+input_review_statefulset_storageclassname_missing := {"object": {
+	"apiVersion": "apps/v1",
+	"kind": "StatefulSet",
+	"metadata": {"name": "foo"},
+	"spec": {"volumeClaimTemplates": [{
+		"metadata": {"name": "bar"},
+		"spec": {
+			"accessModes": ["ReadWriteOnce"],
+			"volumeMode": "Filesystem",
+			"resources": {"requests": {"storage": "8Gi"}},
+		},
+	}]},
+}}
+
+inv := {"cluster": {"storage.k8s.io/v1": {"StorageClass": {
+	"fast": {"somestuff": 1},
+	"slow": {"somestuff": 2},
+}}}}
+
+inv_nosync := {"cluster": {}}

--- a/src/v1/general/uniqueingresshost/constraint.tmpl
+++ b/src/v1/general/uniqueingresshost/constraint.tmpl
@@ -1,0 +1,36 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8suniqueingresshost
+  annotations:
+    metadata.gatekeeper.sh/title: "Unique Ingress Host"
+    metadata.gatekeeper.sh/version: 1.0.4
+    metadata.gatekeeper.sh/requires-sync-data: |
+      "[
+        [
+          {
+            "groups": ["extensions"],
+            "versions": ["v1beta1"],
+            "kinds": ["Ingress"]
+          },
+          {
+            "groups": ["networking.k8s.io"],
+            "versions": ["v1beta1", "v1"],
+            "kinds": ["Ingress"]
+          }
+        ]
+      ]"
+    description: >-
+      Requires all Ingress rule hosts to be unique.
+
+      Does not handle hostname wildcards:
+      https://kubernetes.io/docs/concepts/services-networking/ingress/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sUniqueIngressHost
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/uniqueingresshost/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/uniqueingresshost/src.rego
+++ b/src/v1/general/uniqueingresshost/src.rego
@@ -1,0 +1,24 @@
+package k8suniqueingresshost
+
+import rego.v1
+
+identical(obj, review) if {
+	obj.metadata.namespace == review.object.metadata.namespace
+	obj.metadata.name == review.object.metadata.name
+}
+
+violation contains {"msg": msg} if {
+	input.review.kind.kind == "Ingress"
+	regex.match(`^(extensions|networking.k8s.io)$`, input.review.kind.group)
+	host := input.review.object.spec.rules[_].host
+
+	some otherapiversion
+	other := data.inventory.namespace[_][otherapiversion].Ingress[_]
+
+	# false positive
+	# regal ignore:non-loop-expression
+	regex.match(`^(extensions|networking.k8s.io)/.+$`, otherapiversion)
+	other.spec.rules[_].host == host
+	not identical(other, input.review)
+	msg := sprintf("ingress host conflicts with an existing ingress <%v>", [host])
+}

--- a/src/v1/general/uniqueingresshost/src_test.rego
+++ b/src/v1/general/uniqueingresshost/src_test.rego
@@ -1,0 +1,156 @@
+package k8suniqueingresshost
+
+import rego.v1
+
+test_no_data if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules1, "extensions/v1beta1"), "extensions")}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_identical if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules1, "extensions/v1beta1"), "extensions")}
+	inv := inventory_data([ingress("my-ingress", "prod", my_rules1, "extensions/v1beta1")])
+	trace(sprintf("%v", [inv]))
+
+	results := violation with input as inp with data.inventory as inv
+	trace(sprintf("%v", [results]))
+
+	count(results) == 0
+}
+
+test_collision if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules1, "extensions/v1beta1"), "extensions")}
+	inv := inventory_data([ingress("my-ingress", "prod2", my_rules1, "extensions/v1beta1")])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_collision_with_multiple if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules3, "extensions/v1beta1"), "extensions")}
+	inv := inventory_data([ingress("my-ingress", "prod2", my_rules1, "extensions/v1beta1"), ingress("my-ingress1", "prod2", my_rules2, "extensions/v1beta1")])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 2
+}
+
+test_no_collision if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules1, "extensions/v1beta1"), "extensions")}
+	inv := inventory_data([ingress("my-ingress", "prod2", my_rules2, "extensions/v1beta1")])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_no_collision_with_multiple if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules4, "extensions/v1beta1"), "extensions")}
+	inv := inventory_data([ingress("my-ingress", "prod2", my_rules1, "extensions/v1beta1"), ingress("my-ingress", "prod3", my_rules2, "extensions/v1beta1")])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_no_collision_with_multiple_apis if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules4, "networking.k8s.io/v1beta1"), "networking.k8s.io")}
+	inv := inventory_data2([ingress("my-ingress", "prod2", my_rules1, "networking.k8s.io/v1beta1"), ingress("my-ingress", "prod3", my_rules2, "networking.k8s.io/v1beta1")])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_collision_with_multiple_apis if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules3, "networking.k8s.io/v1beta1"), "networking.k8s.io")}
+	inv := inventory_data2([ingress("my-ingress", "prod2", my_rules1, "networking.k8s.io/v1beta1"), ingress("my-ingress", "prod3", my_rules2, "networking.k8s.io/v1beta1")])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 2
+}
+
+test_no_collision_with_multiple_bad_review_apis if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules1, "app/v1beta1"), "app")}
+	inv := inventory_data([ingress("my-ingress", "prod2", my_rules1, "extensions/v1beta1"), ingress("my-ingress", "prod3", my_rules2, "extensions/v1beta1")])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_no_collision_with_multiple_bad_review_apis2 if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules1, "test.extensions/v1beta1"), "test.extensions")}
+	inv := inventory_data([ingress("my-ingress", "prod2", my_rules1, "extensions/v1beta1"), ingress("my-ingress", "prod3", my_rules2, "extensions/v1beta1")])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_collision_with_multiple_apis_mixed if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules1, "networking.k8s.io/v1beta1"), "networking.k8s.io")}
+	inv := inventory_data([ingress("my-ingress", "prod2", my_rules1, "extensions/v1beta1"), ingress("my-ingress", "prod3", my_rules2, "extensions/v1beta1")])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_no_collision_with_multiple_apis_slash if {
+	inp := {"review": review(ingress("my-ingress", "prod", my_rules1, "networking.k8s.io/v1beta1"), "networking.k8s.io")}
+	inv := inventory_data1([ingress("my-ingress", "prod2", my_rules1, "extensions.something.io/v1beta1"), ingress("my-ingress", "prod3", my_rules2, "extensions.something.io/v1beta1")])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+review(ing, group) := {
+	"kind": {
+		"kind": "Ingress",
+		"version": "v1beta1",
+		"group": group,
+	},
+	"namespace": ing.metadata.namespace,
+	"name": ing.metadata.name,
+	"object": ing,
+}
+
+my_rule(host) := {
+	"host": host,
+	"http": {"paths": [{"backend": {"serviceName": "nginx", "servicePort": 80}}]},
+}
+
+my_rules1 := [my_rule("a.abc.com")]
+
+my_rules2 := [my_rule("a1.abc.com")]
+
+my_rules3 := [
+	my_rule("a.abc.com"),
+	my_rule("a1.abc.com"),
+]
+
+my_rules4 := [
+	my_rule("a2.abc.com"),
+	my_rule("a3.abc.com"),
+]
+
+ingress(name, ns, rules, apiversion) := {
+	"kind": "Ingress",
+	"apiVersion": apiversion,
+	"metadata": {
+		"name": name,
+		"namespace": ns,
+	},
+	"spec": {"rules": rules},
+}
+
+inventory_data(ingresses) := out if {
+	namespaces := {ns | ns = ingresses[_].metadata.namespace}
+	out = {"namespace": {ns: {"extensions/v1beta1": {"Ingress": flatten_by_name(ingresses, ns)}} |
+		ns := namespaces[_]
+	}}
+}
+
+inventory_data1(ingresses) := out if {
+	namespaces := {ns | ns = ingresses[_].metadata.namespace}
+	out = {"namespace": {ns: {"extensions.something.io/v1beta1": {"Ingress": flatten_by_name(ingresses, ns)}} |
+		ns := namespaces[_]
+	}}
+}
+
+inventory_data2(ingresses) := out if {
+	namespaces := {ns | ns = ingresses[_].metadata.namespace}
+	out = {"namespace": {ns: {"networking.k8s.io/v1beta1": {"Ingress": flatten_by_name(ingresses, ns)}} |
+		ns := namespaces[_]
+	}}
+}
+
+flatten_by_name(ingresses, ns) := {o.metadata.name: o |
+	some o in ingresses
+	o.metadata.namespace == ns
+}

--- a/src/v1/general/uniqueserviceselector/constraint.tmpl
+++ b/src/v1/general/uniqueserviceselector/constraint.tmpl
@@ -1,0 +1,33 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8suniqueserviceselector
+  annotations:
+    metadata.gatekeeper.sh/title: "Unique Service Selector"
+    metadata.gatekeeper.sh/version: 1.0.2
+    metadata.gatekeeper.sh/requires-sync-data: |
+      "[
+        [
+          {
+            "groups":[""],
+            "versions": ["v1"],
+            "kinds": ["Service"]
+          }
+        ]
+      ]"
+    description: >-
+      Requires Services to have unique selectors within a namespace.
+      Selectors are considered the same if they have identical keys and values.
+      Selectors may share a key/value pair so long as there is at least one
+      distinct key/value pair between them.
+
+      https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sUniqueServiceSelector
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/uniqueserviceselector/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/uniqueserviceselector/src.rego
+++ b/src/v1/general/uniqueserviceselector/src.rego
@@ -1,0 +1,32 @@
+package k8suniqueserviceselector
+
+import rego.v1
+
+make_apiversion(kind) := sprintf("%v/%v", [kind.group, kind.version]) if kind.group != ""
+
+make_apiversion(kind) := kind.version if kind.group == ""
+
+identical(obj, review) if {
+	obj.metadata.namespace == review.namespace
+	obj.metadata.name == review.name
+	obj.kind == review.kind.kind
+	obj.apiVersion == make_apiversion(review.kind)
+}
+
+flatten_selector(obj) := concat(",", sort([s |
+	some key, val in obj.spec.selector
+	s := concat(":", [key, val])
+]))
+
+violation contains {"msg": msg} if {
+	input.review.kind.kind == "Service"
+	input.review.kind.version == "v1"
+	input.review.kind.group == ""
+	input_selector := flatten_selector(input.review.object)
+	some namespace, name
+	other := data.inventory.namespace[namespace][_].Service[name]
+	not identical(other, input.review)
+	other_selector := flatten_selector(other)
+	input_selector == other_selector
+	msg := sprintf("same selector as service <%v> in namespace <%v>", [name, namespace])
+}

--- a/src/v1/general/uniqueserviceselector/src_test.rego
+++ b/src/v1/general/uniqueserviceselector/src_test.rego
@@ -1,0 +1,130 @@
+package k8suniqueserviceselector
+
+import rego.v1
+
+test_no_data if {
+	inp := {"review": review(service("my-service", "prod", {"a": "b"}))}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_identical if {
+	inp := {"review": review(service("my-service", "prod", {"a": "b"}))}
+	inv := tmp_data([service("my-service", "prod", {"a": "b"})])
+	trace(sprintf("%v", [inv]))
+
+	results := violation with input as inp with data.inventory as inv
+	trace(sprintf("%v", [results]))
+
+	count(results) == 0
+}
+
+test_collision if {
+	inp := {"review": review(service("my-service", "prod", {"a": "b"}))}
+	inv := tmp_data([service("my-service", "prod2", {"a": "b"})])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_collision_with_multiple if {
+	inp := {"review": review(service("my-service", "prod", {"a": "b"}))}
+	inv := tmp_data([service("my-service", "prod2", {"a": "b"}), service("my-service", "prod3", {"a": "b"})])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 2
+}
+
+test_no_collision if {
+	inp := {"review": review(service("my-service", "prod", {"a": "b"}))}
+	inv := tmp_data([service("my-service", "prod2", {"a": "c"})])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_no_collision_with_multiple if {
+	inp := {"review": review(service("my-service", "prod", {"a": "b"}))}
+	inv := tmp_data([service("my-service", "prod2", {"a": "b2"}), service("my-service", "prod3", {"a": "b2"})])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+test_compound_selector_collision if {
+	inp := {"review": review(service("my-service", "prod", {"r": "d", "a": "b"}))}
+	inv := tmp_data([service("my-service", "prod2", {"a": "b", "r": "d"})])
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 1
+}
+
+test_no_service_selector if {
+	inp := {"review": review(service_without_selector("kubernetes", "default"))}
+	inv := data_networkpolicy("default")
+	results := violation with input as inp with data.inventory as inv
+	count(results) == 0
+}
+
+review(srv) := {
+	"kind": {
+		"kind": "Service",
+		"version": "v1",
+		"group": "",
+	},
+	"namespace": srv.metadata.namespace,
+	"name": srv.metadata.name,
+	"object": srv,
+}
+
+service_without_selector(name, ns) := {
+	"kind": "Service",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": name,
+		"namespace": ns,
+	},
+	"spec": {
+		"clusterIP": "10.43.0.1",
+		"clusterIPs": ["10.43.0.1"],
+		"ports": [{
+			"name": "https",
+			"port": 443,
+			"protocol": "TCP",
+			"targetPort": 6443,
+		}],
+		"sessionAffinity": "None",
+		"type": "ClusterIP",
+	},
+}
+
+service(name, ns, selector) := {
+	"kind": "Service",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": name,
+		"namespace": ns,
+	},
+	"spec": {"selector": selector},
+}
+
+data_networkpolicy(ns) := {"namespace": {ns: {"v1": {"NetworkPolicy": {"default-network-policy": {
+	"apiVersion": "networking.k8s.io/v1",
+	"kind": "NetworkPolicy",
+	"metadata": {
+		"name": "default-network-policy",
+		"namespace": ns,
+	},
+	"spec": {
+		"ingress": [{"from": [{"podSelector": {}}]}],
+		"podSelector": {},
+		"policyTypes": ["Ingress"],
+	},
+}}}}}}
+
+tmp_data(services) := out if {
+	namespaces := {ns | ns = services[_].metadata.namespace}
+	out = {"namespace": {ns: {"v1": {"Service": flatten_by_name(services, ns)}} |
+		ns := namespaces[_]
+	}}
+}
+
+flatten_by_name(services, ns) := {service.metadata.name: service |
+	some service in services
+	service.metadata.namespace == ns
+}

--- a/src/v1/general/verifydeprecatedapi/constraint.tmpl
+++ b/src/v1/general/verifydeprecatedapi/constraint.tmpl
@@ -1,0 +1,45 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: verifydeprecatedapi
+  annotations:
+    metadata.gatekeeper.sh/title: "Verify deprecated APIs"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Verifies deprecated Kubernetes APIs to ensure all the API versions are up to date. This template does not apply to audit as audit looks at the resources which are already present in the cluster with non-deprecated API versions.
+spec:
+  crd:
+    spec:
+      names:
+        kind: VerifyDeprecatedAPI
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            kvs:
+              type: array
+              description: Deprecated api versions and corresponding kinds
+              items:
+                type: object
+                properties:
+                  deprecatedAPI:
+                    type: string
+                    description: deprecated api
+                    example: flowcontrol.apiserver.k8s.io/v1beta2
+                  kinds:
+                    type: array
+                    items:
+                      type: string
+                    description: impacted list of kinds
+                    example: '["FlowSchema", "PriorityLevelConfiguration"]'
+                  targetAPI:
+                    type: string
+                    description: target api
+                    example: flowcontrol.apiserver.k8s.io/v1beta3
+            k8sVersion:
+              type: number
+              description: kubernetes version
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/verifydeprecatedapi/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/v1/general/verifydeprecatedapi/src.rego
+++ b/src/v1/general/verifydeprecatedapi/src.rego
@@ -1,0 +1,30 @@
+package verifydeprecatedapi
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+	some kvs in input.parameters.kvs
+	kvs.deprecatedAPI == input.review.object.apiVersion
+	some kind in kvs.kinds
+	kind == input.review.object.kind
+
+	msg := message(kind, input.review.object.apiVersion, input.parameters.k8sVersion, kvs.targetAPI)
+}
+
+message(kind, api_version, k8s_version, target_api) := msg if {
+	not match(target_api)
+	msg := sprintf(
+		"API %v for %v is deprecated in Kubernetes version %v, please use %v instead",
+		[kind, api_version, k8s_version, target_api],
+	)
+}
+
+message(kind, api_version, k8s_version, target_api) := msg if {
+	match(target_api)
+	msg := sprintf(
+		"API %v for %v is deprecated in Kubernetes version %v, please see Kubernetes API deprecation guide",
+		[kind, api_version, k8s_version],
+	)
+}
+
+match("None")

--- a/src/v1/general/verifydeprecatedapi/src_test.rego
+++ b/src/v1/general/verifydeprecatedapi/src_test.rego
@@ -1,0 +1,43 @@
+package verifydeprecatedapi
+
+import rego.v1
+
+test_hpa_with_deprecated_api if {
+	inp := {"review": hpa("autoscaling/v2beta2"), "parameters": {"kvs": [{"deprecatedAPI": "autoscaling/v2beta2", "kinds": ["HorizontalPodAutoscaler"], "targetAPI": "autoscaling/v2"}], "k8sVersion": 1.26}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_hpa_without_deprecated_api if {
+	inp := {"review": hpa("autoscaling/v2"), "parameters": {"kvs": [{"deprecatedAPI": "autoscaling/v2beta2", "kinds": ["HorizontalPodAutoscaler"], "targetAPI": "autoscaling/v2"}], "k8sVersion": 1.26}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+hpa(api) := {
+	"apiVersion": api,
+	"kind": "HorizontalPodAutoscaler",
+	"metadata": {
+		"name": "nginx-deployment",
+		"namespace": "default",
+	},
+	"spec": {
+		"maxReplicas": "10",
+		"metrics": [{
+			"resource": {
+				"name": "cpu",
+				"target": {
+					"averageUtilization": "80",
+					"type": "Utilization",
+				},
+			},
+			"type": "Resource",
+		}],
+		"minReplicas": "1",
+		"scaleTargetRef": {
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
+			"name": "nginx-deployment",
+		},
+	},
+}

--- a/src/v1/pod-security-policy/allow-privilege-escalation/constraint.tmpl
+++ b/src/v1/pod-security-policy/allow-privilege-escalation/constraint.tmpl
@@ -1,0 +1,51 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspallowprivilegeescalationcontainer
+  annotations:
+    metadata.gatekeeper.sh/title: "Allow Privilege Escalation in Container"
+    metadata.gatekeeper.sh/version: 1.1.0
+    description: >-
+      Controls restricting escalation to root privileges. Corresponds to the
+      `allowPrivilegeEscalation` field in a PodSecurityPolicy. For more
+      information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privilege-escalation
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPAllowPrivilegeEscalationContainer
+      validation:
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls restricting escalation to root privileges. Corresponds to the
+            `allowPrivilegeEscalation` field in a PodSecurityPolicy. For more
+            information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privilege-escalation
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/allow-privilege-escalation/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/allow-privilege-escalation/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+          - |
+{{ file.Read "src/pod-security-policy/allow-privilege-escalation/lib_exclude_update.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          - |
+{{ file.Read "src/pod-security-policy/allow-privilege-escalation/lib_exempt_container.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/allow-privilege-escalation/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/allow-privilege-escalation/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/allow-privilege-escalation/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/allow-privilege-escalation/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/allow-privilege-escalation/src.rego
+++ b/src/v1/pod-security-policy/allow-privilege-escalation/src.rego
@@ -1,0 +1,25 @@
+package k8spspallowprivilegeescalationcontainer
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg, "details": {}} if {
+	# spec.containers.securityContext.allowPrivilegeEscalation field is immutable.
+	not is_update(input.review)
+
+	some c in input_containers
+	not is_exempt(c)
+	input_allow_privilege_escalation(c)
+	msg := sprintf("Privilege escalation container is not allowed: %v", [c.name])
+}
+
+input_allow_privilege_escalation(c) if not "securityContext" in object.keys(c)
+
+input_allow_privilege_escalation(c) if not c.securityContext.allowPrivilegeEscalation == false
+
+input_containers contains container if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+}

--- a/src/v1/pod-security-policy/allow-privilege-escalation/src_test.rego
+++ b/src/v1/pod-security-policy/allow-privilege-escalation/src_test.rego
@@ -1,0 +1,133 @@
+package k8spspallowprivilegeescalationcontainer
+
+import rego.v1
+
+test_input_container_not_privilege_escalation_allowed if {
+	inp := {"review": input_review}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_privilege_escalation_not_allowed if {
+	inp := {"review": input_review_priv}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_one_container_with_exemption if {
+	inp := {"review": input_review_priv, "parameters": {"exemptImages": ["one/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_many_not_privilege_escalation_allowed if {
+	inp := {"review": input_review_many}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_container_many_mixed_privilege_escalation_not_allowed if {
+	inp := {"review": input_review_many_mixed}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_input_container_many_mixed_privilege_escalation_not_allowed_one_exempted if {
+	inp := {"review": input_review_many_mixed, "parameters": {"exemptImages": ["one/*"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_container_many_mixed_privilege_escalation_not_allowed_all_exempted if {
+	inp := {"review": input_review_many_mixed, "parameters": {"exemptImages": ["one/*", "two/*", "three/*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_many_mixed_privilege_escalation_not_allowed_two if {
+	inp := {"review": input_review_many_mixed_two}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_update if {
+	inp := {"review": object.union(input_review_priv, {"operation": "UPDATE"})}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one},
+}}
+
+input_review_priv := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one_priv},
+}}
+
+input_review_many := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"initContainers": input_containers_one,
+	},
+}}
+
+input_review_many_mixed := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"initContainers": input_containers_one_priv,
+	},
+}}
+
+input_review_many_mixed_two := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many_mixed,
+		"initContainers": input_containers_one_priv,
+	},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "one/nginx",
+	"securityContext": {"allowPrivilegeEscalation": false},
+}]
+
+input_containers_one_priv := [{
+	"name": "nginx",
+	"image": "one/nginx",
+	"securityContext": {"allowPrivilegeEscalation": true},
+}]
+
+input_containers_many := [
+	{
+		"name": "nginx",
+		"image": "one/nginx",
+		"securityContext": {"allowPrivilegeEscalation": false},
+	},
+	{
+		"name": "nginx1",
+		"image": "two/nginx",
+	},
+	{
+		"name": "nginx2",
+		"image": "three/nginx",
+		"securityContext": {"runAsUser": "1000"},
+	},
+]
+
+input_containers_many_mixed := [
+	{
+		"name": "nginx",
+		"image": "one/nginx",
+		"securityContext": {"allowPrivilegeEscalation": false},
+	},
+	{
+		"name": "nginx1",
+		"image": "two/nginx",
+		"securityContext": {"allowPrivilegeEscalation": true},
+	},
+]

--- a/src/v1/pod-security-policy/apparmor/constraint.tmpl
+++ b/src/v1/pod-security-policy/apparmor/constraint.tmpl
@@ -1,0 +1,56 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspapparmor
+  annotations:
+    metadata.gatekeeper.sh/title: "App Armor"
+    metadata.gatekeeper.sh/version: 1.1.0
+    description: >-
+      Configures an allow-list of AppArmor profiles for use by containers.
+      This corresponds to specific annotations applied to a PodSecurityPolicy.
+      For information on AppArmor, see
+      https://kubernetes.io/docs/tutorials/clusters/apparmor/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPAppArmor
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Configures an allow-list of AppArmor profiles for use by containers.
+            This corresponds to specific annotations applied to a PodSecurityPolicy.
+            For information on AppArmor, see
+            https://kubernetes.io/docs/tutorials/clusters/apparmor/
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            allowedProfiles:
+              description: "An array of AppArmor profiles. Examples: `runtime/default`, `unconfined`."
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/apparmor/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/apparmor/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+          - |
+{{ file.Read "src/pod-security-policy/apparmor/lib_exempt_container.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+

--- a/src/v1/pod-security-policy/apparmor/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/apparmor/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/apparmor/src.rego
+++ b/src/v1/pod-security-policy/apparmor/src.rego
@@ -1,0 +1,47 @@
+package k8spspapparmor
+
+import rego.v1
+
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg, "details": {}} if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+	not is_exempt(container)
+	not input_apparmor_allowed(input.review.object, container)
+
+	msg := sprintf(
+		"AppArmor profile is not allowed, pod: %v, container: %v. Allowed profiles: %v",
+		[input.review.object.metadata.name, container.name, input.parameters.allowedProfiles],
+	)
+}
+
+input_apparmor_allowed(pod, container) if get_apparmor_profile(pod, container) in input.parameters.allowedProfiles
+
+get_apparmor_profile(_, container) := canonicalize_apparmor_profile(profile) if {
+	profile := object.get(container, ["securityContext", "appArmorProfile"], null)
+	profile != null
+}
+
+get_apparmor_profile(pod, container) := out if {
+	profile := object.get(container, ["securityContext", "appArmorProfile"], null)
+	profile == null
+	out := pod.metadata.annotations[sprintf("container.apparmor.security.beta.kubernetes.io/%v", [container.name])]
+}
+
+get_apparmor_profile(pod, container) := out if {
+	profile := object.get(container, ["securityContext", "appArmorProfile"], null)
+	profile == null
+	not pod.metadata.annotations[sprintf("container.apparmor.security.beta.kubernetes.io/%v", [container.name])]
+	out := canonicalize_apparmor_profile(object.get(pod, ["spec", "securityContext", "appArmorProfile"], null))
+}
+
+canonicalize_apparmor_profile(profile) := "runtime/default" if profile.type == "RuntimeDefault"
+
+canonicalize_apparmor_profile(profile) := "unconfined" if profile.type == "Unconfined"
+
+canonicalize_apparmor_profile(profile) := sprintf("localhost/%s", [profile.localhostProfile]) if {
+	profile.type = "Localhost"
+}
+
+canonicalize_apparmor_profile(null) := "runtime/default"

--- a/src/v1/pod-security-policy/apparmor/src_test.rego
+++ b/src/v1/pod-security-policy/apparmor/src_test.rego
@@ -1,0 +1,140 @@
+package k8spspapparmor
+
+import rego.v1
+
+test_input_apparmor_allowed_empty if {
+	inp := {"review": input_review_container, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_apparmor_allowed_empty_but_exempted if {
+	inp := {"review": input_review_container, "parameters": input_parameters_exempt_container}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_apparmor_not_allowed_no_annotation_empty if {
+	inp := {"review": input_review_no_annotation, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_apparmor_not_allowed_no_annotation if {
+	inp := {"review": input_review_no_annotation, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_apparmor_container_allowed_in_list if {
+	inp := {"review": input_review_container, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_apparmor_container_not_allowed_not_in_list if {
+	inp := {"review": input_review_container, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_apparmor_containers_allowed_in_list if {
+	inp := {"review": input_review_containers, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_apparmor_containers_not_allowed_not_in_list if {
+	inp := {"review": input_review_containers, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_apparmor_containers_allowed_in_list_mixed_no_annotation if {
+	inp := {"review": input_review_containers_missing_annotation, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_apparmor_containers_not_allowed_not_in_list_mixed_no_annotation if {
+	inp := {"review": input_review_containers_missing_annotation, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_apparmor_containers_not_allowed_not_in_list_mixed if {
+	inp := {"review": input_review_containers_mixed, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+input_review_container := {"object": {
+	"metadata": {
+		"name": "nginx",
+		"annotations": {"container.apparmor.security.beta.kubernetes.io/nginx": "runtime/default"},
+	},
+	"spec": {"containers": [{
+		"name": "nginx",
+		"image": "nginx",
+	}]},
+}}
+
+input_review_no_annotation := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": [{
+		"name": "nginx",
+		"image": "nginx",
+	}]},
+}}
+
+input_review_containers := {"object": {
+	"metadata": {
+		"name": "nginx",
+		"annotations": {
+			"container.apparmor.security.beta.kubernetes.io/nginx": "runtime/default",
+			"container.apparmor.security.beta.kubernetes.io/nginx2": "runtime/default",
+		},
+	},
+	"spec": {"containers": two_containers},
+}}
+
+input_review_containers_missing_annotation := {"object": {
+	"metadata": {
+		"name": "nginx",
+		"annotations": {"container.apparmor.security.beta.kubernetes.io/nginx": "runtime/default"},
+	},
+	"spec": {"containers": two_containers},
+}}
+
+input_review_containers_mixed := {"object": {
+	"metadata": {
+		"name": "nginx",
+		"annotations": {
+			"container.apparmor.security.beta.kubernetes.io/nginx": "runtime/default",
+			"container.apparmor.security.beta.kubernetes.io/nginx2": "unconfined",
+		},
+	},
+	"spec": {"containers": two_containers},
+}}
+
+two_containers := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+	},
+]
+
+input_parameters_empty := {"allowedProfiles": []}
+
+input_parameters_exempt_container := {
+	"allowedProfiles": [],
+	"exemptImages": "nginx",
+}
+
+input_parameters_in_list := {"allowedProfiles": ["runtime/default"]}
+
+input_parameters_not_in_list := {"allowedProfiles": ["unconfined"]}

--- a/src/v1/pod-security-policy/capabilities/constraint.tmpl
+++ b/src/v1/pod-security-policy/capabilities/constraint.tmpl
@@ -1,0 +1,62 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspcapabilities
+  annotations:
+    metadata.gatekeeper.sh/title: "Capabilities"
+    metadata.gatekeeper.sh/version: 1.1.1
+    description: >-
+      Controls Linux capabilities on containers. Corresponds to the
+      `allowedCapabilities` and `requiredDropCapabilities` fields in a
+      PodSecurityPolicy. For more information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#capabilities
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPCapabilities
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls Linux capabilities on containers. Corresponds to the
+            `allowedCapabilities` and `requiredDropCapabilities` fields in a
+            PodSecurityPolicy. For more information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#capabilities
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            allowedCapabilities:
+              type: array
+              description: "A list of Linux capabilities that can be added to a container."
+              items:
+                type: string
+            requiredDropCapabilities:
+              type: array
+              description: "A list of Linux capabilities that are required to be dropped from a container."
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/capabilities/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/capabilities/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+          - |
+{{ file.Read "src/pod-security-policy/capabilities/lib_exclude_update.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          - |
+{{ file.Read "src/pod-security-policy/capabilities/lib_exempt_container.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/capabilities/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/capabilities/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/capabilities/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/capabilities/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/capabilities/src.rego
+++ b/src/v1/pod-security-policy/capabilities/src.rego
@@ -1,0 +1,60 @@
+package capabilities
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg} if {
+	# spec.containers.securityContext.capabilities field is immutable.
+	not is_update(input.review)
+
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+
+	not is_exempt(container)
+	has_disallowed_capabilities(container)
+
+	msg := sprintf(
+		"%s <%v> has a disallowed capability. Allowed capabilities are %v",
+		[trim_suffix(type, "s"), container.name, get_default(input.parameters, "allowedCapabilities", "NONE")],
+	)
+}
+
+violation contains {"msg": msg} if {
+	not is_update(input.review)
+
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+
+	not is_exempt(container)
+	missing_drop_capabilities(container)
+
+	msg := sprintf(
+		"%s <%v> is not dropping all required capabilities. Container must drop all of %v or \"ALL\"",
+		[trim_suffix(type, "s"), container.name, input.parameters.requiredDropCapabilities],
+	)
+}
+
+has_disallowed_capabilities(container) if {
+	allowed := {c | c := lower(input.parameters.allowedCapabilities[_])}
+	not allowed["*"]
+	capabilities := {c | c := lower(container.securityContext.capabilities.add[_])}
+
+	count(capabilities - allowed) > 0
+}
+
+missing_drop_capabilities(container) if {
+	must_drop := {c | c := lower(input.parameters.requiredDropCapabilities[_])}
+	dropped := {c | c := lower(container.securityContext.capabilities.drop[_])}
+
+	count(must_drop - dropped) > 0
+	count({"all"} - dropped) > 0
+}
+
+get_default(obj, param, _) := obj[param]
+
+get_default(obj, param, _default) := _default if {
+	not obj[param]
+	not obj[param] == false
+}

--- a/src/v1/pod-security-policy/capabilities/src_test.rego
+++ b/src/v1/pod-security-policy/capabilities/src_test.rego
@@ -1,0 +1,369 @@
+package capabilities
+
+import rego.v1
+
+test_input_all_allowed if {
+	inp := {"review": input_review([cadd(["one", "two"])]), "parameters": {"allowedCapabilities": ["*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_all_allowed_container_x2 if {
+	inp := {"review": input_review([cadd(["one", "two"]), cadd(["three"])]), "parameters": {"allowedCapabilities": ["*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_one_allowed if {
+	inp := {"review": input_review([cadd(["one"])]), "parameters": {"allowedCapabilities": ["one"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_one_allowed_container_x2 if {
+	inp := {"review": input_review([cadd(["one"]), cadd(["one"])]), "parameters": {"allowedCapabilities": ["one"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_two_allowed_container_x2 if {
+	inp := {"review": input_review([cadd(["one"]), cadd(["two"])]), "parameters": {"allowedCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_two_allowed_two_used_container_x2 if {
+	inp := {"review": input_review([cadd(["one", "two"]), cadd(["one", "two"])]), "parameters": {"allowedCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_none_allowed if {
+	inp := {"review": input_review([cadd(["one"])]), "parameters": {"allowedCapabilities": []}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_none_allowed_undefined if {
+	inp := {"review": input_review([cadd(["one"])]), "parameters": {}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_none_allowed_undefined_x2_x2 if {
+	inp := {"review": input_review([cadd(["one", "two"]), cadd(["three", "two"])]), "parameters": {}}
+	results := violation with input as inp
+	trace(sprintf("results are: %v", [results]))
+	count(results) == 2
+}
+
+test_input_disallowed_x1 if {
+	inp := {"review": input_review([cadd(["three"])]), "parameters": {"allowedCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_disallowed_x2_just_one if {
+	inp := {"review": input_review([cadd(["one"]), cadd(["three", "two"])]), "parameters": {"allowedCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_disallowed_x2 if {
+	inp := {"review": input_review([cadd(["three"]), cadd(["three", "two"])]), "parameters": {"allowedCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_disallowed_x2_but_exempt if {
+	inp := {"review": input_review([cadd(["three"]), cadd(["three", "two"])]), "parameters": {"allowedCapabilities": ["one", "two"], "exemptImages": ["nginx"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_empty_drop if {
+	inp := {"review": input_review([cdrop(["one", "two"])]), "parameters": {"requiredDropCapabilities": []}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_all_dropped if {
+	inp := {"review": input_review([cdrop(["one", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_extra_dropped if {
+	inp := {"review": input_review([cdrop(["one", "two", "three"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_all_dropped_x2 if {
+	inp := {"review": input_review([cdrop(["one", "two"]), cdrop(["one", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_missing_drop if {
+	inp := {"review": input_review([cdrop(["two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_one_missing_drop_x2 if {
+	inp := {"review": input_review([cdrop(["one"]), cdrop(["one", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_missing_drop_x2 if {
+	inp := {"review": input_review([cdrop(["one"]), cdrop(["two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_drop_undefined_x2 if {
+	inp := {"review": input_review([cadd([]), cadd([])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_drop_undefined_x2_but_exempt if {
+	inp := {"review": input_review([cadd([]), cadd([])]), "parameters": {"requiredDropCapabilities": ["one", "two"], "exemptImages": ["nginx"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_drop_literal_all if {
+	inp := {"review": input_review([cdrop(["ALL"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_drop_literal_all_lower if {
+	inp := {"review": input_review([cdrop(["all"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_drop_literal_all_with_all_param if {
+	inp := {"review": input_review([cdrop(["ALL"])]), "parameters": {"requiredDropCapabilities": ["one", "ALL"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_drop_literal_all_x2 if {
+	inp := {"review": input_review([cdrop(["ALL", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_update if {
+	inp := {"review": object.union(input_review([cadd(["one"])]), {"operation": "UPDATE"}), "parameters": {"allowedCapabilities": []}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+# init containers
+test_init_container_input_all_allowed if {
+	inp := {"review": input_init_review([cadd(["one", "two"])]), "parameters": {"allowedCapabilities": ["*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_all_allowed_container_x2 if {
+	inp := {"review": input_init_review([cadd(["one", "two"]), cadd(["three"])]), "parameters": {"allowedCapabilities": ["*"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_one_allowed if {
+	inp := {"review": input_init_review([cadd(["one"])]), "parameters": {"allowedCapabilities": ["one"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_one_allowed_container_x2 if {
+	inp := {"review": input_init_review([cadd(["one"]), cadd(["one"])]), "parameters": {"allowedCapabilities": ["one"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_two_allowed_container_x2 if {
+	inp := {"review": input_init_review([cadd(["one"]), cadd(["two"])]), "parameters": {"allowedCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_two_allowed_two_used_container_x2 if {
+	inp := {"review": input_init_review([cadd(["one", "two"]), cadd(["one", "two"])]), "parameters": {"allowedCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_none_allowed if {
+	inp := {"review": input_init_review([cadd(["one"])]), "parameters": {"allowedCapabilities": []}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_none_allowed_undefined if {
+	inp := {"review": input_init_review([cadd(["one"])]), "parameters": {}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_none_allowed_undefined_x2_x2 if {
+	inp := {"review": input_init_review([cadd(["one", "two"]), cadd(["three", "two"])]), "parameters": {}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_init_container_input_disallowed_x1 if {
+	inp := {"review": input_init_review([cadd(["three"])]), "parameters": {"allowedCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_disallowed_x2_just_one if {
+	inp := {"review": input_init_review([cadd(["one"]), cadd(["three", "two"])]), "parameters": {"allowedCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_disallowed_x2 if {
+	inp := {"review": input_init_review([cadd(["three"]), cadd(["three", "two"])]), "parameters": {"allowedCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_init_container_input_disallowed_x2_but_exempt if {
+	inp := {"review": input_init_review([cadd(["three"]), cadd(["three", "two"])]), "parameters": {"allowedCapabilities": ["one", "two"], "exemptImages": ["nginx"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_empty_drop if {
+	inp := {"review": input_init_review([cdrop(["one", "two"])]), "parameters": {"requiredDropCapabilities": []}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_all_dropped if {
+	inp := {"review": input_init_review([cdrop(["one", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_extra_dropped if {
+	inp := {"review": input_init_review([cdrop(["one", "two", "three"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_all_dropped_x2 if {
+	inp := {"review": input_init_review([cdrop(["one", "two"]), cdrop(["one", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_missing_drop if {
+	inp := {"review": input_init_review([cdrop(["two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_one_missing_drop_x2 if {
+	inp := {"review": input_init_review([cdrop(["one"]), cdrop(["one", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_missing_drop_x2 if {
+	inp := {"review": input_init_review([cdrop(["one"]), cdrop(["two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_init_container_input_drop_undefined_x2 if {
+	inp := {"review": input_init_review([cadd([]), cadd([])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_init_container_input_drop_undefined_x2_but_exempt if {
+	inp := {"review": input_init_review([cadd([]), cadd([])]), "parameters": {"requiredDropCapabilities": ["one", "two"], "exemptImages": ["nginx"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_drop_literal_all if {
+	inp := {"review": input_init_review([cdrop(["ALL"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_drop_literal_all_lower if {
+	inp := {"review": input_init_review([cdrop(["all"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_drop_literal_all_with_all_param if {
+	inp := {"review": input_init_review([cdrop(["ALL"])]), "parameters": {"requiredDropCapabilities": ["one", "ALL"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_init_container_input_drop_literal_with_all_param if {
+	inp := {"review": input_init_review([cdrop(["one"])]), "parameters": {"requiredDropCapabilities": ["one", "ALL"]}}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_init_container_input_drop_literal_all_x2 if {
+	inp := {"review": input_init_review([cdrop(["ALL", "two"])]), "parameters": {"requiredDropCapabilities": ["one", "two"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review(containers) := output if {
+	cs := [o |
+		some i, c in containers
+		o := inject_name(i, c)
+	]
+	output = {"object": {
+		"metadata": {"name": "nginx"},
+		"spec": {"containers": cs},
+	}}
+}
+
+input_init_review(containers) := output if {
+	cs := [o |
+		some i, c in containers
+		o := inject_name(i, c)
+	]
+	output = {"object": {
+		"metadata": {"name": "nginx"},
+		"spec": {"initContainers": cs},
+	}}
+}
+
+cdrop(drop) := {
+	"image": "nginx",
+	"securityContext": {"capabilities": {"drop": drop}},
+}
+
+cadd(add) := {
+	"image": "nginx",
+	"securityContext": {"capabilities": {"add": add}},
+}
+
+inject_name(name, obj) := out if {
+	all_keys := object.keys(obj) | {"name"}
+	out := {k: v |
+		some k in all_keys
+		v := get_default(obj, k, name)
+	}
+}

--- a/src/v1/pod-security-policy/flexvolume-drivers/constraint.tmpl
+++ b/src/v1/pod-security-policy/flexvolume-drivers/constraint.tmpl
@@ -1,0 +1,43 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspflexvolumes
+  annotations:
+    metadata.gatekeeper.sh/title: "FlexVolumes"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Controls the allowlist of FlexVolume drivers. Corresponds to the
+      `allowedFlexVolumes` field in PodSecurityPolicy. For more information,
+      see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#flexvolume-drivers
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPFlexVolumes
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls the allowlist of FlexVolume drivers. Corresponds to the
+            `allowedFlexVolumes` field in PodSecurityPolicy. For more information,
+            see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#flexvolume-drivers
+          properties:
+            allowedFlexVolumes:
+              type: array
+              description: "An array of AllowedFlexVolume objects."
+              items:
+                type: object
+                properties:
+                  driver:
+                    description: "The name of the FlexVolume driver."
+                    type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/pod-security-policy/flexvolume-drivers/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/pod-security-policy/flexvolume-drivers/lib_exclude_update.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/flexvolume-drivers/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/flexvolume-drivers/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/flexvolume-drivers/src.rego
+++ b/src/v1/pod-security-policy/flexvolume-drivers/src.rego
@@ -1,0 +1,26 @@
+package k8spspflexvolumes
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+
+violation contains {"msg": msg, "details": {}} if {
+	# spec.volumes field is immutable.
+	not is_update(input.review)
+	some volume in input_flexvolumes
+	not input_flexvolumes_allowed(volume)
+
+	msg := sprintf(
+		"FlexVolume %v is not allowed, pod: %v. Allowed drivers: %v",
+		[volume, input.review.object.metadata.name, input.parameters.allowedFlexVolumes],
+	)
+}
+
+input_flexvolumes_allowed(volume) if {
+	input.parameters.allowedFlexVolumes[_].driver == volume.flexVolume.driver
+}
+
+input_flexvolumes contains volume if {
+	some volume in input.review.object.spec.volumes
+	"flexVolume" in object.keys(volume)
+}

--- a/src/v1/pod-security-policy/flexvolume-drivers/src_test.rego
+++ b/src/v1/pod-security-policy/flexvolume-drivers/src_test.rego
@@ -1,0 +1,193 @@
+package k8spspflexvolumes
+
+import rego.v1
+
+test_input_flexvolume_empty_params if {
+	inp := {"review": input_review, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_flexvolume_many_empty_params if {
+	inp := {"review": input_review_many, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_no_flexvolume_is_allowed if {
+	inp := {"review": input_review_no_flexvolume, "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_flexvolume_allowed if {
+	inp := {"review": input_review, "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_flexvolume_many_is_allowed if {
+	inp := {"review": input_review_many, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_flexvolume_many_is_allowed_no_flexvolume if {
+	inp := {"review": input_review_many_no_flexvolume, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_flexvolume_not_allowed if {
+	inp := {"review": input_review, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_flexvolume_many_not_allowed if {
+	inp := {"review": input_review_many_not_allowed, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_flexvolume_many_one_allowed if {
+	inp := {"review": input_review_many, "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_flexvolume_many_mixed_allowed if {
+	inp := {"review": input_review_many, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_update if {
+	inp := {"review": object.union(input_review, {"operation": "UPDATE"}), "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_one,
+		"volumes": [{
+			"name": "cache-volume",
+			"flexVolume": {"driver": "example/lvm"},
+		}],
+	},
+}}
+
+input_review_no_flexvolume := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one},
+}}
+
+input_review_many := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"volumes": input_volumes_many,
+	},
+}}
+
+input_review_many_no_flexvolume := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"volumes": input_volumes_many_no_flexvolume,
+	},
+}}
+
+input_review_many_not_allowed := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"volumes": input_volumes_not_allowed,
+	},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "nginx",
+	"volumeMounts": [{
+		"mountPath": "/cache",
+		"name": "cache-volume",
+	}],
+}]
+
+input_containers_many := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"volumeMounts": [{
+			"mountPath": "/cache",
+			"name": "cache-volume",
+			"readOnly": true,
+		}],
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"volumeMounts": [{
+			"mountPath": "/cache",
+			"name": "cache-volume2",
+			"readOnly": true,
+		}],
+	},
+]
+
+input_volumes_many := [
+	{
+		"name": "cache-volume",
+		"flexVolume": {"driver": "example/lvm"},
+	},
+	{
+		"name": "cache-volume2",
+		"flexVolume": {"driver": "example/cifs"},
+	},
+	{
+		"name": "certs",
+		"secret": {"secretName": "cert-data"},
+	},
+]
+
+input_volumes_many_no_flexvolume := [
+	{
+		"name": "certs",
+		"secret": {"secretName": "cert-data"},
+	},
+	{
+		"name": "data",
+		"hostPath": {
+			"path": "/tmp/data",
+			"type": "File",
+		},
+	},
+]
+
+input_volumes_not_allowed := [
+	{
+		"name": "cache-volume",
+		"flexVolume": {"driver": "example/lvm"},
+	},
+	{
+		"name": "cache-volume2",
+		"flexVolume": {"driver": "example/other"},
+	},
+]
+
+input_parameters_empty := {"allowedFlexVolumes": []}
+
+input_parameter_in_list := {"allowedFlexVolumes": [{"driver": "example/lvm"}]}
+
+input_parameters_in_list := {"allowedFlexVolumes": [
+	{"driver": "example/lvm"},
+	{"driver": "example/cifs"},
+]}
+
+input_parameters_not_in_list := {"allowedFlexVolumes": [
+	{"driver": "example/testdriver"},
+	{"driver": "example/cifs"},
+]}

--- a/src/v1/pod-security-policy/forbidden-sysctls/constraint.tmpl
+++ b/src/v1/pod-security-policy/forbidden-sysctls/constraint.tmpl
@@ -1,0 +1,52 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspforbiddensysctls
+  annotations:
+    metadata.gatekeeper.sh/title: "Forbidden Sysctls"
+    metadata.gatekeeper.sh/version: 1.2.0
+    description: >-
+      Controls the `sysctl` profile used by containers. Corresponds to the
+      `allowedUnsafeSysctls` and `forbiddenSysctls` fields in a PodSecurityPolicy.
+      When specified, any sysctl not in the `allowedSysctls` parameter is considered to be forbidden.
+      The `forbiddenSysctls` parameter takes precedence over the `allowedSysctls` parameter.
+      For more information, see https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPForbiddenSysctls
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls the `sysctl` profile used by containers. Corresponds to the
+            `allowedUnsafeSysctls` and `forbiddenSysctls` fields in a PodSecurityPolicy.
+            When specified, any sysctl not in the `allowedSysctls` parameter is considered to be forbidden.
+            The `forbiddenSysctls` parameter takes precedence over the `allowedSysctls` parameter.
+            For more information, see https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/
+          properties:
+            allowedSysctls:
+              type: array
+              description: "An allow-list of sysctls. `*` allows all sysctls not listed in the `forbiddenSysctls` parameter."
+              items:
+                type: string
+            forbiddenSysctls:
+              type: array
+              description: "A disallow-list of sysctls. `*` forbids all sysctls."
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/forbidden-sysctls/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/forbidden-sysctls/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+            - |
+{{ file.Read "src/pod-security-policy/forbidden-sysctls/lib_exclude_update.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/forbidden-sysctls/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/forbidden-sysctls/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/forbidden-sysctls/src.rego
+++ b/src/v1/pod-security-policy/forbidden-sysctls/src.rego
@@ -1,0 +1,56 @@
+package k8spspforbiddensysctls
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+
+# Block if forbidden
+violation contains {"msg": msg, "details": {}} if {
+	# spec.securityContext.sysctls field is immutable.
+	not is_update(input.review)
+	sysctl := input.review.object.spec.securityContext.sysctls[_].name
+	forbidden_sysctl(sysctl)
+	msg := sprintf(
+		"The sysctl %v is not allowed, pod: %v. Forbidden sysctls: %v",
+		[sysctl, input.review.object.metadata.name, input.parameters.forbiddenSysctls],
+	)
+}
+
+# Block if not explicitly allowed
+violation contains {"msg": msg, "details": {}} if {
+	not is_update(input.review)
+	sysctl := input.review.object.spec.securityContext.sysctls[_].name
+	not allowed_sysctl(sysctl)
+	msg := sprintf(
+		"The sysctl %v is not explicitly allowed, pod: %v. Allowed sysctls: %v",
+		[sysctl, input.review.object.metadata.name, allowed_sysctl_string],
+	)
+}
+
+# * may be used to forbid all sysctls
+forbidden_sysctl(_) if "*" in input.parameters.forbiddenSysctls
+
+forbidden_sysctl(sysctl) if sysctl in input.parameters.forbiddenSysctls
+
+forbidden_sysctl(sysctl) if {
+	some forbidden in input.parameters.forbiddenSysctls
+	endswith(forbidden, "*")
+	startswith(sysctl, trim_suffix(forbidden, "*"))
+}
+
+# * may be used to allow all sysctls
+allowed_sysctl(_) if "*" in input.parameters.allowedSysctls
+
+allowed_sysctl(sysctl) if sysctl in input.parameters.allowedSysctls
+
+allowed_sysctl(sysctl) if {
+	some allowed in input.parameters.allowedSysctls
+	endswith(allowed, "*")
+	startswith(sysctl, trim_suffix(allowed, "*"))
+}
+
+allowed_sysctl(_) if not input.parameters.allowedSysctls
+
+default allowed_sysctl_string := "unspecified"
+
+allowed_sysctl_string := input.parameters.allowedSysctls

--- a/src/v1/pod-security-policy/forbidden-sysctls/src_test.rego
+++ b/src/v1/pod-security-policy/forbidden-sysctls/src_test.rego
@@ -1,0 +1,283 @@
+package k8spspforbiddensysctls
+
+import rego.v1
+
+test_input_sysctls_forbidden_all if {
+	inp := {"review": input_review, "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_sysctls_forbidden_in_list if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_sysctls_forbidden_in_list_mixed if {
+	inp := {"review": input_review, "parameters": input_parameters_one_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_sysctls_forbidden_not_in_list if {
+	inp := {"review": input_review, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_sysctls_forbidden_in_list_wildcard if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list_wildcard}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_sysctls_forbidden_in_list_wildcard_mixed if {
+	inp := {"review": input_review, "parameters": input_parameters_one_in_list_wildcard}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_sysctls_forbidden_not_in_list_wildcard if {
+	inp := {"review": input_review, "parameters": input_parameters_not_in_list_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_sysctls_empty_forbidden if {
+	inp := {"review": input_review, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccontext_empty_wildcard if {
+	inp := {"review": input_review_seccontext_empty, "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_sysctls_empty_wildcard if {
+	inp := {"review": input_review_sysctls_empty, "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccontext_null_wildcard if {
+	inp := {"review": input_review_seccontext_null, "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccontext_empty_empty_forbidden if {
+	inp := {"review": input_review_seccontext_empty, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_sysctls_empty_empty_forbidden if {
+	inp := {"review": input_review_sysctls_empty, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccontext_null_empty_forbidden if {
+	inp := {"review": input_review_seccontext_null, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_init_sysctls_forbidden_all if {
+	inp := {"review": input_init_review, "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_init_sysctls_forbidden_in_list if {
+	inp := {"review": input_init_review, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_init_sysctls_forbidden_in_list_mixed if {
+	inp := {"review": input_init_review, "parameters": input_parameters_one_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_init_sysctls_forbidden_not_in_list if {
+	inp := {"review": input_init_review, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_sysctls_allowed_all if {
+	inp := {"review": input_review, "parameters": input_parameters_sysctls_allowed_all}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+# Empty allowedSysctls means none are allowed.
+# This is in contrast to unspecified allowedSysctls which does not
+# place any restrictions by itself.
+test_input_sysctls_allowed_empty if {
+	inp := {"review": input_review, "parameters": input_parameters_sysctls_allowed_empty}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_sysctls_allowed_exact if {
+	inp := {"review": input_review, "parameters": input_parameters_sysctls_allowed_exact}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_sysctls_allowed_wildcards if {
+	inp := {"review": input_review, "parameters": input_parameters_sysctls_allowed_wildcards}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_sysctls_some_allowed_exact if {
+	inp := {"review": input_review, "parameters": input_parameters_sysctls_some_allowed_exact}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_sysctls_some_allowed_wildcards if {
+	inp := {"review": input_review, "parameters": input_parameters_sysctls_some_allowed_wildcards}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_sysctls_allowed_and_forbidden if {
+	inp := {"review": input_review, "parameters": input_parameters_sysctls_allowed_and_forbidden}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_update if {
+	inp := {"review": object.union(input_review, {"operation": "UPDATE"}), "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": {
+			"name": "nginx",
+			"image": "nginx",
+		},
+		"securityContext": {"sysctls": [
+			{
+				"name": "kernel.shm_rmid_forced",
+				"value": "0",
+			},
+			{
+				"name": "net.core.somaxconn",
+				"value": "1024",
+			},
+		]},
+	},
+}}
+
+input_init_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"initContainers": {
+			"name": "nginx",
+			"image": "nginx",
+		},
+		"securityContext": {"sysctls": [
+			{
+				"name": "kernel.shm_rmid_forced",
+				"value": "0",
+			},
+			{
+				"name": "net.core.somaxconn",
+				"value": "1024",
+			},
+		]},
+	},
+}}
+
+input_review_seccontext_empty := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": {
+			"name": "nginx",
+			"image": "nginx",
+		},
+		"securityContext": {},
+	},
+}}
+
+input_review_sysctls_empty := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": {
+			"name": "nginx",
+			"image": "nginx",
+		},
+		"securityContext": {"sysctls": []},
+	},
+}}
+
+input_review_seccontext_null := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": {
+		"name": "nginx",
+		"image": "nginx",
+	}},
+}}
+
+input_parameters_wildcard := {"forbiddenSysctls": ["*"]}
+
+input_parameters_in_list := {"forbiddenSysctls": [
+	"kernel.shm_rmid_forced",
+	"net.core.somaxconn",
+]}
+
+input_parameters_one_in_list := {"forbiddenSysctls": ["kernel.shm_rmid_forced"]}
+
+input_parameters_not_in_list := {"forbiddenSysctls": ["kernel.msgmax"]}
+
+input_parameters_in_list_wildcard := {"forbiddenSysctls": [
+	"kernel.*",
+	"net.core*",
+]}
+
+input_parameters_one_in_list_wildcard := {"forbiddenSysctls": ["kernel.*"]}
+
+input_parameters_not_in_list_wildcard := {"forbiddenSysctls": ["kernel.msg*"]}
+
+input_parameters_empty := {"forbiddenSysctls": []}
+
+input_parameters_sysctls_allowed_all := {"allowedSysctls": ["*"]}
+
+input_parameters_sysctls_allowed_empty := {"allowedSysctls": []}
+
+input_parameters_sysctls_allowed_wildcards := {"allowedSysctls": [
+	"kernel.*",
+	"net.*",
+]}
+
+input_parameters_sysctls_allowed_exact := {"allowedSysctls": [
+	"kernel.shm_rmid_forced",
+	"net.core.somaxconn",
+]}
+
+input_parameters_sysctls_some_allowed_exact := {"allowedSysctls": ["net.core.somaxconn"]}
+
+input_parameters_sysctls_some_allowed_wildcards := {"allowedSysctls": ["net.*"]}
+
+input_parameters_sysctls_allowed_and_forbidden := {
+	"allowedSysctls": [
+		"kernel.shm_rmid_forced",
+		"net.core.somaxconn",
+	],
+	"forbiddenSysctls": [
+		"kernel.shm_rmid_forced",
+		"net.core.somaxconn",
+	],
+}

--- a/src/v1/pod-security-policy/fsgroup/constraint.tmpl
+++ b/src/v1/pod-security-policy/fsgroup/constraint.tmpl
@@ -1,0 +1,57 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspfsgroup
+  annotations:
+    metadata.gatekeeper.sh/title: "FS Group"
+    metadata.gatekeeper.sh/version: 1.1.0
+    description: >-
+      Controls allocating an FSGroup that owns the Pod's volumes. Corresponds
+      to the `fsGroup` field in a PodSecurityPolicy. For more information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPFSGroup
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls allocating an FSGroup that owns the Pod's volumes. Corresponds
+            to the `fsGroup` field in a PodSecurityPolicy. For more information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
+          properties:
+            rule:
+              description: "An FSGroup rule name."
+              enum:
+                - MayRunAs
+                - MustRunAs
+                - RunAsAny
+              type: string
+            ranges:
+              type: array
+              description: "GID ranges affected by the rule."
+              items:
+                type: object
+                properties:
+                  min:
+                    description: "The minimum GID in the range, inclusive."
+                    type: integer
+                  max:
+                    description: "The maximum GID in the range, inclusive."
+                    type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/fsgroup/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/fsgroup/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+            - |
+{{ file.Read "src/pod-security-policy/fsgroup/lib_exclude_update.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/fsgroup/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/fsgroup/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/fsgroup/src.rego
+++ b/src/v1/pod-security-policy/fsgroup/src.rego
@@ -1,0 +1,53 @@
+package k8spspfsgroup
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+
+violation contains {"msg": msg, "details": {}} if {
+	# spec.securityContext.fsGroup field is immutable.
+	not is_update(input.review)
+	"rule" in object.keys(input.parameters)
+	not input_fs_group_allowed(input.review.object.spec)
+
+	msg := sprintf("The provided pod spec fsGroup is not allowed, pod: %v. Allowed fsGroup: %v", [
+		input.review.object.metadata.name,
+		input.parameters,
+	])
+}
+
+input_fs_group_allowed(_) if {
+	# RunAsAny - No range is required. Allows any fsGroup ID to be specified.
+	input.parameters.rule == "RunAsAny"
+}
+
+input_fs_group_allowed(spec) if {
+	# MustRunAs - Validates pod spec fsgroup against all ranges
+	input.parameters.rule == "MustRunAs"
+	some range in input.parameters.ranges
+	value_within_range(range, spec.securityContext.fsGroup)
+}
+
+input_fs_group_allowed(spec) if {
+	# MayRunAs - Validates pod spec fsgroup against all ranges or allow pod spec fsgroup to be left unset
+	input.parameters.rule == "MayRunAs"
+	not "securityContext" in object.keys(spec)
+}
+
+input_fs_group_allowed(spec) if {
+	# MayRunAs - Validates pod spec fsgroup against all ranges or allow pod spec fsgroup to be left unset
+	input.parameters.rule == "MayRunAs"
+	not spec.securityContext.fsGroup
+}
+
+input_fs_group_allowed(spec) if {
+	# MayRunAs - Validates pod spec fsgroup against all ranges or allow pod spec fsgroup to be left unset
+	input.parameters.rule == "MayRunAs"
+	some range in input.parameters.ranges
+	value_within_range(range, spec.securityContext.fsGroup)
+}
+
+value_within_range(range, value) if {
+	range.min <= value
+	range.max >= value
+}

--- a/src/v1/pod-security-policy/fsgroup/src_test.rego
+++ b/src/v1/pod-security-policy/fsgroup/src_test.rego
@@ -1,0 +1,143 @@
+package k8spspfsgroup
+
+import rego.v1
+
+test_input_fsgroup_allowed_all if {
+	inp := {"review": input_review_with_fsgroup, "parameters": input_parameters_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_fsgroup_allowed_all if {
+	inp := {"review": input_review, "parameters": input_parameters_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_fsgroup_MustRunAs_allowed if {
+	inp := {"review": input_review_with_fsgroup, "parameters": input_parameters_in_list_mustrunas}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_fsgroup_MustRunAs_not_allowed if {
+	inp := {"review": input_review_with_fsgroup, "parameters": input_parameters_in_list_mustrunas_outofrange}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_no_fsgroup_MustRunAs_not_allowed if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list_mustrunas}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_securitycontext_no_fsgroup_MustRunAs_not_allowed if {
+	inp := {"review": input_review_with_securitycontext_no_fsgroup, "parameters": input_parameters_in_list_mustrunas}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_fsgroup_MayRunAs_allowed if {
+	inp := {"review": input_review_with_fsgroup, "parameters": input_parameters_in_list_mayrunas}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_fsgroup_MayRunAs_not_allowed if {
+	inp := {"review": input_review_with_fsgroup, "parameters": input_parameters_in_list_mayrunas_outofrange}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_no_fsgroup_MayRunAs_allowed if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list_mayrunas}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_securitycontext_no_fsgroup_MayRunAs_allowed if {
+	inp := {"review": input_review_with_securitycontext_no_fsgroup, "parameters": input_parameters_in_list_mayrunas}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_update if {
+	inp := {"review": object.union(input_review_with_fsgroup, {"operation": "UPDATE"}), "parameters": input_parameters_in_list_mustrunas_outofrange}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_one,
+		"volumes": input_volumes,
+	},
+}}
+
+input_review_with_fsgroup := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"securityContext": {"fsGroup": 2000},
+		"containers": input_containers_one,
+		"volumes": input_volumes,
+	},
+}}
+
+input_review_with_securitycontext_no_fsgroup := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"securityContext": {"runAsUser": "1000"},
+		"containers": input_containers_one,
+		"volumes": input_volumes,
+	},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "nginx",
+	"volumeMounts": [{
+		"mountPath": "/cache",
+		"name": "cache-volume",
+	}],
+}]
+
+input_volumes := [{
+	"name": "cache-volume",
+	"emptyDir": {},
+}]
+
+input_parameters_runasany := {"rule": "RunAsAny"}
+
+input_parameters_in_list_mustrunas := {
+	"rule": "MustRunAs",
+	"ranges": [{
+		"min": 1,
+		"max": 2000,
+	}],
+}
+
+input_parameters_in_list_mustrunas_outofrange := {
+	"rule": "MustRunAs",
+	"ranges": [{
+		"min": 1,
+		"max": 1000,
+	}],
+}
+
+input_parameters_in_list_mayrunas := {
+	"rule": "MayRunAs",
+	"ranges": [{
+		"min": 1,
+		"max": 2000,
+	}],
+}
+
+input_parameters_in_list_mayrunas_outofrange := {
+	"rule": "MayRunAs",
+	"ranges": [{
+		"min": 1,
+		"max": 1000,
+	}],
+}

--- a/src/v1/pod-security-policy/host-filesystem/constraint.tmpl
+++ b/src/v1/pod-security-policy/host-filesystem/constraint.tmpl
@@ -1,0 +1,52 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spsphostfilesystem
+  annotations:
+    metadata.gatekeeper.sh/title: "Host Filesystem"
+    metadata.gatekeeper.sh/version: 1.1.1
+    description: >-
+      Controls usage of the host filesystem. Corresponds to the
+      `allowedHostPaths` field in a PodSecurityPolicy. For more information,
+      see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPHostFilesystem
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls usage of the host filesystem. Corresponds to the
+            `allowedHostPaths` field in a PodSecurityPolicy. For more information,
+            see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
+          properties:
+            allowedHostPaths:
+              type: array
+              description: "An array of hostpath objects, representing paths and read/write configuration."
+              items:
+                type: object
+                properties:
+                  pathPrefix:
+                    type: string
+                    description: "The path prefix that the host volume must match."
+                  readOnly:
+                    type: boolean
+                    description: "when set to true, any container volumeMounts matching the pathPrefix must include `readOnly: true`."
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source: 
+{{ file.Read "src/pod-security-policy/host-filesystem/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/host-filesystem/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+            - |
+{{ file.Read "src/pod-security-policy/host-filesystem/lib_exclude_update.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/host-filesystem/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/host-filesystem/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/host-filesystem/src.rego
+++ b/src/v1/pod-security-policy/host-filesystem/src.rego
@@ -1,0 +1,88 @@
+package k8spsphostfilesystem
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+
+violation contains {"msg": msg, "details": {}} if {
+	# spec.volumes field is immutable.
+	not is_update(input.review)
+
+	some volume in input_hostpath_volumes
+	input_hostpath_violation(allowed_paths, volume)
+	msg := sprintf(
+		"HostPath volume %v is not allowed, pod: %v. Allowed path: %v",
+		[volume, input.review.object.metadata.name, allowed_paths],
+	)
+}
+
+input_hostpath_violation(allowed_paths, _) if {
+	# An empty list means all host paths are blocked
+	allowed_paths == []
+}
+
+input_hostpath_violation(allowed_paths, volume) if {
+	not input_hostpath_allowed(allowed_paths, volume)
+}
+
+default allowed_paths := []
+
+allowed_paths := input.parameters.allowedHostPaths
+
+input_hostpath_allowed(allowed_paths, volume) if {
+	some allowed_host_path in allowed_paths
+	path_matches(allowed_host_path.pathPrefix, volume.hostPath.path)
+	not allowed_host_path.readOnly == true
+}
+
+input_hostpath_allowed(allowed_paths, volume) if {
+	not writeable_input_volume_mounts(volume.name)
+	some allowed_host_path in allowed_paths
+	path_matches(allowed_host_path.pathPrefix, volume.hostPath.path)
+	allowed_host_path.readOnly
+}
+
+writeable_input_volume_mounts(volume_name) if {
+	some container in input_containers
+	some mount in container.volumeMounts
+	mount.name == volume_name
+	not mount.readOnly
+}
+
+# This allows "/foo", "/foo/", "/foo/bar" etc., but
+# disallows "/fool", "/etc/foo" etc.
+path_matches(prefix, path) if {
+	a := path_array(prefix)
+	b := path_array(path)
+	prefix_matches(a, b)
+}
+
+path_array(p) := out if {
+	p != "/"
+	out := split(trim(p, "/"), "/")
+}
+
+# This handles the special case for "/", since
+# split(trim("/", "/"), "/") == [""]
+path_array("/") := []
+
+prefix_matches(a, b) if {
+	count(a) <= count(b)
+	not any_not_equal_upto(a, b, count(a))
+}
+
+any_not_equal_upto(a, b, n) if {
+	some i, v in a
+	v != b[i]
+	i < n
+}
+
+input_hostpath_volumes contains volume if {
+	some volume in input.review.object.spec.volumes
+	"hostPath" in object.keys(volume)
+}
+
+input_containers contains container if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+}

--- a/src/v1/pod-security-policy/host-filesystem/src_test.rego
+++ b/src/v1/pod-security-policy/host-filesystem/src_test.rego
@@ -1,0 +1,392 @@
+package k8spsphostfilesystem
+
+import rego.v1
+
+test_input_hostpath_block_all if {
+	inp := {"review": input_review, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_block_all_null_params if {
+	inp := {"review": input_review, "parameters": null}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_block_all_no_params if {
+	inp := {"review": input_review}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_many_block_all if {
+	inp := {"review": input_review_many, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_hostpath_no_volumes if {
+	inp := {"review": input_review_no_volumes, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hostpath_mixed_volumes if {
+	inp := {"review": input_review_many_mixed_volumes, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hostpath_mixed_volumes_not_allowed if {
+	inp := {"review": input_review_many_mixed_volumes, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_no_hostpath if {
+	inp := {"review": input_review_many_no_hostpath, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hostpath_allowed_readonly if {
+	inp := {"review": input_review_many, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hostpath_not_allowed_readonly if {
+	inp := {"review": input_review, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_many_not_allowed_readonly if {
+	inp := {"review": input_review_many, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_hostpath_allowed_writable_allowed if {
+	inp := {"review": input_review_writable, "parameters": input_parameters_in_list_writable}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hostpath_allowed_writable_not_allowed if {
+	inp := {"review": input_review_writable, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_not_allowed_writable if {
+	inp := {"review": input_review_writable, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_allowed_not_writable if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_allowed_is_writable if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list_writable}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hostpath_not_allowed_is_writable if {
+	inp := {"review": input_review, "parameters": input_parameters_not_in_list_writable}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_not_allowed if {
+	inp := {"review": input_review, "parameters": input_parameters_not_in_list_writable}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_allowed_readonly_mixed_parameters if {
+	inp := {"review": input_review_many_mixed_writable, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_allowed_readonly_mixed__writable_parameters if {
+	inp := {"review": input_review_many_readonly, "parameters": input_parameters_in_list_mixed_writable}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hostpath_allowed_mixed_writable_mixed_parameters if {
+	inp := {"review": input_review_many_mixed_writable, "parameters": input_parameters_in_list_mixed_writable}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_update if {
+	inp := {"review": object.union(input_review, {"operation": "UPDATE"}), "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+# Init Containers
+test_input_hostpath_allowed_readonly_init_containers if {
+	inp := {"review": input_init_review, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_allowed_readonly_many_init_containers if {
+	inp := {"review": input_init_review_many, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hostpath_not_allowed_readonly_init_containers if {
+	inp := {"review": input_init_review, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_hostpath_many_not_allowed_readonly_init_containers if {
+	inp := {"review": input_init_review_many, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+# Unit Tests
+test_path_matches if {
+	path_matches("/foo", "/foo/")
+	path_matches("/foo", "/foo/r")
+	path_matches("/", "/foo")
+	not path_matches("/foo", "/fool")
+	not path_matches("/foo", "/etc/foo")
+	not path_matches("/foo", "/")
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_one,
+		"volumes": input_volumes,
+	},
+}}
+
+input_init_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"initContainers": input_containers_one,
+		"volumes": input_volumes,
+	},
+}}
+
+input_review_writable := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_writable,
+		"volumes": input_volumes,
+	},
+}}
+
+input_review_many := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"volumes": input_volumes_many,
+	},
+}}
+
+input_review_many_readonly := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"volumes": input_volumes_many_mixed,
+	},
+}}
+
+input_review_many_mixed_writable := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many_mixed_writable,
+		"volumes": input_volumes_many_mixed,
+	},
+}}
+
+input_init_review_many := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"initContainers": input_containers_many,
+		"volumes": input_volumes_many,
+	},
+}}
+
+input_review_no_volumes := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": [{
+		"name": "nginx",
+		"image": "nginx",
+	}]},
+}}
+
+input_review_many_mixed_volumes := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many_mixed_volume,
+		"volumes": input_volumes,
+	},
+}}
+
+input_review_many_no_hostpath := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"initContainers": input_containers_many,
+		"volumes": input_volumes_no_hostpath,
+	},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "nginx",
+	"volumeMounts": [{
+		"mountPath": "/cache",
+		"name": "cache-volume",
+	}],
+}]
+
+input_containers_writable := [{
+	"name": "nginx",
+	"image": "nginx",
+	"volumeMounts": [{
+		"mountPath": "/cache",
+		"name": "cache-volume",
+		"readOnly": false,
+	}],
+}]
+
+input_containers_many := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"volumeMounts": [{
+			"mountPath": "/cache",
+			"name": "cache-volume",
+			"readOnly": true,
+		}],
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"volumeMounts": [{
+			"mountPath": "/cache",
+			"name": "cache-volume2",
+			"readOnly": true,
+		}],
+	},
+]
+
+input_containers_many_mixed_volume := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"volumeMounts": [{
+			"mountPath": "/cache",
+			"name": "cache-volume",
+			"readOnly": true,
+		}],
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+	},
+]
+
+input_containers_many_mixed_writable := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"volumeMounts": [{
+			"mountPath": "/cache",
+			"name": "cache-volume",
+			"readOnly": true,
+		}],
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"volumeMounts": [{
+			"mountPath": "/cache",
+			"name": "cache-volume2",
+			"readOnly": false,
+		}],
+	},
+]
+
+input_volumes := [{
+	"name": "cache-volume",
+	"hostPath": {"path": "/tmp"},
+}]
+
+input_volumes_no_hostpath := [
+	{
+		"name": "cache-volume",
+		"emptyDir": {},
+	},
+	{
+		"name": "cache-volume2",
+		"secret": {"secretName": "test-secret"},
+	},
+]
+
+input_volumes_many := [
+	{
+		"name": "cache-volume",
+		"hostPath": {"path": "/tmp"},
+	},
+	{
+		"name": "cache-volume2",
+		"hostPath": {"path": "/tmp/test"},
+	},
+]
+
+input_volumes_many_mixed := [
+	{
+		"name": "cache-volume",
+		"hostPath": {"path": "/tmp"},
+	},
+	{
+		"name": "cache-volume2",
+		"hostPath": {"path": "/foo/test"},
+	},
+]
+
+input_parameters_empty := {"allowedHostPaths": []}
+
+input_parameters_in_list := {"allowedHostPaths": [{
+	"readOnly": true,
+	"pathPrefix": "/tmp",
+}]}
+
+input_parameters_not_in_list := {"allowedHostPaths": [{
+	"readOnly": true,
+	"pathPrefix": "/foo",
+}]}
+
+input_parameters_in_list_writable := {"allowedHostPaths": [
+	{"pathPrefix": "/tmp"},
+	{"pathPrefix": "/foo"},
+]}
+
+input_parameters_not_in_list_writable := {"allowedHostPaths": [{"pathPrefix": "/foo"}]}
+
+input_parameters_in_list_mixed_writable := {"allowedHostPaths": [
+	{
+		"pathPrefix": "/tmp",
+		"readOnly": true,
+	},
+	{"pathPrefix": "/foo"},
+]}

--- a/src/v1/pod-security-policy/host-namespaces/constraint.tmpl
+++ b/src/v1/pod-security-policy/host-namespaces/constraint.tmpl
@@ -1,0 +1,33 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spsphostnamespace
+  annotations:
+    metadata.gatekeeper.sh/title: "Host Namespace"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Disallows sharing of host PID and IPC namespaces by pod containers.
+      Corresponds to the `hostPID` and `hostIPC` fields in a PodSecurityPolicy.
+      For more information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPHostNamespace
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Disallows sharing of host PID and IPC namespaces by pod containers.
+            Corresponds to the `hostPID` and `hostIPC` fields in a PodSecurityPolicy.
+            For more information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/pod-security-policy/host-namespaces/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/pod-security-policy/host-namespaces/lib_exclude_update.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/host-namespaces/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/host-namespaces/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/host-namespaces/src.rego
+++ b/src/v1/pod-security-policy/host-namespaces/src.rego
@@ -1,0 +1,18 @@
+package k8spsphostnamespace
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+
+violation contains {"msg": msg, "details": {}} if {
+	# spec.hostPID and spec.hostIPC fields are immutable.
+	not is_update(input.review)
+
+	input_share_hostnamespace
+
+	msg := sprintf("Sharing the host namespace is not allowed: %v", [input.review.object.metadata.name])
+}
+
+input_share_hostnamespace if input.review.object.spec.hostPID
+
+input_share_hostnamespace if input.review.object.spec.hostIPC

--- a/src/v1/pod-security-policy/host-namespaces/src_test.rego
+++ b/src/v1/pod-security-policy/host-namespaces/src_test.rego
@@ -1,0 +1,68 @@
+package k8spsphostnamespace
+
+import rego.v1
+
+test_input_no_hostnamespace_allowed if {
+	inp := {"review": input_review}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_hostPID_not_allowed if {
+	inp := {"review": input_review_hostPID}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_hostIPC_not_allowed if {
+	inp := {"review": input_review_hostIPC}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_hostnamespace_both_not_allowed if {
+	inp := {"review": input_review_hostnamespace_both}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_update if {
+	inp := {"review": object.union(input_review_hostPID, {"operation": "UPDATE"})}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers},
+}}
+
+input_review_hostPID := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"hostPID": true,
+		"containers": input_containers,
+	},
+}}
+
+input_review_hostIPC := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"hostIPC": true,
+		"containers": input_containers,
+	},
+}}
+
+input_review_hostnamespace_both := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"hostPID": true,
+		"hostIPC": true,
+		"containers": input_containers,
+	},
+}}
+
+input_containers := [{
+	"name": "nginx",
+	"image": "nginx",
+}]

--- a/src/v1/pod-security-policy/host-network-ports/constraint.tmpl
+++ b/src/v1/pod-security-policy/host-network-ports/constraint.tmpl
@@ -1,0 +1,61 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spsphostnetworkingports
+  annotations:
+    metadata.gatekeeper.sh/title: "Host Networking Ports"
+    metadata.gatekeeper.sh/version: 1.1.4
+    description: >-
+      Controls usage of host network namespace by pod containers. HostNetwork verification happens without exception for exemptImages. Specific
+      ports must be specified. Corresponds to the `hostNetwork` and
+      `hostPorts` fields in a PodSecurityPolicy. For more information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPHostNetworkingPorts
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls usage of host network namespace by pod containers. HostNetwork verification happens without exception for exemptImages. Specific
+            ports must be specified. Corresponds to the `hostNetwork` and
+            `hostPorts` fields in a PodSecurityPolicy. For more information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            hostNetwork:
+              description: "Determines if the policy allows the use of HostNetwork in the pod spec."
+              type: boolean
+            min:
+              description: "The start of the allowed port range, inclusive."
+              type: integer
+            max:
+              description: "The end of the allowed port range, inclusive."
+              type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/host-network-ports/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/host-network-ports/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+            - |
+{{ file.Read "src/pod-security-policy/host-network-ports/lib_exclude_update.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}
+            - |
+{{ file.Read "src/pod-security-policy/host-network-ports/lib_exempt_container.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/host-network-ports/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/host-network-ports/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/host-network-ports/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/host-network-ports/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/host-network-ports/src.rego
+++ b/src/v1/pod-security-policy/host-network-ports/src.rego
@@ -1,0 +1,38 @@
+package k8spsphostnetworkingports
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg, "details": {}} if {
+	# spec.hostNetwork field is immutable.
+	not is_update(input.review)
+
+	input_share_hostnetwork(input.review.object)
+	msg := sprintf(
+		"The specified hostNetwork and hostPort are not allowed, pod: %v. Allowed values: %v",
+		[input.review.object.metadata.name, input.parameters],
+	)
+}
+
+input_share_hostnetwork(o) if {
+	not input.parameters.hostNetwork
+	o.spec.hostNetwork
+}
+
+input_share_hostnetwork(_) if {
+	host_port := input_containers[_].ports[_].hostPort
+	host_port < input.parameters.min
+}
+
+input_share_hostnetwork(_) if {
+	host_port := input_containers[_].ports[_].hostPort
+	host_port > input.parameters.max
+}
+
+input_containers contains container if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+	not is_exempt(container)
+}

--- a/src/v1/pod-security-policy/host-network-ports/src_test.rego
+++ b/src/v1/pod-security-policy/host-network-ports/src_test.rego
@@ -1,0 +1,158 @@
+package k8spsphostnetworkingports
+
+import rego.v1
+
+test_input_no_hostnetwork_no_port_is_allowed if {
+	inp := {"review": input_review, "parameters": input_parameters_ports}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_hostnetwork_allowed_ports_is_allowed if {
+	inp := {"review": input_review_no_hostnetwork_allowed_ports, "parameters": input_parameters_ports}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_no_hostnetwork_container_ports_not_allowed if {
+	inp := {"review": input_review_no_hostnetwork_container_ports_outofrange, "parameters": input_parameters_ports}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_with_hostnetwork_is_allowed if {
+	inp := {"review": input_review_with_hostnetwork_no_port, "parameters": input_parameters_ports}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_with_hostnetwork_constraint_no_hostnetwork_not_allowed if {
+	inp := {"review": input_review_with_hostnetwork_no_port, "parameters": input_parameters_ports_no_hostnetwork}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_with_hostnetwork_constraint_no_hostnetwork_explicit if {
+	inp := {"review": input_review_no_hostnetwork_explicit, "parameters": input_parameters_ports_no_hostnetwork}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_with_hostnetwork_container_ports_not_allowed if {
+	inp := {"review": input_review_with_hostnetwork_port_outofrange, "parameters": input_parameters_ports}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_with_hostnetwork_container_ports_not_allowed_but_exempt if {
+	inp := {"review": input_review_with_hostnetwork_port_outofrange, "parameters": input_parameters_exempt}
+	results := violation with input as inp
+	trace(sprintf("%v", [results]))
+	count(results) == 0
+}
+
+test_update if {
+	inp := {"review": object.union(input_review_no_hostnetwork_container_ports_outofrange, {"operation": "UPDATE"}), "parameters": input_parameters_ports}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one},
+}}
+
+input_review_no_hostnetwork_allowed_ports := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one_port},
+}}
+
+input_review_no_hostnetwork_container_ports_outofrange := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one_port_outofrange},
+}}
+
+input_review_with_hostnetwork_no_port := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"hostNetwork": true,
+		"containers": input_containers_one,
+	},
+}}
+
+input_review_no_hostnetwork_explicit := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"hostNetwork": false,
+		"containers": input_containers_one,
+	},
+}}
+
+input_review_with_hostnetwork_port_outofrange := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"hostNetwork": true,
+		"containers": input_containers_many_port_outofrange,
+		"initContainers": input_containers_one_port_outofrange,
+	},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "nginx",
+}]
+
+input_containers_one_port := [{
+	"name": "nginx",
+	"image": "nginx",
+	"ports": [{
+		"containerPort": 80,
+		"hostPort": 8080,
+	}],
+}]
+
+input_containers_one_port_outofrange := [{
+	"name": "nginx",
+	"image": "nginx",
+	"ports": [{
+		"containerPort": 80,
+		"hostPort": 9001,
+	}],
+}]
+
+input_containers_many_port_outofrange := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"ports": [{
+			"containerPort": 80,
+			"hostPort": 9001,
+		}],
+	},
+	{
+		"name": "nginx1",
+		"image": "nginx",
+		"ports": [{
+			"containerPort": 9200,
+			"hostPort": 9200,
+		}],
+	},
+]
+
+input_parameters_ports := {
+	"hostNetwork": true,
+	"min": 80,
+	"max": 9000,
+}
+
+input_parameters_ports_no_hostnetwork := {
+	"min": 80,
+	"max": 9000,
+}
+
+input_parameters_exempt := {
+	"exemptImages": ["nginx"],
+	"hostNetwork": true,
+	"min": 80,
+	"max": 9000,
+}

--- a/src/v1/pod-security-policy/privileged-containers/constraint.tmpl
+++ b/src/v1/pod-security-policy/privileged-containers/constraint.tmpl
@@ -1,0 +1,51 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspprivilegedcontainer
+  annotations:
+    metadata.gatekeeper.sh/title: "Privileged Container"
+    metadata.gatekeeper.sh/version: 1.1.2
+    description: >-
+      Controls the ability of any container to enable privileged mode.
+      Corresponds to the `privileged` field in a PodSecurityPolicy. For more
+      information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPPrivilegedContainer
+      validation:
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls the ability of any container to enable privileged mode.
+            Corresponds to the `privileged` field in a PodSecurityPolicy. For more
+            information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/privileged-containers/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/privileged-containers/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+            - |
+{{ file.Read "src/pod-security-policy/privileged-containers/lib_exclude_update.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}
+            - |
+{{ file.Read "src/pod-security-policy/privileged-containers/lib_exempt_container.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/privileged-containers/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/privileged-containers/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/privileged-containers/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/privileged-containers/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/privileged-containers/src.rego
+++ b/src/v1/pod-security-policy/privileged-containers/src.rego
@@ -1,0 +1,22 @@
+package k8spspprivileged
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg, "details": {}} if {
+	# spec.containers.privileged field is immutable.
+	not is_update(input.review)
+
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+
+	not is_exempt(container)
+	container.securityContext.privileged
+
+	msg := sprintf(
+		"Privileged container is not allowed: %v, securityContext: %v",
+		[container.name, container.securityContext],
+	)
+}

--- a/src/v1/pod-security-policy/privileged-containers/src_test.rego
+++ b/src/v1/pod-security-policy/privileged-containers/src_test.rego
@@ -1,0 +1,121 @@
+package k8spspprivileged
+
+import rego.v1
+
+test_input_container_not_privileged_allowed if {
+	inp := {"review": input_review}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_privileged_not_allowed if {
+	inp := {"review": input_review_priv}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_container_many_not_privileged_allowed if {
+	inp := {"review": input_review_many}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_many_mixed_privileged_not_allowed if {
+	inp := {"review": input_review_many_mixed}
+	results := violation with input as inp
+	count(results) > 0
+}
+
+test_input_container_many_mixed_privileged_not_allowed_three if {
+	inp := {"review": input_review_many_mixed_two}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_container_many_mixed_privileged_not_allowed_three_but_exempt if {
+	inp := {"review": input_review_many_mixed_two, "parameters": {"exemptImages": ["nginx"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_update if {
+	inp := {"review": object.union(input_review_priv, {"operation": "UPDATE"})}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one},
+}}
+
+input_review_priv := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one_priv},
+}}
+
+input_review_many := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"initContainers": input_containers_one,
+	},
+}}
+
+input_review_many_mixed := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"initContainers": input_containers_one_priv,
+	},
+}}
+
+input_review_many_mixed_two := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many_mixed,
+		"initContainers": input_containers_one_priv,
+	},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": {"privileged": false},
+}]
+
+input_containers_one_priv := [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": {"privileged": true},
+}]
+
+input_containers_many := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": {"privileged": false},
+	},
+	{
+		"name": "nginx1",
+		"image": "nginx",
+	},
+]
+
+input_containers_many_mixed := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": {"privileged": false},
+	},
+	{
+		"name": "nginx1",
+		"image": "nginx",
+		"securityContext": {"privileged": true},
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"securityContext": {},
+	},
+]

--- a/src/v1/pod-security-policy/proc-mount/constraint.tmpl
+++ b/src/v1/pod-security-policy/proc-mount/constraint.tmpl
@@ -1,0 +1,62 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspprocmount
+  annotations:
+    metadata.gatekeeper.sh/title: "Proc Mount"
+    metadata.gatekeeper.sh/version: 1.1.2
+    description: >-
+      Controls the allowed `procMount` types for the container. Corresponds to
+      the `allowedProcMountTypes` field in a PodSecurityPolicy. For more
+      information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#allowedprocmounttypes
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPProcMount
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls the allowed `procMount` types for the container. Corresponds to
+            the `allowedProcMountTypes` field in a PodSecurityPolicy. For more
+            information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#allowedprocmounttypes
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            procMount:
+              type: string
+              description: >-
+                Defines the strategy for the security exposure of certain paths
+                in `/proc` by the container runtime. Setting to `Default` uses
+                the runtime defaults, where `Unmasked` bypasses the default
+                behavior.
+              enum:
+                - Default
+                - Unmasked
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/proc-mount/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/proc-mount/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+            - |
+{{ file.Read "src/pod-security-policy/proc-mount/lib_exclude_update.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}
+            - |
+{{ file.Read "src/pod-security-policy/proc-mount/lib_exempt_container.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/proc-mount/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/proc-mount/lib_exclude_update.rego
@@ -1,0 +1,5 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if review.operation == "UPDATE"

--- a/src/v1/pod-security-policy/proc-mount/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/proc-mount/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/proc-mount/src.rego
+++ b/src/v1/pod-security-policy/proc-mount/src.rego
@@ -1,0 +1,33 @@
+package k8spspprocmount
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg, "details": {}} if {
+	# spec.containers.securityContext.procMount field is immutable.
+	not is_update(input.review)
+
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+
+	not is_exempt(container)
+	not input_proc_mount_type_allowed(allowed_proc_mount, container.securityContext.procMount)
+
+	msg := sprintf(
+		"ProcMount type is not allowed, container: %v. Allowed procMount types: %v",
+		[container.name, allowed_proc_mount],
+	)
+}
+
+input_proc_mount_type_allowed("default", cpm) if lower(cpm) == "default"
+
+input_proc_mount_type_allowed("unmasked", _)
+
+default allowed_proc_mount := "default"
+
+allowed_proc_mount := provided if {
+	provided := lower(input.parameters.procMount)
+	provided in {"default", "unmasked"}
+}

--- a/src/v1/pod-security-policy/proc-mount/src_test.rego
+++ b/src/v1/pod-security-policy/proc-mount/src_test.rego
@@ -1,0 +1,177 @@
+package k8spspprocmount
+
+import rego.v1
+
+test_input_container_not_proc_mount_allowed if {
+	inp := {"review": input_review, "parameters": input_parameters_default}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_proc_mount_not_allowed if {
+	inp := {"review": input_review_unmasked, "parameters": input_parameters_default}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_container_proc_mount_not_allowed_null_param if {
+	inp := {"review": input_review_unmasked, "parameters": null}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_container_proc_mount_not_allowed_missing_param if {
+	inp := {"review": input_review_unmasked}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_container_many_not_proc_mount_allowed if {
+	inp := {"review": input_review_many, "parameters": input_parameters_default}
+	results := violation with input as inp
+	print(results)
+	count(results) == 0
+}
+
+test_input_container_many_mixed_proc_mount_not_allowed if {
+	inp := {"review": input_review_many_mixed, "parameters": input_parameters_default}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_container_many_mixed_proc_mount_not_allowed_two if {
+	inp := {"review": input_review_many_mixed_two, "parameters": input_parameters_default}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_container_many_mixed_proc_mount_not_allowed_two_but_exempt if {
+	inp := {"review": input_review_many_mixed_two, "parameters": input_parameters_exempt}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_proc_mount_case_insensitive if {
+	inp := {"review": input_review, "parameters": input_parameters_default_lower}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_proc_mount_case_invalid_procMount if {
+	inp := {"review": input_review, "parameters": input_parameters_invalid_procMount}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_not_proc_mount_unmasked if {
+	inp := {"review": input_review, "parameters": input_parameters_unmasked}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_proc_mount_unmasked if {
+	inp := {"review": input_review_unmasked, "parameters": input_parameters_unmasked}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_many_mixed_proc_mount_allowed_two if {
+	inp := {"review": input_review_many_mixed_two, "parameters": input_parameters_unmasked}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_update if {
+	inp := {"review": object.union(input_review_unmasked, {"operation": "UPDATE"}), "parameters": input_parameters_default}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one},
+}}
+
+input_review_unmasked := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one_unmasked},
+}}
+
+input_review_many := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"initContainers": input_containers_one,
+	},
+}}
+
+input_review_many_mixed := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"initContainers": input_containers_one_unmasked,
+	},
+}}
+
+input_review_many_mixed_two := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many_mixed,
+		"initContainers": input_containers_one_unmasked,
+	},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": {"procMount": "Default"},
+}]
+
+input_containers_one_unmasked := [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": {"procMount": "Unmasked"},
+}]
+
+input_containers_many := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": {"procMount": "Default"},
+	},
+	{
+		"name": "nginx1",
+		"image": "nginx",
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"securityContext": {"runAsUser": "1000"},
+	},
+]
+
+input_containers_many_mixed := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": {"procMount": "Default"},
+	},
+	{
+		"name": "nginx1",
+		"image": "nginx",
+		"securityContext": {"procMount": "Unmasked"},
+	},
+]
+
+input_parameters_default := {"procMount": "Default"}
+
+input_parameters_default_lower := {"procMount": "default"}
+
+input_parameters_unmasked := {"procMount": "Unmasked"}
+
+input_parameters_exempt := {
+	"exemptImages": ["nginx"],
+	"procMount": "Default",
+}
+
+input_parameters_invalid_procMount := {"procMount": "invalid"}

--- a/src/v1/pod-security-policy/read-only-root-filesystem/constraint.tmpl
+++ b/src/v1/pod-security-policy/read-only-root-filesystem/constraint.tmpl
@@ -1,0 +1,52 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspreadonlyrootfilesystem
+  annotations:
+    metadata.gatekeeper.sh/title: "Read Only Root Filesystem"
+    metadata.gatekeeper.sh/version: 1.1.1
+    description: >-
+      Requires the use of a read-only root file system by pod containers.
+      Corresponds to the `readOnlyRootFilesystem` field in a
+      PodSecurityPolicy. For more information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPReadOnlyRootFilesystem
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Requires the use of a read-only root file system by pod containers.
+            Corresponds to the `readOnlyRootFilesystem` field in a
+            PodSecurityPolicy. For more information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/read-only-root-filesystem/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/read-only-root-filesystem/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+            - |
+{{ file.Read "src/pod-security-policy/read-only-root-filesystem/lib_exclude_update.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}
+            - |
+{{ file.Read "src/pod-security-policy/read-only-root-filesystem/lib_exempt_container.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/read-only-root-filesystem/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/read-only-root-filesystem/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/read-only-root-filesystem/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/read-only-root-filesystem/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/read-only-root-filesystem/src.rego
+++ b/src/v1/pod-security-policy/read-only-root-filesystem/src.rego
@@ -1,0 +1,25 @@
+package k8spspreadonlyrootfilesystem
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg, "details": {}} if {
+	# spec.containers.readOnlyRootFilesystem field is immutable.
+	not is_update(input.review)
+
+	some container in input_containers
+	not is_exempt(container)
+	input_read_only_root_fs(container)
+	msg := sprintf("only read-only root filesystem container is allowed: %v", [container.name])
+}
+
+input_read_only_root_fs(c) if not "securityContext" in object.keys(c)
+
+input_read_only_root_fs(c) if not c.securityContext.readOnlyRootFilesystem == true
+
+input_containers contains container if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+}

--- a/src/v1/pod-security-policy/read-only-root-filesystem/src_test.rego
+++ b/src/v1/pod-security-policy/read-only-root-filesystem/src_test.rego
@@ -1,0 +1,111 @@
+package k8spspreadonlyrootfilesystem
+
+import rego.v1
+
+test_input_container_not_readonlyrootfilesystem_allowed if {
+	inp := {"review": input_review}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_container_readonlyrootfilesystem_not_allowed if {
+	inp := {"review": input_review_ro}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_container_many_mixed_readonlyrootfilesystem_not_allowed if {
+	inp := {"review": input_review_many_mixed}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_container_many_mixed_readonlyrootfilesystem_not_allowed_two if {
+	inp := {"review": input_review_many_mixed_two}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_input_container_many_mixed_readonlyrootfilesystem_not_allowed_two_but_exempt if {
+	inp := {"review": input_review_many_mixed_two, "parameters": {"exemptImages": ["nginx"]}}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_update if {
+	inp := {"review": object.union(input_review, {"operation": "UPDATE"})}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one},
+}}
+
+input_review_ro := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one_ro},
+}}
+
+input_review_many_mixed := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"initContainers": input_containers_one,
+	},
+}}
+
+input_review_many_mixed_two := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many_mixed,
+		"initContainers": input_containers_one_ro,
+	},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": {"readOnlyRootFilesystem": false},
+}]
+
+input_containers_one_ro := [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": {"readOnlyRootFilesystem": true},
+}]
+
+input_containers_many := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": {"readOnlyRootFilesystem": true},
+	},
+	{
+		"name": "nginx1",
+		"image": "nginx",
+	},
+]
+
+input_containers_many_mixed := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": {"readOnlyRootFilesystem": false},
+	},
+	{
+		"name": "nginx1",
+		"image": "nginx",
+		"securityContext": {"readOnlyRootFilesystem": true},
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+	},
+	{
+		"name": "nginx3",
+		"image": "nginx",
+		"securityContext": {"runAsUser": "1000"},
+	},
+]

--- a/src/v1/pod-security-policy/seccomp/constraint.tmpl
+++ b/src/v1/pod-security-policy/seccomp/constraint.tmpl
@@ -1,0 +1,80 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspseccomp
+  annotations:
+    metadata.gatekeeper.sh/title: "Seccomp"
+    metadata.gatekeeper.sh/version: 1.1.0
+    description: >-
+      Controls the seccomp profile used by containers. Corresponds to the
+      `seccomp.security.alpha.kubernetes.io/allowedProfileNames` annotation on
+      a PodSecurityPolicy. For more information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPSeccomp
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls the seccomp profile used by containers. Corresponds to the
+            `seccomp.security.alpha.kubernetes.io/allowedProfileNames` annotation on
+            a PodSecurityPolicy. For more information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            allowedProfiles:
+              type: array
+              description: >-
+                An array of allowed profile values for seccomp on Pods/Containers.
+
+                Can use the annotation naming scheme: `runtime/default`, `docker/default`, `unconfined` and/or
+                `localhost/some-profile.json`. The item `localhost/*` will allow any localhost based profile.
+
+                Can also use the securityContext naming scheme: `RuntimeDefault`, `Unconfined`
+                and/or `Localhost`. For securityContext `Localhost`, use the parameter `allowedLocalhostProfiles`
+                to list the allowed profile JSON files.
+
+                The policy code will translate between the two schemes so it is not necessary to use both.
+
+                Putting a `*` in this array allows all Profiles to be used.
+
+                This field is required since with an empty list this policy will block all workloads.
+              items:
+                type: string
+            allowedLocalhostFiles:
+              type: array
+              description: >-
+                When using securityContext naming scheme for seccomp and including `Localhost` this array holds
+                the allowed profile JSON files.
+
+                Putting a `*` in this array will allows all JSON files to be used.
+
+                This field is required to allow `Localhost` in securityContext as with an empty list it will block.
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code: 
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/seccomp/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/seccomp/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+            - |
+{{ file.Read "src/pod-security-policy/seccomp/lib_exempt_container.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/seccomp/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/seccomp/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/seccomp/src.rego
+++ b/src/v1/pod-security-policy/seccomp/src.rego
@@ -1,0 +1,136 @@
+package k8spspseccomp
+
+import rego.v1
+
+import data.lib.exempt_container.is_exempt
+
+container_annotation_key_prefix := "container.seccomp.security.alpha.kubernetes.io/"
+
+pod_annotation_key := "seccomp.security.alpha.kubernetes.io/pod"
+
+violation contains {"msg": msg} if {
+	not input_wildcard_allowed_profiles
+	some name, container in input_containers
+	not is_exempt(container)
+	result := get_profile(container)
+	not allowed_profile(result.profile, allowed_profiles)
+	msg := sprintf(
+		"Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v",
+		[result.profile, name, result.location, allowed_profiles],
+	)
+}
+
+input_wildcard_allowed_profiles if "*" in input.parameters.allowedProfiles
+
+input_wildcard_allowed_files if "*" in input.parameters.allowedLocalhostFiles
+
+input_wildcard_allowed_files if "localhost/*" in input.parameters.allowedProfiles
+
+# Simple allowed Profiles
+allowed_profile(profile, allowed) if {
+	not startswith(profile, "localhost/")
+	profile in allowed
+}
+
+# annotation localhost with wildcard
+allowed_profile(profile, allowed) if {
+	"localhost/*" in allowed
+	startswith(profile, "localhost/")
+}
+
+# annotation localhost without wildcard
+allowed_profile(profile, allowed) if {
+	startswith(profile, "localhost/")
+	profile in allowed
+}
+
+# The profiles explicitly in the list
+allowed_profiles contains allowed if {
+	some allowed in input.parameters.allowedProfiles
+}
+
+# Seccomp Localhost to annotation translation
+allowed_profiles contains allowed if {
+	some profile in input.parameters.allowedProfiles
+	not contains(profile, "/")
+	some file in input.parameters.allowedLocalhostFiles
+	some allowed in canonicalize_seccomp_profile({"type": profile, "localhostProfile": file}, "")
+}
+
+# Container profile as defined in pod annotation
+get_profile(container) := {"profile": profile, "file": "", "location": location} if {
+	not has_securitycontext_container(container)
+	not has_annotation(get_container_annotation_key(container.name))
+	not has_securitycontext_pod
+	profile := input.review.object.metadata.annotations[pod_annotation_key]
+	location := sprintf("annotation %v", [pod_annotation_key])
+}
+
+# Container profile as defined in container annotation
+get_profile(container) := {"profile": profile, "file": "", "location": location} if {
+	not has_securitycontext_container(container)
+	not has_securitycontext_pod
+	container_annotation := get_container_annotation_key(container.name)
+	has_annotation(container_annotation)
+	profile := input.review.object.metadata.annotations[container_annotation]
+	location := sprintf("annotation %v", [container_annotation])
+}
+
+# Container profile as defined in pods securityContext
+get_profile(container) := {"profile": profile, "file": file, "location": "pod securityContext"} if {
+	not has_securitycontext_container(container)
+	some profile in canonicalize_seccomp_profile(
+		input.review.object.spec.securityContext.seccompProfile,
+		canonicalize_runtime_default_profile,
+	)
+	file := object.get(input.review.object.spec.securityContext.seccompProfile, "localhostProfile", "")
+}
+
+# Container profile as defined in containers securityContext
+get_profile(container) := {"profile": profile, "file": file, "location": "container securityContext"} if {
+	has_securitycontext_container(container)
+	some profile in canonicalize_seccomp_profile(
+		container.securityContext.seccompProfile,
+		canonicalize_runtime_default_profile,
+	)
+	file := object.get(container.securityContext.seccompProfile, "localhostProfile", "")
+}
+
+# Container profile missing
+get_profile(container) := {"profile": "not configured", "file": "", "location": "no explicit profile found"} if {
+	not has_securitycontext_container(container)
+	not has_securitycontext_pod
+	not has_annotation(get_container_annotation_key(container.name))
+	not has_annotation(pod_annotation_key)
+}
+
+has_annotation(annotation) if input.review.object.metadata.annotations[annotation]
+
+has_securitycontext_pod if input.review.object.spec.securityContext.seccompProfile
+
+has_securitycontext_container(container) if container.securityContext.seccompProfile
+
+get_container_annotation_key(name) := concat("", [container_annotation_key_prefix, name])
+
+input_containers[container.name] := container if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+}
+
+default canonicalize_runtime_default_profile := "runtime/default"
+
+canonicalize_runtime_default_profile := "docker/default" if {
+	"docker/default" in input.parameters.allowedProfiles
+}
+
+canonicalize_seccomp_profile(profile, def) := ["runtime/default", "docker/default"] if {
+	profile.type == "RuntimeDefault"
+	def == ""
+} else := [def] if {
+	profile.type == "RuntimeDefault"
+	def != ""
+} else := [sprintf("localhost/%s", [profile.localhostProfile])] if {
+	profile.type == "Localhost"
+} else := ["unconfined"] if {
+	profile.type == "Unconfined"
+}

--- a/src/v1/pod-security-policy/seccomp/src_test.rego
+++ b/src/v1/pod-security-policy/seccomp/src_test.rego
@@ -1,0 +1,658 @@
+package k8spspseccomp
+
+import rego.v1
+
+# Annotation based seccomp with containers
+test_input_annotation_seccomp_empty_parameters if {
+	inp := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_allowed_all if {
+	inp := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_allowed_in_list if {
+	inp := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_not_allowed_not_in_list if {
+	inp := {"review": get_object(pod_annotation, {}, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_pod_multiple_empty_parameters if {
+	inp := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_annotation_seccomp_pod_multiple_allowed_all if {
+	inp := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_multiple_allowed_in_list if {
+	inp := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_multiple_not_allowed_not_in_list if {
+	inp := {"review": get_object(pod_annotation, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_annotation_seccomp_container_allowed_all if {
+	inp := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_container_allowed_in_list if {
+	inp := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_container_not_allowed_not_in_list if {
+	inp := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_containers_allowed_in_list if {
+	inp := {"review": get_object(container_annotations, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_containers_not_allowed_not_in_list if {
+	inp := {"review": get_object(container_annotations, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_annotation_seccomp_containers_mixed if {
+	inp := {"review": get_object(container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_containers_mixed_missing if {
+	inp := {"review": get_object(container_annotation, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_containers_allowed_in_list_multiple if {
+	inp := {"review": get_object(container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_container if {
+	inp := {"review": get_object(pod_container_annotations, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_container_not_allowed if {
+	inp := {"review": get_object(pod_container_annotations, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_annotation_seccomp_pod_container_both_allowed if {
+	inp := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_container_mixed_allowed if {
+	inp := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_pod_container_mixed_not_allowed if {
+	inp := {"review": get_object(pod_container_annotations_mixed, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_annotation_seccomp_pod_container_both_allowed_reversed if {
+	inp := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_container_mixed_allowed_reversed if {
+	inp := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_pod_container_mixed_not_allowed_reversed if {
+	inp := {"review": get_object(pod_container_annotations_mixed_rev, {}, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+# Annotation based seccomp with init containers
+test_input_annotation_seccomp_pod_initcontainer_both_allowed if {
+	inp := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_annotation_seccomp_pod_initcontainer_mixed_allowed if {
+	inp := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_annotation_seccomp_pod_initcontainer_mixed_not_allowed if {
+	inp := {"review": get_object(pod_container_annotations_mixed, {}, {}, multiple_containers), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+# securityContext based seccomp with containers
+test_input_seccomp_empty_parameters if {
+	inp := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_empty}
+	results := violation with input as inp
+	print(results)
+	count(results) == 1
+}
+
+test_input_seccomp_allowed_all if {
+	inp := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_allowed_in_list if {
+	inp := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_not_allowed_not_in_list if {
+	inp := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_pod_multiple_empty_parameters if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_seccomp_pod_multiple_allowed_all if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_multiple_allowed_in_list if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_multiple_not_allowed_not_in_list if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_seccomp_pod_localhost_allowed_wrong_file if {
+	inp := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_pod_localhost_allowed_no_specified_file if {
+	inp := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc_localhost_no_file}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_pod_localhost_allowed_wildcard_file if {
+	inp := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc_localhost_wildcard_file}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_localhost_allowed_annotation_wildcard_file if {
+	inp := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_localhost_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_localhost_allowed_both_wildcard_file if {
+	inp := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_localhost_wildcard_both}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_not_allowed_not_configured if {
+	inp := {"review": get_object({}, {}, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_not_allowed_multiple_not_configured if {
+	inp := {"review": get_object({}, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_seccomp_container_allowed_all if {
+	inp := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_container_allowed_in_list if {
+	inp := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_container_not_allowed_not_in_list if {
+	inp := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_containers_allowed_in_list if {
+	inp := {"review": get_object({}, {}, multiple_containers_sc, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_containers_not_allowed_not_in_list if {
+	inp := {"review": get_object({}, {}, multiple_containers_sc, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_seccomp_containers_mixed if {
+	inp := {"review": get_object({}, {}, multiple_containers_sc_mixed, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_containers_mixed_missing if {
+	inp := {"review": get_object({}, {}, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_containers_allowed_in_list_multiple if {
+	inp := {"review": get_object({}, {}, multiple_containers_sc_mixed, {}), "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_container if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_container_mixed_not_allowed_but_exempt if {
+	inp := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_exempt}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_container_not_allowed if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_seccomp_pod_container_both_allowed if {
+	inp := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_container_mixed_allowed if {
+	inp := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_pod_container_mixed_not_allowed if {
+	inp := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+# securityContext based seccomp with init containers
+test_input_seccomp_pod_initcontainer_both_allowed if {
+	inp := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_initcontainer_mixed_allowed if {
+	inp := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_pod_initcontainer_mixed_not_allowed if {
+	inp := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+# Both annotation and securityContext based seccomp mixed
+test_input_both_seccomp_pod_context_container_annotation if {
+	inp := {"review": get_object(container_annotation_unconfined, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_both_seccomp_pod_annotation_container_context if {
+	inp := {"review": get_object(pod_annotation_unconfined, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_both_seccomp_pod_context_and_annotation if {
+	inp := {"review": get_object(pod_annotation, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_both_seccomp_container_context_and_annotation if {
+	inp := {"review": get_object(container_annotation, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_both_seccomp_pod_context_container_annotation_not_allowed if {
+	inp := {"review": get_object(container_annotation_unconfined, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_both_seccomp_pod_annotation_container_context_not_allowed if {
+	inp := {"review": get_object(pod_annotation_unconfined, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_both_seccomp_pod_context_and_annotation_not_allowed if {
+	inp := {"review": get_object(pod_annotation, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_both_seccomp_container_context_and_annotation_not_allowed if {
+	inp := {"review": get_object(container_annotation, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_both_seccomp_pod_context_container_annotation_multiple_mixed if {
+	inp := {"review": get_object(container_annotation, context_unconfined, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+# Testing translation between annotation and securityContext
+test_translation_seccomp_allowed_annotation_all if {
+	inp := {"parameters": input_parameters_annotation}
+	output := allowed_profiles with input as inp
+	output == allowed_full_translated_annotation_style
+}
+
+test_translation_seccomp_allowed_context_all if {
+	inp := {"parameters": input_parameters_sc}
+	output := allowed_profiles with input as inp
+	output == allowed_full_translated
+}
+
+test_translation_seccomp_allowed_context_localhost_wildcard_file if {
+	inp := {"parameters": input_parameters_sc_localhost_wildcard_file}
+	output := allowed_profiles with input as inp
+	output == {"Localhost", "localhost/*"}
+}
+
+test_translation_seccomp_allowed_context_localhost_no_file if {
+	inp := {"parameters": input_parameters_sc_localhost_no_file}
+	output := allowed_profiles with input as inp
+	output == {"Localhost"}
+}
+
+test_input_translation_seccomp_annotation_match_allowed_context if {
+	inp := {"review": get_object(container_annotation, {}, single_container, {}), "parameters": input_parameters_sc}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_translation_seccomp_context_match_allowed_annotation if {
+	inp := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_annotation}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_translation_seccomp_context_localhost_allowed_annotation if {
+	inp := {"review": get_object({}, context_localhost1, single_container, {}), "parameters": input_parameters_annotation}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_translation_seccomp_context_localhost_allowed_annotation_missing if {
+	inp := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_annotation}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+# Create Review Object
+get_object(annotations, podcontext, containers, initcontainers) := {"object": {
+	"metadata": {
+		"name": "nginx",
+		"annotations": annotations,
+	},
+	"spec": {
+		"containers": containers,
+		"initContainers": initcontainers,
+		"securityContext": podcontext,
+	},
+}}
+
+# Test Containers
+single_container := [{
+	"name": "nginx",
+	"image": "nginx",
+}]
+
+multiple_containers := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+	},
+]
+
+single_container_sc := [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": context_runtimedefault,
+}]
+
+multiple_containers_sc := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+]
+
+multiple_containers_sc_mixed := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"securityContext": context_localhost,
+	},
+]
+
+multiple_containers_sc_missing := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+	},
+]
+
+# Test Annotations
+pod_annotation := {"seccomp.security.alpha.kubernetes.io/pod": "runtime/default"}
+
+pod_annotation_unconfined := {"seccomp.security.alpha.kubernetes.io/pod": "unconfined"}
+
+pod_container_annotations := {
+	"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+}
+
+pod_container_annotations_mixed := {
+	"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+	"container.seccomp.security.alpha.kubernetes.io/nginx": "localhost/profile.json",
+}
+
+pod_container_annotations_mixed_rev := {
+	"seccomp.security.alpha.kubernetes.io/pod": "localhost/profile.json",
+	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+}
+
+container_annotation := {"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"}
+
+container_annotation_unconfined := {"container.seccomp.security.alpha.kubernetes.io/nginx": "unconfined"}
+
+container_annotations := {
+	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+	"container.seccomp.security.alpha.kubernetes.io/nginx2": "runtime/default",
+}
+
+container_annotations_mixed := {
+	"container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+	"container.seccomp.security.alpha.kubernetes.io/nginx2": "localhost/profile.json",
+}
+
+# Test securityContexts
+context_localhost := {"seccompProfile": {"type": "Localhost", "localhostProfile": "profile.json"}}
+
+context_localhost1 := {"seccompProfile": {"type": "Localhost", "localhostProfile": "profile1.json"}}
+
+context_runtimedefault := {"seccompProfile": {"type": "RuntimeDefault"}}
+
+context_unconfined := {"seccompProfile": {"type": "Unconfined"}}
+
+# Test Parameters
+input_parameters_empty := {"allowedProfiles": []}
+
+input_parameters_wildcard := {"allowedProfiles": ["*"]}
+
+input_parameters_localhost_wildcard := {"allowedProfiles": ["localhost/*"]}
+
+input_parameters_localhost_wildcard_both := {"allowedProfiles": ["localhost/*"], "allowedLocalhostFiles": ["*"]}
+
+input_parameter_in_list := {"allowedProfiles": [
+	"runtime/default",
+	"RuntimeDefault",
+]}
+
+input_parameters_in_list := {
+	"allowedProfiles": [
+		"runtime/default",
+		"RuntimeDefault",
+		"docker/default",
+		"Localhost",
+	],
+	"allowedLocalhostFiles": ["profile.json"],
+}
+
+input_parameters_not_in_list := {"allowedProfiles": [
+	"unconfined",
+	"Unconfined",
+]}
+
+input_parameters_exempt := {
+	"exemptImages": ["nginx"],
+	"allowedProfiles": ["unconfined"],
+}
+
+input_parameters_annotation := {"allowedProfiles": [
+	"runtime/default",
+	"docker/default",
+	"localhost/profile1.json",
+	"localhost/profile2.json",
+	"unconfined",
+]}
+
+input_parameters_sc := {
+	"allowedProfiles": [
+		"RuntimeDefault",
+		"Localhost",
+		"Unconfined",
+	],
+	"allowedLocalhostFiles": [
+		"profile1.json",
+		"profile2.json",
+	],
+}
+
+input_parameters_sc_localhost_wildcard_file := {
+	"allowedProfiles": ["Localhost"],
+	"allowedLocalhostFiles": ["*"],
+}
+
+input_parameters_sc_localhost_no_file := {"allowedProfiles": ["Localhost"]}
+
+allowed_full_translated := {
+	"Localhost", "localhost/profile1.json", "localhost/profile2.json",
+	"RuntimeDefault", "docker/default", "runtime/default",
+	"Unconfined", "unconfined",
+}
+
+allowed_full_translated_annotation_style := {
+	"runtime/default",
+	"docker/default",
+	"localhost/profile1.json",
+	"localhost/profile2.json",
+	"unconfined",
+}

--- a/src/v1/pod-security-policy/seccompv2/constraint.tmpl
+++ b/src/v1/pod-security-policy/seccompv2/constraint.tmpl
@@ -1,0 +1,73 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspseccompv2
+  annotations:
+    metadata.gatekeeper.sh/title: "Seccomp V2"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Controls the seccomp profile used by containers. Corresponds to the
+      `securityContext.seccompProfile` field. Security contexts from the annotation is not considered as Kubernetes no longer reads security contexts from the annotation.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPSeccompV2
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls the seccomp profile used by containers. Corresponds to the
+            `securityContext.seccompProfile` field. Security contexts from the annotation is not considered as Kubernetes no longer reads security contexts from the annotation.
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            allowedProfiles:
+              type: array
+              description: >-
+                An array of allowed profile values for seccomp on Pods/Containers.
+
+                Can use the securityContext naming scheme: `RuntimeDefault`, `Unconfined`
+                and/or `Localhost`. For securityContext `Localhost`, use the parameter `allowedLocalhostFiles`
+                to list the allowed profile JSON files.
+
+                The policy code will translate between the two schemes so it is not necessary to use both.
+
+                Putting a `*` in this array allows all Profiles to be used.
+
+                This field is required since with an empty list this policy will block all workloads.
+              items:
+                type: string
+            allowedLocalhostFiles:
+              type: array
+              description: >-
+                When using securityContext naming scheme for seccomp and including `Localhost` this array holds
+                the allowed profile JSON files.
+
+                Putting a `*` in this array will allows all JSON files to be used.
+
+                This field is required to allow `Localhost` in securityContext as with an empty list it will block.
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code: 
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/pod-security-policy/seccompv2/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/pod-security-policy/seccompv2/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}
+          libs:
+            - |
+{{ file.Read "src/pod-security-policy/seccompv2/lib_exempt_container.rego" | strings.Indent 14 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/seccompv2/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/seccompv2/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/seccompv2/src.rego
+++ b/src/v1/pod-security-policy/seccompv2/src.rego
@@ -1,0 +1,98 @@
+package k8spspseccomp
+
+import rego.v1
+
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg} if {
+	not input_wildcard_allowed_profiles
+	some name, container in input_containers
+	not is_exempt(container)
+	result := get_profile(container)
+	not allowed_profile(result.profile, result.file, allowed_profiles)
+	msg := get_message(result.profile, result.file, name, result.location, allowed_profiles)
+}
+
+get_message(profile, _, name, location, allowed_profiles) := message if {
+	profile != "Localhost"
+	message := sprintf(
+		"Seccomp profile '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v",
+		[profile, name, location, allowed_profiles],
+	)
+}
+
+get_message("Localhost", file, name, location, allowed_profiles) := sprintf(
+	"Seccomp profile 'Localhost' with file '%v' is not allowed for container '%v'. Found at: %v. Allowed profiles: %v",
+	[file, name, location, allowed_profiles],
+)
+
+input_wildcard_allowed_profiles if "*" in input.parameters.allowedProfiles
+
+input_wildcard_allowed_files if "*" in input.parameters.allowedLocalhostFiles
+
+allowed_profile(_, _, _) if {
+	input_wildcard_allowed_profiles
+}
+
+allowed_profile("Localhost", _, _) if {
+	input_wildcard_allowed_files
+}
+
+# Simple allowed Profiles
+allowed_profile(profile, _, allowed) if {
+	profile != "Localhost"
+	some allow_profile in allowed
+	profile == allow_profile.type
+}
+
+# annotation localhost without wildcard
+allowed_profile("Localhost", file, allowed) if {
+	some allow_profile in allowed
+	allow_profile.type == "Localhost"
+	file == allow_profile.localHostProfile
+}
+
+# The profiles explicitly in the list
+allowed_profiles contains {"type": profile} if {
+	some profile in input.parameters.allowedProfiles
+	profile != "Localhost"
+}
+
+allowed_profiles contains {"type": "Localhost", "localHostProfile": file} if {
+	some profile in input.parameters.allowedProfiles
+	profile == "Localhost"
+	some file in object.get(input.parameters, "allowedLocalhostFiles", [""])
+}
+
+# Container profile as defined in containers securityContext
+get_profile(container) := {
+	"profile": container.securityContext.seccompProfile.type,
+	"file": object.get(container.securityContext.seccompProfile, "localhostProfile", ""),
+	"location": "container securityContext",
+} if {
+	container.securityContext.seccompProfile
+}
+
+# Container profile as defined in pods securityContext
+get_profile(container) := {
+	"profile": input.review.object.spec.securityContext.seccompProfile.type,
+	"file": object.get(input.review.object.spec.securityContext.seccompProfile, "localhostProfile", ""),
+	"location": "pod securityContext",
+} if {
+	not container.securityContext.seccompProfile
+}
+
+# Container profile missing
+get_profile(container) := {
+	"profile": "not configured",
+	"file": "",
+	"location": "no explicit profile found",
+} if {
+	not container.securityContext.seccompProfile
+	not input.review.object.spec.securityContext.seccompProfile
+}
+
+input_containers[container.name] := container if {
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+}

--- a/src/v1/pod-security-policy/seccompv2/src_test.rego
+++ b/src/v1/pod-security-policy/seccompv2/src_test.rego
@@ -1,0 +1,355 @@
+package k8spspseccomp
+
+import rego.v1
+
+# securityContext based seccomp with containers
+
+test_input_seccomp_allowed_in_list if {
+	inp := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_allowed_all if {
+	inp := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_container_allowed_all if {
+	inp := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_container_allowed_in_list if {
+	inp := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_containers_allowed_in_list if {
+	inp := {"review": get_object({}, {}, multiple_containers_sc, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_containers_allowed_in_list_localhost if {
+	inp := {"review": get_object({}, {}, single_container_sc_localhost, {}), "parameters": input_parameters_in_list_locahost_file}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_containers_allowed_in_list_multiple if {
+	inp := {"review": get_object({}, {}, multiple_containers_sc_mixed, {}), "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_not_allowed_not_in_list if {
+	inp := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_empty_parameters if {
+	inp := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_pod_localhost_allowed_wrong_file if {
+	inp := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_pod_localhost_allowed_no_specified_file if {
+	inp := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc_localhost_no_file}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_containers_mixed if {
+	inp := {"review": get_object({}, {}, multiple_containers_sc_mixed, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_containers_mixed_missing if {
+	inp := {"review": get_object({}, {}, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_container_not_allowed_not_in_list if {
+	inp := {"review": get_object({}, {}, single_container_sc, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_containers_not_allowed_not_in_list if {
+	inp := {"review": get_object({}, {}, multiple_containers_sc, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_seccomp_not_allowed_multiple_not_configured if {
+	inp := {"review": get_object({}, {}, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+# securityContext based seccomp with pod
+
+test_input_seccomp_pod_multiple_allowed_all if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_localhost_allowed_both_wildcard_file if {
+	inp := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_localhost_wildcard_both}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_container if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_container_both_allowed if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_container_mixed_not_allowed_but_exempt if {
+	inp := {"review": get_object({}, context_runtimedefault, single_container, {}), "parameters": input_parameters_exempt}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_multiple_allowed_in_list if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_localhost_allowed_wildcard_file if {
+	inp := {"review": get_object({}, context_localhost, single_container, {}), "parameters": input_parameters_sc_localhost_wildcard_file}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_multiple_empty_parameters if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_seccomp_pod_multiple_not_allowed_not_in_list if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_seccomp_pod_container_not_allowed if {
+	inp := {"review": get_object({}, context_runtimedefault, multiple_containers_sc_missing, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_seccomp_pod_container_mixed_allowed if {
+	inp := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_pod_container_mixed_not_allowed if {
+	inp := {"review": get_object({}, context_localhost, multiple_containers_sc_missing, {}), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+# securityContext based seccomp with init containers
+test_input_seccomp_pod_initcontainer_both_allowed if {
+	inp := {"review": get_object({}, context_runtimedefault, {}, multiple_containers_sc_missing), "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seccomp_pod_initcontainer_mixed_allowed if {
+	inp := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameter_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seccomp_pod_initcontainer_mixed_not_allowed if {
+	inp := {"review": get_object({}, context_localhost, {}, multiple_containers_sc_missing), "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+# Localhost seccomp profile build
+
+test_translation_seccomp_allowed_context_localhost_wildcard_file if {
+	inp := {"parameters": input_parameters_localhost_wildcard_both}
+	output := allowed_profiles with input as inp
+	output == {{"type": "Localhost", "localHostProfile": "*"}}
+}
+
+test_translation_seccomp_allowed_context_localhost_no_file if {
+	inp := {"parameters": input_parameters_sc_localhost_no_file}
+	output := allowed_profiles with input as inp
+	output == {{"localHostProfile": "", "type": "Localhost"}}
+}
+
+test_translation_seccomp_allowed_context_localhost_with_file if {
+	inp := {"parameters": input_parameters_sc_localhost_with_file}
+	output := allowed_profiles with input as inp
+	output == {{"type": "Localhost", "localHostProfile": "profile.json"}}
+}
+
+test_translation_seccomp_allowed_context_mixed if {
+	inp := {"parameters": input_parameters_in_list}
+	output := allowed_profiles with input as inp
+	output == {{"type": "Localhost", "localHostProfile": "profile.json"}, {"type": "RuntimeDefault"}}
+}
+
+# Create Review Object
+get_object(annotations, podcontext, containers, initcontainers) := {"object": {
+	"metadata": {
+		"name": "nginx",
+		"annotations": annotations,
+	},
+	"spec": {
+		"containers": containers,
+		"initContainers": initcontainers,
+		"securityContext": podcontext,
+	},
+}}
+
+# Test Containers
+single_container := [{
+	"name": "nginx",
+	"image": "nginx",
+}]
+
+multiple_containers := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+	},
+]
+
+single_container_sc := [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": context_runtimedefault,
+}]
+
+single_container_sc_localhost := [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": context_localhost,
+}]
+
+multiple_containers_sc := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+]
+
+multiple_containers_sc_mixed := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"securityContext": context_localhost,
+	},
+]
+
+multiple_containers_sc_missing := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": context_runtimedefault,
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+	},
+]
+
+# Test securityContexts
+context_localhost := {"seccompProfile": {"type": "Localhost", "localhostProfile": "profile.json"}}
+
+context_runtimedefault := {"seccompProfile": {"type": "RuntimeDefault"}}
+
+# Test Parameters
+input_parameters_empty := {"allowedProfiles": []}
+
+input_parameters_wildcard := {"allowedProfiles": ["*"]}
+
+input_parameter_in_list := {"allowedProfiles": ["RuntimeDefault"]}
+
+input_parameters_in_list := {
+	"allowedProfiles": [
+		"RuntimeDefault",
+		"Localhost",
+	],
+	"allowedLocalhostFiles": ["profile.json"],
+}
+
+input_parameters_in_list_locahost_file := {
+	"allowedProfiles": ["Localhost"],
+	"allowedLocalhostFiles": ["profile.json"],
+}
+
+input_parameters_not_in_list := {"allowedProfiles": ["Unconfined"]}
+
+input_parameters_exempt := {
+	"exemptImages": ["nginx"],
+	"allowedProfiles": ["Unconfined"],
+}
+
+input_parameters_sc := {
+	"allowedProfiles": [
+		"RuntimeDefault",
+		"Localhost",
+		"Unconfined",
+	],
+	"allowedLocalhostFiles": [
+		"profile1.json",
+		"profile2.json",
+	],
+}
+
+input_parameters_sc_localhost_no_file := {"allowedProfiles": ["Localhost"]}
+
+input_parameters_localhost_wildcard_both := {"allowedProfiles": ["Localhost"], "allowedLocalhostFiles": ["*"]}
+
+input_parameters_sc_localhost_wildcard_file := {
+	"allowedProfiles": ["Localhost"],
+	"allowedLocalhostFiles": ["*"],
+}
+
+input_parameters_sc_localhost_with_file := {"allowedProfiles": ["Localhost"], "allowedLocalhostFiles": ["profile.json"]}

--- a/src/v1/pod-security-policy/selinux/constraint.tmpl
+++ b/src/v1/pod-security-policy/selinux/constraint.tmpl
@@ -1,0 +1,65 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspselinuxv2
+  annotations:
+    metadata.gatekeeper.sh/title: "SELinux V2"
+    metadata.gatekeeper.sh/version: 1.0.3
+    description: >-
+      Defines an allow-list of seLinuxOptions configurations for pod
+      containers. Corresponds to a PodSecurityPolicy requiring SELinux configs.
+      For more information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#selinux
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPSELinuxV2
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Defines an allow-list of seLinuxOptions configurations for pod
+            containers. Corresponds to a PodSecurityPolicy requiring SELinux configs.
+            For more information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#selinux
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            allowedSELinuxOptions:
+              type: array
+              description: "An allow-list of SELinux options configurations."
+              items:
+                type: object
+                description: "An allowed configuration of SELinux options for a pod container."
+                properties:
+                  level:
+                    type: string
+                    description: "An SELinux level."
+                  role:
+                    type: string
+                    description: "An SELinux role."
+                  type:
+                    type: string
+                    description: "An SELinux type."
+                  user:
+                    type: string
+                    description: "An SELinux user."
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/pod-security-policy/selinux/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/pod-security-policy/selinux/lib_exclude_update.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+        - |
+{{ file.Read "src/pod-security-policy/selinux/lib_exempt_container.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/selinux/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/selinux/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/selinux/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/selinux/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/selinux/src.rego
+++ b/src/v1/pod-security-policy/selinux/src.rego
@@ -1,0 +1,47 @@
+package k8spspselinux
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+import data.lib.exempt_container.is_exempt
+
+# Disallow top level custom SELinux options
+violation contains {"msg": msg, "details": {}} if {
+	# spec.securityContext.seLinuxOptions field is immutable.
+	not is_update(input.review)
+	not input_se_linux_options_allowed(input.review.object.spec.securityContext.seLinuxOptions)
+
+	msg := sprintf("SELinux options is not allowed, pod: %v. Allowed options: %v", [
+		input.review.object.metadata.name,
+		input.parameters.allowedSELinuxOptions,
+	])
+}
+
+# Disallow container level custom SELinux options
+violation contains {"msg": msg, "details": {}} if {
+	# spec.containers.securityContext.seLinuxOptions field is immutable.
+	not is_update(input.review)
+
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+
+	not is_exempt(container)
+	not input_se_linux_options_allowed(container.securityContext.seLinuxOptions)
+
+	msg := sprintf("SELinux options is not allowed, pod: %v, container: %v. Allowed options: %v", [
+		input.review.object.metadata.name,
+		container.name, input.parameters.allowedSELinuxOptions,
+	])
+}
+
+input_se_linux_options_allowed(options) if {
+	some params in input.parameters.allowedSELinuxOptions
+	field_allowed("level", options, params)
+	field_allowed("role", options, params)
+	field_allowed("type", options, params)
+	field_allowed("user", options, params)
+}
+
+field_allowed(field, options, params) if params[field] == options[field]
+
+field_allowed(field, options, _) if not field in object.keys(options)

--- a/src/v1/pod-security-policy/selinux/src_test.rego
+++ b/src/v1/pod-security-policy/selinux/src_test.rego
@@ -1,0 +1,272 @@
+package k8spspselinux
+
+import rego.v1
+
+test_input_seLinux_options_allowed_in_list if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seLinux_options_allowed_in_list_subset if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list_subset}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_options_allowed_in_list_split_list if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list_split_two}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_option_not_allowed_not_in_list if {
+	inp := {"review": input_review, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_options_empty if {
+	inp := {"review": input_review, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_option_two_empty if {
+	inp := {"review": input_review_two, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_options_no_security_context if {
+	inp := {"review": input_review_no_security_context, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seLinux_options_two_allowed_in_list if {
+	inp := {"review": input_review_two, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seLinux_options_two_subset_allowed_in_list if {
+	inp := {"review": input_review_two_subset, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seLinux_options_subset_allowed_in_list_subset if {
+	inp := {"review": input_review_two_subset, "parameters": input_parameters_in_list_subset}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seLinux_options_subset_allowed_in_list_split_subset if {
+	inp := {"review": input_review_two_subset, "parameters": input_parameters_in_list_split_subset}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seLinux_options_allowed_in_list_split_subset if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list_split_subset}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_options_two_subset_not_allowed_not_in_list if {
+	inp := {"review": input_review_two_subset, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_option_two_not_allowed_not_in_list if {
+	inp := {"review": input_review_two, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_options_many_allowed_in_list if {
+	inp := {"review": input_review_many, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seLinux_options_many_not_allowed_not_in_list if {
+	inp := {"review": input_review_many, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_options_many_not_allowed_not_in_list_but_exempt if {
+	inp := {"review": input_review_many, "parameters": input_parameters_exempt}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seLinux_options_many_not_allowed_not_in_list_two if {
+	inp := {"review": input_review_many, "parameters": input_parameters_not_in_list_two}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_option_two_allowed_in_list_subset if {
+	inp := {"review": input_review_two, "parameters": input_parameters_in_list_subset}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_option_two_not_allowed_not_in_list_subset if {
+	inp := {"review": input_review_two, "parameters": input_parameters_not_in_list_two}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_seLinux_options_many_allowed_in_list_double_seccontext if {
+	inp := {"review": input_review_many_double_seccontext, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_seLinux_options_many_not_allowed_not_in_list_double_seccontext if {
+	inp := {"review": input_review_many_double_seccontext, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_input_seLinux_options_update if {
+	inp := {"review": object.union(input_review, {"operation": "UPDATE"}), "parameters": input_parameters_in_list_subset}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_one},
+}}
+
+input_review_two := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"securityContext": input_seLinuxOptions},
+}}
+
+input_review_two_subset := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"securityContext": input_seLinuxOptions_subset},
+}}
+
+input_review_no_security_context := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {},
+}}
+
+input_review_many := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_many},
+}}
+
+input_review_many_double_seccontext := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"securityContext": input_seLinuxOptions,
+		"containers": input_containers_many,
+		"initContainers": input_containers_one,
+	},
+}}
+
+input_containers_one := [{
+	"name": "nginx",
+	"image": "nginx",
+	"securityContext": input_seLinuxOptions,
+}]
+
+input_containers_many := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"securityContext": {"privileged": true},
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+	},
+	{
+		"name": "nginx3",
+		"image": "nginx",
+		"securityContext": input_seLinuxOptions,
+	},
+]
+
+input_seLinuxOptions := {"seLinuxOptions": {
+	"level": "s0:c123,c456",
+	"role": "object_r",
+	"type": "svirt_sandbox_file_t",
+	"user": "system_u",
+}}
+
+input_seLinuxOptions_subset := {"seLinuxOptions": {
+	"level": "s0:c123,c456",
+	"role": "object_r",
+}}
+
+input_parameters_in_list := {"allowedSELinuxOptions": [{
+	"level": "s0:c123,c456",
+	"role": "object_r",
+	"type": "svirt_sandbox_file_t",
+	"user": "system_u",
+}]}
+
+input_parameters_in_list_split_two := {"allowedSELinuxOptions": [
+	{
+		"level": "s0:c123,c456",
+		"role": "object_r",
+		"type": "svirt_sandbox_file_f",
+		"user": "system_v",
+	},
+	{
+		"level": "s1:c234,c567",
+		"role": "object_f",
+		"type": "svirt_sandbox_file_t",
+		"user": "system_u",
+	},
+]}
+
+input_parameters_in_list_split_subset := {"allowedSELinuxOptions": [
+	{
+		"level": "s0:c123,c456",
+		"role": "object_r",
+	},
+	{
+		"type": "svirt_sandbox_file_t",
+		"user": "system_u",
+	},
+]}
+
+input_parameters_in_list_subset := {"allowedSELinuxOptions": [{
+	"level": "s0:c123,c456",
+	"role": "object_r",
+}]}
+
+input_parameters_not_in_list := {"allowedSELinuxOptions": [{
+	"level": "s1:c234,c567",
+	"role": "sysadm_r",
+	"type": "svirt_lxc_net_t",
+	"user": "sysadm_u",
+}]}
+
+input_parameters_exempt := {
+	"exemptImages": ["nginx"],
+	"allowedSELinuxOptions": [{
+		"level": "s1:c234,c567",
+		"role": "sysadm_r",
+		"type": "svirt_lxc_net_t",
+		"user": "sysadm_u",
+	}],
+}
+
+input_parameters_not_in_list_two := {"allowedSELinuxOptions": [
+	{"level": "s1:c234,c567"},
+	{"level": "s2:c345,c678"},
+]}
+
+input_parameters_empty := {"allowedSELinuxOptions": []}

--- a/src/v1/pod-security-policy/users/constraint.tmpl
+++ b/src/v1/pod-security-policy/users/constraint.tmpl
@@ -1,0 +1,141 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspallowedusers
+  annotations:
+    metadata.gatekeeper.sh/title: "Allowed Users"
+    metadata.gatekeeper.sh/version: 1.0.2
+    description: >-
+      Controls the user and group IDs of the container and some volumes.
+      Corresponds to the `runAsUser`, `runAsGroup`, `supplementalGroups`, and
+      `fsGroup` fields in a PodSecurityPolicy. For more information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPAllowedUsers
+      validation:
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Controls the user and group IDs of the container and some volumes.
+            Corresponds to the `runAsUser`, `runAsGroup`, `supplementalGroups`, and
+            `fsGroup` fields in a PodSecurityPolicy. For more information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            runAsUser:
+              type: object
+              description: "Controls which user ID values are allowed in a Pod or container-level SecurityContext."
+              properties:
+                rule:
+                  type: string
+                  description: "A strategy for applying the runAsUser restriction."
+                  enum:
+                    - MustRunAs
+                    - MustRunAsNonRoot
+                    - RunAsAny
+                ranges:
+                  type: array
+                  description: "A list of user ID ranges affected by the rule."
+                  items:
+                    type: object
+                    description: "The range of user IDs affected by the rule."
+                    properties:
+                      min:
+                        type: integer
+                        description: "The minimum user ID in the range, inclusive."
+                      max:
+                        type: integer
+                        description: "The maximum user ID in the range, inclusive."
+            runAsGroup:
+              type: object
+              description: "Controls which group ID values are allowed in a Pod or container-level SecurityContext."
+              properties:
+                rule:
+                  type: string
+                  description: "A strategy for applying the runAsGroup restriction."
+                  enum:
+                    - MustRunAs
+                    - MayRunAs
+                    - RunAsAny
+                ranges:
+                  type: array
+                  description: "A list of group ID ranges affected by the rule."
+                  items:
+                    type: object
+                    description: "The range of group IDs affected by the rule."
+                    properties:
+                      min:
+                        type: integer
+                        description: "The minimum group ID in the range, inclusive."
+                      max:
+                        type: integer
+                        description: "The maximum group ID in the range, inclusive."
+            supplementalGroups:
+              type: object
+              description: "Controls the supplementalGroups values that are allowed in a Pod or container-level SecurityContext."
+              properties:
+                rule:
+                  type: string
+                  description: "A strategy for applying the supplementalGroups restriction."
+                  enum:
+                    - MustRunAs
+                    - MayRunAs
+                    - RunAsAny
+                ranges:
+                  type: array
+                  description: "A list of group ID ranges affected by the rule."
+                  items:
+                    type: object
+                    description: "The range of group IDs affected by the rule."
+                    properties:
+                      min:
+                        type: integer
+                        description: "The minimum group ID in the range, inclusive."
+                      max:
+                        type: integer
+                        description: "The maximum group ID in the range, inclusive."
+            fsGroup:
+              type: object
+              description: "Controls the fsGroup values that are allowed in a Pod or container-level SecurityContext."
+              properties:
+                rule:
+                  type: string
+                  description: "A strategy for applying the fsGroup restriction."
+                  enum:
+                    - MustRunAs
+                    - MayRunAs
+                    - RunAsAny
+                ranges:
+                  type: array
+                  description: "A list of group ID ranges affected by the rule."
+                  items:
+                    type: object
+                    description: "The range of group IDs affected by the rule."
+                    properties:
+                      min:
+                        type: integer
+                        description: "The minimum group ID in the range, inclusive."
+                      max:
+                        type: integer
+                        description: "The maximum group ID in the range, inclusive."
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/pod-security-policy/users/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/pod-security-policy/users/lib_exclude_update.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+        - |
+{{ file.Read "src/pod-security-policy/users/lib_exempt_container.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/users/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/users/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/users/lib_exempt_container.rego
+++ b/src/v1/pod-security-policy/users/lib_exempt_container.rego
@@ -1,0 +1,20 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
+	some exemption in exempt_images
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/pod-security-policy/users/src.rego
+++ b/src/v1/pod-security-policy/users/src.rego
@@ -1,0 +1,109 @@
+package k8spspallowedusers
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+import data.lib.exempt_container.is_exempt
+
+violation contains {"msg": msg} if {
+	# runAsUser, runAsGroup, supplementalGroups, fsGroup fields are immutable.
+	not is_update(input.review)
+
+	some type in ["containers", "initContainers", "ephemeralContainers"]
+	some container in input.review.object.spec[type]
+	not is_exempt(container)
+
+	some field in ["runAsUser", "runAsGroup", "supplementalGroups", "fsGroup"]
+
+	msg := get_type_violation(field, container)
+}
+
+get_type_violation("runAsUser", container) := get_user_violation(input.parameters.runAsUser, container)
+
+get_type_violation(field, container) := get_violation(field, input.parameters[field], container) if field != "runAsUser"
+
+# RunAsUser (separate due to "MustRunAsNonRoot")
+get_user_violation(params, container) := msg if {
+	provided_user := field_value("runAsUser", container, input.review)
+	not accept_users(params.rule, provided_user)
+	msg := sprintf(
+		"Container %v is attempting to run as disallowed user %v. Allowed runAsUser: %v",
+		[container.name, provided_user, params],
+	)
+}
+
+get_user_violation(params, container) := msg if {
+	not field_value("runAsUser", container, input.review)
+	params.rule = "MustRunAs"
+	msg := sprintf("Container %v is attempting to run without a required securityContext/runAsUser", [container.name])
+}
+
+get_user_violation(params, container) := msg if {
+	params.rule = "MustRunAsNonRoot"
+	not field_value("runAsUser", container, input.review)
+	not field_value("runAsNonRoot", container, input.review)
+	msg := sprintf(
+		"Container %v is attempting to run without a required securityContext/runAsNonRoot or securityContext/runAsUser != 0",
+		[container.name],
+	)
+}
+
+accept_users("RunAsAny", _)
+
+accept_users("MustRunAsNonRoot", provided_user) if provided_user != 0
+
+accept_users("MustRunAs", provided_user) if is_in_range(provided_user, input.parameters.runAsUser.ranges)
+
+# Group Options
+get_violation(field, params, container) := msg if {
+	provided_value := field_value(field, container, input.review)
+	not is_array(provided_value)
+	not accept_value(params.rule, provided_value, params.ranges)
+	msg := sprintf(
+		"Container %v is attempting to run as disallowed group %v. Allowed %v: %v",
+		[container.name, provided_value, field, params],
+	)
+}
+
+# SupplementalGroups is array value
+get_violation(field, params, container) := msg if {
+	array_value := field_value(field, container, input.review)
+	is_array(array_value)
+	some provided_value in array_value
+	not accept_value(params.rule, provided_value, params.ranges)
+	msg := sprintf(
+		"Container %v is attempting to run with disallowed supplementalGroups %v. Allowed %v: %v",
+		[container.name, array_value, field, params],
+	)
+}
+
+get_violation(field, params, container) := msg if {
+	not field_value(field, container, input.review)
+	params.rule == "MustRunAs"
+	msg := sprintf(
+		"Container %v is attempting to run without a required securityContext/%v. Allowed %v: %v",
+		[container.name, field, field, params],
+	)
+}
+
+accept_value("RunAsAny", _, _)
+
+accept_value("MayRunAs", provided_value, ranges) := is_in_range(provided_value, ranges)
+
+accept_value("MustRunAs", provided_value, ranges) := is_in_range(provided_value, ranges)
+
+# If container level is provided, that takes precedence
+field_value(field, container, _) := seccontext_field(field, container)
+
+# If no container level exists, use pod level
+field_value(field, container, review) := seccontext_field(field, review.object.spec) if {
+	not has_seccontext_field(field, container)
+	review.kind.kind == "Pod"
+}
+
+# Helper Functions
+is_in_range(val, ranges) if count({1 | val >= ranges[j].min; val <= ranges[j].max}) > 0
+
+has_seccontext_field(field, obj) if field in object.keys(obj.securityContext)
+
+seccontext_field(field, obj) := obj.securityContext[field]

--- a/src/v1/pod-security-policy/users/src_test.rego
+++ b/src/v1/pod-security-policy/users/src_test.rego
@@ -1,0 +1,1032 @@
+package k8spspallowedusers
+
+import rego.v1
+
+## Test Functionality ##
+# All the following functions will omit a field if the argument is null
+
+## Input Functions ##
+# "review":
+#   review(<pod-level-security-context>, <pod-containers>, <pod-init-containers>)
+#     - Returns an pod review object with "spec" = { "securityContext": <pod-level-security-context>, "containers": <pod-containers>, "initContainers": <pod-init-containers> }
+#     - omits any field where the value is null
+#   ctr(<container-name>, <container-security-context>)
+#     - Returns a container object containing { "name": <container-name>, "securityContext": <container-security-context> }
+#     - omits "securityContext" object if argument is null
+
+# "parameters":
+#   rule(<rule-name>, <rule-ranges>)
+#     - Returns a rule object with { "rule": <rule-name>, "ranges": <rule-ranges> }
+#     - omits "ranges" field if <rule-ranges> is null
+#   range(<min-val>, <max-val>)
+#     - Returns a range object with  { "min": <min-val>, "max": <max-val> }
+# Wrap rule in runAsUser, or
+
+## Other Functions ##
+# run_as_rule("runAsUser" value, "runAsGroup" value, "supplementalGroups" value, "fsGroup" value)
+#   - Returns {"runAsUser": value, "runAsGroup": value, "supplementalGroups": value, "fsGroup": value }
+#   - omits any field where value is null
+# runAsUser(value)
+#   - Returns { "runAsUser": value} if value is not null, else returns {}
+# runAsGroup(value)
+#   - Returns { "runAsGroup": value} if value is not null, else returns {}
+# supplementalGroups(value)
+#   - Returns { "supplementalGroups": value} if value is not null, else returns {}
+# fsGroup(value)
+#   - Returns { "fsGroup": value} if value is not null, else returns {}
+
+## Rego Playground for generating object: https://play.openpolicyagent.org/p/s64GOBr0Dq
+
+## RunAsUser ##
+test_user_one_container_run_as_rule_any if {
+	inp := {"review": review(null, [ctr("cont1", runAsUser(12))], null), "parameters": user_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_run_as_rule_any_root_user if {
+	inp := {"review": review(null, [ctr("cont1", runAsUser(0))], null), "parameters": user_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_run_as_rule_non_root_user_is_not_root if {
+	inp := {"review": review(null, [ctr("cont1", runAsUser(1))], null), "parameters": user_mustrunasnonroot}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_run_as_rule_non_root_user_is_root if {
+	inp := {"review": review(null, [ctr("cont1", runAsUser(0))], null), "parameters": user_mustrunasnonroot}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_run_as_rule_non_root_seccont_runasnonroot_user_is_not_defined if {
+	inp := {"review": review(null, [ctr("cont1", runAsNonRoot(true))], null), "parameters": user_mustrunasnonroot}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_run_as_rule_non_root_seccont_runasnonroot_user_is_root if {
+	inp := {"review": review(null, [ctr("cont1", object.union(runAsNonRoot(true), runAsUser(0)))], null), "parameters": user_mustrunasnonroot}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_run_as_rule_non_root_seccont_runasnonroot_user_is_not_root if {
+	inp := {"review": review(null, [ctr("cont1", object.union(runAsNonRoot(true), runAsUser(10)))], null), "parameters": user_mustrunasnonroot}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_run_as_rule_non_root_seccont_runasnonroot_is_false_user_is_not_defined if {
+	inp := {"review": review(null, [ctr("cont1", runAsNonRoot(false))], null), "parameters": user_mustrunasnonroot}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_run_as_rule_non_root_seccont_runasnonroot_is_false_user_is_not_root if {
+	inp := {"review": review(null, [ctr("cont1", object.union(runAsNonRoot(false), runAsUser(10)))], null), "parameters": user_mustrunasnonroot}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_run_in_range_user_in_range if {
+	inp := {"review": review(null, [ctr("cont1", runAsUser(150))], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_run_in_range_user_out_of_range if {
+	inp := {"review": review(null, [ctr("cont1", runAsUser(10))], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_run_in_range_user_lower_edge_of_range if {
+	inp := {"review": review(null, [ctr("cont1", runAsUser(100))], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_run_in_range_user_upper_edge_of_range if {
+	inp := {"review": review(null, [ctr("cont1", runAsUser(200))], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_run_in_range_seccont_runasnonroot if {
+	inp := {"review": review(null, [ctr("cont1", runAsNonRoot(true))], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_run_in_range_user_between_ranges if {
+	inp := {"review": review(null, [ctr("cont1", runAsUser(200))], null), "parameters": user_mustrunas_two_ranges}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_run_in_range_user_between_ranges_but_exempt if {
+	inp := {"review": review(null, [ctr("cont1", runAsUser(200))], null), "parameters": object.union(user_mustrunas_two_ranges, {"exemptImages": ["nginx"]})}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_non_root_container_pod_conflict if {
+	inp := {"review": review({"runAsNonRoot": true}, [ctr("cont1", runAsNonRoot(false))], null), "parameters": user_mustrunasnonroot}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_two_containers_run_as_rule_any if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(1)), ctr("cont2", runAsUser(100))], null),
+		"parameters": user_runasany,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_two_containers_run_as_rule_non_root_users_are_not_root if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(1)), ctr("cont2", runAsUser(100))], null),
+		"parameters": user_mustrunasnonroot,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_two_containers_run_as_rule_non_root_one_is_root if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(1)), ctr("cont2", runAsUser(0))], null),
+		"parameters": user_mustrunasnonroot,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_two_containers_run_as_rule_non_root_one_seccont_runasnonroot if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(1)), ctr("cont2", runAsNonRoot(true))], null),
+		"parameters": user_mustrunasnonroot,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_two_containers_run_as_rule_non_root_one_root_other_has_seccont_runasnonroot if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(0)), ctr("cont2", runAsNonRoot(true))], null),
+		"parameters": user_mustrunasnonroot,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_two_containers_run_in_range_both_in_range if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(150)), ctr("cont2", runAsUser(103))], null),
+		"parameters": user_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_two_containers_run_in_range_one_in_range if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(150)), ctr("cont2", runAsUser(13))], null),
+		"parameters": user_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_two_containers_run_in_range_neither_in_range_two_ranges if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(150)), ctr("cont2", runAsUser(130))], null),
+		"parameters": user_mustrunas_two_ranges,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_user_one_container_one_initcontainer_run_in_range_user_in_range if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(150))], [ctr("init1", runAsUser(150))]),
+		"parameters": user_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_one_initcontainer_run_in_range_user_not_in_range if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(150))], [ctr("init1", runAsUser(250))]),
+		"parameters": user_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_empty_security_context if {
+	inp := {"review": review(null, [ctr("cont1", {})], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_no_security_context if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_no_security_context_RunAsAny if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": user_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_empty_security_context_empty_pod_security_context if {
+	inp := {"review": review({}, [ctr("cont1", {})], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_no_security_context_no_pod_security_context if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_pod_defined_null_container_run_in_range_user_in_range if {
+	inp := {"review": review(runAsUser(150), [ctr("cont1", null)], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_pod_defined_run_in_range_user_in_range if {
+	inp := {"review": review(runAsUser(150), [ctr("cont1", {})], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_pod_defined_run_in_range_user_not_in_range if {
+	inp := {"review": review(runAsUser(250), [ctr("cont1", {})], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_one_container_pod_defined_run_in_range_container_overrides_user_in_range if {
+	inp := {"review": review(runAsUser(250), [ctr("cont1", runAsUser(150))], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_one_container_pod_defined_run_in_range_container_overrides_user_not_in_range if {
+	inp := {"review": review(runAsUser(150), [ctr("cont1", runAsUser(250))], null), "parameters": user_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_user_input_container_run_as_rule_any_ignore_ranges if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(10))], null),
+		"parameters": runAsUser(rule("RunAsAny", [range(100, 200)])),
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_input_container_run_as_rule_non_root_ignore_ranges if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsUser(10))], null),
+		"parameters": runAsUser(rule("MustRunAsNonRoot", [range(100, 200)])),
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_user_input_container_run_as_rule_non_root_seccont_runasnonroot_ignore_ranges if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsNonRoot(true))], null),
+		"parameters": runAsUser(rule("MustRunAsNonRoot", [range(100, 200)])),
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+## runAsGroup ##
+test_group_one_container_run_as_rule_any if {
+	inp := {"review": review(null, [ctr("cont1", runAsGroup(12))], null), "parameters": group_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_run_as_rule_any_root_user if {
+	inp := {"review": review(null, [ctr("cont1", runAsGroup(0))], null), "parameters": group_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_run_in_range_user_in_range if {
+	inp := {"review": review(null, [ctr("cont1", runAsGroup(150))], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_run_in_range_user_out_of_range if {
+	inp := {"review": review(null, [ctr("cont1", runAsGroup(10))], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_one_container_run_in_range_user_lower_edge_of_range if {
+	inp := {"review": review(null, [ctr("cont1", runAsGroup(100))], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_run_in_range_user_upper_edge_of_range if {
+	inp := {"review": review(null, [ctr("cont1", runAsGroup(200))], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_run_in_range_user_between_ranges if {
+	inp := {"review": review(null, [ctr("cont1", runAsGroup(200))], null), "parameters": group_mustrunas_two_ranges}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_two_containers_run_as_rule_any if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsGroup(1)), ctr("cont2", runAsGroup(100))], null),
+		"parameters": group_runasany,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_two_containers_run_in_range_both_in_range if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsGroup(150)), ctr("cont2", runAsGroup(103))], null),
+		"parameters": group_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_two_containers_run_in_range_one_in_range if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsGroup(150)), ctr("cont2", runAsGroup(13))], null),
+		"parameters": group_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_two_containers_run_in_range_neither_in_range_two_ranges if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsGroup(150)), ctr("cont2", runAsGroup(130))], null),
+		"parameters": group_mustrunas_two_ranges,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_group_one_container_one_initcontainer_run_in_range_user_in_range if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsGroup(150))], [ctr("init1", runAsGroup(150))]),
+		"parameters": group_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_one_initcontainer_run_in_range_user_not_in_range if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsGroup(150))], [ctr("init1", runAsGroup(250))]),
+		"parameters": group_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_one_container_empty_security_context if {
+	inp := {"review": review(null, [ctr("cont1", {})], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_one_container_no_security_context if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_one_container_no_security_context_RunAsAny if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": group_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_empty_security_context_empty_pod_security_context if {
+	inp := {"review": review({}, [ctr("cont1", {})], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_one_container_no_security_context_no_pod_security_context if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_one_container_pod_defined_null_container_run_in_range_user_in_range if {
+	inp := {"review": review(runAsGroup(150), [ctr("cont1", null)], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_pod_defined_run_in_range_user_in_range if {
+	inp := {"review": review(runAsGroup(150), [ctr("cont1", {})], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_pod_defined_run_in_range_user_not_in_range if {
+	inp := {"review": review(runAsGroup(250), [ctr("cont1", {})], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_one_container_pod_defined_run_in_range_container_overrides_user_in_range if {
+	inp := {"review": review(runAsGroup(250), [ctr("cont1", runAsGroup(150))], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_pod_defined_run_in_range_container_overrides_user_not_in_range if {
+	inp := {"review": review(runAsGroup(150), [ctr("cont1", runAsGroup(250))], null), "parameters": group_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_input_container_run_as_rule_any_ignore_ranges if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsGroup(10))], null),
+		"parameters": runAsGroup(rule("RunAsAny", [range(100, 200)])),
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_empty_security_context_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", {})], null), "parameters": group_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_no_security_context_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": group_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_run_in_range_user_in_range_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", runAsGroup(150))], null), "parameters": group_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_run_in_range_user_out_of_range_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", runAsGroup(10))], null), "parameters": group_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_one_container_run_in_range_user_between_ranges_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", runAsGroup(200))], null), "parameters": group_mayrunas_two_ranges}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_group_two_containers_run_in_range_neither_in_range_two_ranges_mayrun if {
+	inp := {
+		"review": review(null, [ctr("cont1", runAsGroup(150)), ctr("cont2", runAsGroup(130))], null),
+		"parameters": group_mayrunas_two_ranges,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_group_one_container_pod_defined_run_in_range_container_overrides_user_in_range_mayrun if {
+	inp := {"review": review(runAsGroup(250), [ctr("cont1", runAsGroup(150))], null), "parameters": group_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_group_one_container_pod_defined_run_in_range_container_overrides_user_not_in_range_mayrun if {
+	inp := {"review": review(runAsGroup(150), [ctr("cont1", runAsGroup(250))], null), "parameters": group_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+## supplementalGroups ##
+test_supplemental_two_containers_run_as_rule_any if {
+	inp := {
+		"review": review(supplementalGroups([15]), [ctr("cont1", null), ctr("cont2", null)], null),
+		"parameters": supplemental_runasany,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_two_containers_run_in_range_both_in_range if {
+	inp := {
+		"review": review(supplementalGroups([150]), [ctr("cont1", null), ctr("cont2", null)], null),
+		"parameters": supplemental_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_two_containers_run_in_range_neither_in_range_two_ranges if {
+	inp := {
+		"review": review(supplementalGroups([150]), [ctr("cont1", null), ctr("cont2", null)], null),
+		"parameters": supplemental_mustrunas_two_ranges,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_supplemental_one_container_one_initcontainer_run_in_range_user_in_range if {
+	inp := {
+		"review": review(supplementalGroups([150]), [ctr("cont1", null)], [ctr("init1", null)]),
+		"parameters": supplemental_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_one_container_one_initcontainer_run_in_range_user_not_in_range if {
+	inp := {
+		"review": review(supplementalGroups([250]), [ctr("cont1", null)], [ctr("init1", null)]),
+		"parameters": supplemental_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_supplemental_one_container_empty_security_context if {
+	inp := {"review": review(null, [ctr("cont1", {})], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_supplemental_one_container_no_security_context if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_supplemental_one_container_no_security_context_RunAsAny if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": supplemental_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_one_container_empty_security_context_empty_pod_security_context if {
+	inp := {"review": review({}, [ctr("cont1", {})], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_supplemental_one_container_no_security_context_no_pod_security_context if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_supplemental_one_container_pod_defined_null_container_run_in_range_user_in_range if {
+	inp := {"review": review(supplementalGroups([150]), [ctr("cont1", null)], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_one_container_pod_defined_run_in_range_user_in_range if {
+	inp := {"review": review(supplementalGroups([150]), [ctr("cont1", {})], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_one_container_pod_defined_run_in_range_user_not_in_range if {
+	inp := {"review": review(supplementalGroups([250]), [ctr("cont1", {})], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_supplemental_one_container_pod_defined_run_in_range_container_overrides_user_in_range if {
+	inp := {"review": review(supplementalGroups([250]), [ctr("cont1", supplementalGroups(150))], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_one_container_pod_defined_run_in_range_container_overrides_user_not_in_range if {
+	inp := {"review": review(supplementalGroups([150]), [ctr("cont1", supplementalGroups(250))], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_supplemental_one_container_empty_security_context_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", {})], null), "parameters": supplemental_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_one_container_no_security_context_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": supplemental_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_two_containers_run_in_range_neither_in_range_mayrun if {
+	inp := {
+		"review": review(supplementalGroups([230]), [ctr("cont1", null), ctr("cont2", null)], null),
+		"parameters": supplemental_mayrunas_two_ranges,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_supplemental_two_containers_run_in_range_both_in_range_mayrun if {
+	inp := {
+		"review": review(supplementalGroups([100]), [ctr("cont1", null), ctr("cont2", null)], null),
+		"parameters": supplemental_mayrunas_two_ranges,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_one_container_run_in_range_two_ranges_both_in_range if {
+	inp := {"review": review(supplementalGroups([120, 180]), [ctr("cont1", null)], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_one_container_run_in_range_two_ranges_none_in_range if {
+	inp := {"review": review(supplementalGroups([120, 180]), [ctr("cont1", null)], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_supplemental_one_container_run_in_range_two_ranges_one_in_range if {
+	inp := {"review": review(supplementalGroups([150, 250]), [ctr("cont1", null)], null), "parameters": supplemental_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+## fsGroup ##
+test_fsgroup_two_containers_run_as_rule_any if {
+	inp := {
+		"review": review(fsGroup(15), [ctr("cont1", null), ctr("cont2", null)], null),
+		"parameters": fsgroup_runasany,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_fsgroup_two_containers_run_in_range_both_in_range if {
+	inp := {
+		"review": review(fsGroup(150), [ctr("cont1", null), ctr("cont2", null)], null),
+		"parameters": fsgroup_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_fsgroup_two_containers_run_in_range_neither_in_range_two_ranges if {
+	inp := {
+		"review": review(fsGroup(150), [ctr("cont1", null), ctr("cont2", null)], null),
+		"parameters": fsgroup_mustrunas_two_ranges,
+	}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_fsgroup_one_container_one_initcontainer_run_in_range_user_in_range if {
+	inp := {
+		"review": review(fsGroup(150), [ctr("cont1", null)], [ctr("init1", null)]),
+		"parameters": fsgroup_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_fsgroup_one_container_one_initcontainer_run_in_range_user_not_in_range if {
+	inp := {
+		"review": review(fsGroup(250), null, [ctr("init1", null)]),
+		"parameters": fsgroup_mustrunas_100_200,
+	}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_fsgroup_one_container_empty_security_context if {
+	inp := {"review": review(null, [ctr("cont1", {})], null), "parameters": fsgroup_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_fsgroup_one_container_no_security_context if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": fsgroup_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_fsgroup_one_container_no_security_context_RunAsAny if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": fsgroup_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_fsgroup_one_container_empty_security_context_empty_pod_security_context if {
+	inp := {"review": review({}, [ctr("cont1", {})], null), "parameters": fsgroup_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_fsgroup_one_container_no_security_context_no_pod_security_context if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": fsgroup_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_fsgroup_one_container_pod_defined_null_container_run_in_range_user_in_range if {
+	inp := {"review": review(fsGroup(150), [ctr("cont1", null)], null), "parameters": fsgroup_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_fsgroup_one_container_pod_defined_run_in_range_user_in_range if {
+	inp := {"review": review(fsGroup(150), [ctr("cont1", {})], null), "parameters": fsgroup_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_fsgroup_one_container_pod_defined_run_in_range_user_not_in_range if {
+	inp := {"review": review(fsGroup(250), [ctr("cont1", {})], null), "parameters": fsgroup_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_fsgroup_one_container_pod_defined_run_in_range_container_overrides_user_in_range if {
+	inp := {"review": review(fsGroup(250), [ctr("cont1", fsGroup(150))], null), "parameters": fsgroup_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_fsgroup_one_container_pod_defined_run_in_range_container_overrides_user_not_in_range if {
+	inp := {"review": review(fsGroup(150), [ctr("cont1", fsGroup(250))], null), "parameters": fsgroup_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_fsgroup_input_container_run_as_rule_any_ignore_ranges if {
+	inp := {
+		"review": review(null, [ctr("cont1", fsGroup(10))], null),
+		"parameters": fsGroup(rule("RunAsAny", [range(100, 200)])),
+	}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_fsgroup_one_container_empty_security_context_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", {})], null), "parameters": fsgroup_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_fsgroup_one_container_no_security_context_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", null)], null), "parameters": fsgroup_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+## Mixed Functionality ##
+test_mixed_runAsAny_all_non_root if {
+	inp := {"review": review(run_as_rule(12, 30, [50], 101), [ctr("cont1", null)], null), "parameters": mixed_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_mixed_runAsAny_all_root if {
+	inp := {"review": review(run_as_rule(0, 0, [0], 0), [ctr("cont1", null)], null), "parameters": mixed_runasany}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_mixed_pod_level_all_defined_all_in_range_mustrun if {
+	inp := {"review": review(run_as_rule(150, 150, [150], 150), [ctr("cont1", null)], null), "parameters": mixed_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_mixed_pod_level_all_defined_none_in_range_mustrun if {
+	inp := {"review": review(run_as_rule(250, 250, [250], 250), [ctr("cont1", null)], null), "parameters": mixed_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 4
+}
+
+test_mixed_pod_level_all_defined_mixed_in_range_mustrun if {
+	inp := {"review": review(run_as_rule(150, 150, [250], 250), [ctr("cont1", null)], null), "parameters": mixed_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_mixed_container_level_all_defined_all_in_range_mustrun if {
+	inp := {"review": review(null, [ctr("cont1", run_as_rule(150, 150, [150], 150))], null), "parameters": mixed_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_mixed_container_level_all_defined_none_in_range_mustrun if {
+	inp := {"review": review(null, [ctr("cont1", run_as_rule(250, 250, [250], 250))], null), "parameters": mixed_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 4
+}
+
+test_mixed_container_level_all_defined_mixed_in_range_mustrun if {
+	inp := {"review": review(null, [ctr("cont1", run_as_rule(150, 150, [250], 250))], null), "parameters": mixed_mustrunas_100_200}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_mixed_pod_level_all_defined_none_in_range_mayrun if {
+	inp := {"review": review(run_as_rule(250, 250, [250], 250), [ctr("cont1", null)], null), "parameters": mixed_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+test_mixed_pod_level_all_defined_mixed_in_range_mayrun if {
+	inp := {"review": review(run_as_rule(150, 150, [250], 250), [ctr("cont1", null)], null), "parameters": mixed_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_mixed_container_level_all_defined_all_in_range_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", run_as_rule(150, 150, null, null))], null), "parameters": mixed_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_mixed_container_level_all_defined_none_in_range_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", run_as_rule(250, 250, null, null))], null), "parameters": mixed_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_mixed_container_level_all_defined_mixed_in_range_mayrun if {
+	inp := {"review": review(null, [ctr("cont1", run_as_rule(150, 250, null, null))], null), "parameters": mixed_mayrunas_100_200}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_mixed_pod_level_all_defined_none_in_range_mixed_rules if {
+	inp := {"review": review(run_as_rule(0, 0, 250, 250), [ctr("cont1", null)], null), "parameters": mixed_all_rules}
+	results := violation with input as inp
+	count(results) == 3
+}
+
+# violation from  MustRunAs SupplementalGroups and MayRunAs FSGroup, range within 100&200
+test_mixed_pod_level_all_defined_mixed_in_range_mixed_rules if {
+	inp := {"review": review(run_as_rule(150, 150, 250, 250), [ctr("cont1", null)], null), "parameters": mixed_all_rules}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+# violation from no MustRunAs SupplementalGroups defined (can't define on container level)
+test_mixed_container_level_all_defined_all_in_range_mixed_rules if {
+	inp := {"review": review(null, [ctr("cont1", run_as_rule(150, 150, null, null))], null), "parameters": mixed_all_rules}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+# violation from MustRunAsNonRoot RunAsUser rule, and no MustRunAs SupplementalGroups defined (can't define on container level)
+test_mixed_container_level_all_defined_none_in_range_mixed_rules if {
+	inp := {"review": review(null, [ctr("cont1", run_as_rule(0, 0, null, null))], null), "parameters": mixed_all_rules}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+# violation from no MustRunAs SupplementalGroups defined (can't define on container level)
+test_mixed_container_level_all_defined_mixed_in_range_mixed_rules if {
+	inp := {"review": review(null, [ctr("cont1", run_as_rule(150, 150, null, null))], null), "parameters": mixed_all_rules}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_update if {
+	inp := {"review": object.union(review(null, [ctr("cont1", run_as_rule(150, 150, null, null))], null), {"operation": "UPDATE"}), "parameters": mixed_all_rules}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+## Functions ##
+review(context, containers, init_containers) := out if {
+	sec_obj := obj_if_exists("securityContext", context)
+	cont_obj := obj_if_exists("containers", containers)
+	init_obj := obj_if_exists("initContainers", init_containers)
+	out = {
+		"kind": {"kind": "Pod"},
+		"metadata": {"name": "test-pod"},
+		"object": {"spec": object.union(object.union(sec_obj, cont_obj), init_obj)},
+	}
+}
+
+ctr(name, context) := out if {
+	name_obj := {"name": name, "image": "nginx"}
+	sec := obj_if_exists("securityContext", context)
+	out = object.union(name_obj, sec)
+}
+
+runAsUser(user) := run_as_rule(user, null, null, null)
+
+runAsNonRoot(bool) := {"runAsNonRoot": bool}
+
+runAsGroup(group) := run_as_rule(null, group, null, null)
+
+supplementalGroups(supplemental) := run_as_rule(null, null, supplemental, null)
+
+fsGroup(fsgroup) := run_as_rule(null, null, null, fsgroup)
+
+run_as_rule(user, group, supplemental, fsgroup) := out if {
+	user_obj := obj_if_exists("runAsUser", user)
+	group_obj := obj_if_exists("runAsGroup", group)
+	supplemental_obj := obj_if_exists("supplementalGroups", supplemental)
+	fsgroup_obj := obj_if_exists("fsGroup", fsgroup)
+	out = object.union(object.union(user_obj, group_obj), object.union(supplemental_obj, fsgroup_obj))
+}
+
+obj_if_exists(key, val) := {key: val} if not is_null(val)
+
+obj_if_exists(_, val) := {} if is_null(val)
+
+# Parameters
+user_runasany := runAsUser(rule("RunAsAny", null))
+
+user_mustrunas_100_200 := runAsUser(rule("MustRunAs", [range(100, 200)]))
+
+user_mustrunas_two_ranges := runAsUser(rule("MustRunAs", [range(100, 100), range(250, 250)]))
+
+user_mustrunasnonroot := runAsUser(rule("MustRunAsNonRoot", null))
+
+group_runasany := runAsGroup(rule("RunAsAny", null))
+
+group_mustrunas_100_200 := runAsGroup(rule("MustRunAs", [range(100, 200)]))
+
+group_mustrunas_two_ranges := runAsGroup(rule("MustRunAs", [range(100, 100), range(250, 250)]))
+
+group_mayrunas_100_200 := runAsGroup(rule("MayRunAs", [range(100, 200)]))
+
+group_mayrunas_two_ranges := runAsGroup(rule("MayRunAs", [range(100, 100), range(250, 250)]))
+
+supplemental_runasany := supplementalGroups(rule("RunAsAny", null))
+
+supplemental_mustrunas_100_200 := supplementalGroups(rule("MustRunAs", [range(100, 200)]))
+
+supplemental_mustrunas_two_ranges := supplementalGroups(rule("MustRunAs", [range(100, 100), range(250, 250)]))
+
+supplemental_mayrunas_100_200 := supplementalGroups(rule("MayRunAs", [range(100, 200)]))
+
+supplemental_mayrunas_two_ranges := supplementalGroups(rule("MayRunAs", [range(100, 100), range(250, 250)]))
+
+fsgroup_runasany := fsGroup(rule("RunAsAny", null))
+
+fsgroup_mustrunas_100_200 := fsGroup(rule("MustRunAs", [range(100, 200)]))
+
+fsgroup_mustrunas_two_ranges := fsGroup(rule("MustRunAs", [range(100, 100), range(250, 250)]))
+
+fsgroup_mayrunas_100_200 := fsGroup(rule("MayRunAs", [range(100, 200)]))
+
+fsgroup_mayrunas_two_ranges := fsGroup(rule("MayRunAs", [range(100, 100), range(250, 250)]))
+
+mixed_runasany := run_as_rule(rule("RunAsAny", null), rule("RunAsAny", null), rule("RunAsAny", null), rule("RunAsAny", null))
+
+mixed_mustrunas_100_200 := run_as_rule(rule("MustRunAs", [range(100, 200)]), rule("MustRunAs", [range(100, 200)]), rule("MustRunAs", [range(100, 200)]), rule("MustRunAs", [range(100, 200)]))
+
+mixed_mayrunas_100_200 := run_as_rule(rule("MustRunAsNonRoot", null), rule("MayRunAs", [range(100, 200)]), rule("MayRunAs", [range(100, 200)]), rule("MayRunAs", [range(100, 200)]))
+
+mixed_all_rules := run_as_rule(rule("MustRunAsNonRoot", null), rule("RunAsAny", null), rule("MustRunAs", [range(100, 200)]), rule("MayRunAs", [range(100, 200)]))
+
+rule(rule, ranges) := out if {
+	ranges_obj = obj_if_exists("ranges", ranges)
+	out := object.union({"rule": rule}, ranges_obj)
+}
+
+range(from, to) := {
+	"min": from,
+	"max": to,
+}

--- a/src/v1/pod-security-policy/volumes/constraint.tmpl
+++ b/src/v1/pod-security-policy/volumes/constraint.tmpl
@@ -1,0 +1,39 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspvolumetypes
+  annotations:
+    metadata.gatekeeper.sh/title: "Volume Types"
+    metadata.gatekeeper.sh/version: 1.0.2
+    description: >-
+      Restricts mountable volume types to those specified by the user.
+      Corresponds to the `volumes` field in a PodSecurityPolicy. For more
+      information, see
+      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPVolumeTypes
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          description: >-
+            Restricts mountable volume types to those specified by the user.
+            Corresponds to the `volumes` field in a PodSecurityPolicy. For more
+            information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
+          properties:
+            volumes:
+              description: "`volumes` is an array of volume types. All volume types can be enabled using `*`."
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/pod-security-policy/volumes/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}
+      libs:
+        - |
+{{ file.Read "src/pod-security-policy/volumes/lib_exclude_update.rego" | strings.Indent 10 | strings.TrimSuffix "\n" }}

--- a/src/v1/pod-security-policy/volumes/lib_exclude_update.rego
+++ b/src/v1/pod-security-policy/volumes/lib_exclude_update.rego
@@ -1,0 +1,7 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if {
+	review.operation == "UPDATE"
+}

--- a/src/v1/pod-security-policy/volumes/src.rego
+++ b/src/v1/pod-security-policy/volumes/src.rego
@@ -1,0 +1,22 @@
+package k8spspvolumetypes
+
+import rego.v1
+
+import data.lib.exclude_update.is_update
+
+violation contains {"msg": msg, "details": {}} if {
+	# spec.volumes field is immutable.
+	not is_update(input.review)
+	some field in {x | input.review.object.spec.volumes[_][x]; x != "name"}
+	not input_volume_type_allowed(field)
+
+	msg := sprintf(
+		"The volume type %v is not allowed, pod: %v. Allowed volume types: %v",
+		[field, input.review.object.metadata.name, input.parameters.volumes],
+	)
+}
+
+# * may be used to allow all volume types
+input_volume_type_allowed(_) if "*" in input.parameters.volumes
+
+input_volume_type_allowed(field) if field in input.parameters.volumes

--- a/src/v1/pod-security-policy/volumes/src_test.rego
+++ b/src/v1/pod-security-policy/volumes/src_test.rego
@@ -1,0 +1,170 @@
+package k8spspvolumetypes
+
+import rego.v1
+
+test_input_volume_type_allowed_all if {
+	inp := {"review": input_review, "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_volume_type_allowed_all_many_volumes if {
+	inp := {"review": input_review_many, "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_volume_type_none_allowed if {
+	inp := {"review": input_review, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_volume_type_none_allowed_many_volumes if {
+	inp := {"review": input_review_many, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_volume_type_allowed_all_no_volumes if {
+	inp := {"review": input_review_no_volumes, "parameters": input_parameters_wildcard}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_volume_type_none_allowed_no_volumes if {
+	inp := {"review": input_review_no_volumes, "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_volume_type_allowed_in_list_no_volumes if {
+	inp := {"review": input_review_no_volumes, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_volume_type_allowed_in_list if {
+	inp := {"review": input_review, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_volume_type_allowed_not_in_list if {
+	inp := {"review": input_review, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_volume_type_allowed_in_list_many_volumes if {
+	inp := {"review": input_review_many, "parameters": input_parameters_in_list}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+test_input_volume_type_allowed_not_all_in_list_many_volumes if {
+	inp := {"review": input_review_many, "parameters": input_parameters_not_in_list}
+	results := violation with input as inp
+	count(results) == 2
+}
+
+test_input_volume_type_allowed_in_list_many_volumes_mixed if {
+	inp := {"review": input_review_many, "parameters": input_parameters_mixed}
+	results := violation with input as inp
+	count(results) == 1
+}
+
+test_input_volume_type_update if {
+	inp := {"review": object.union(input_review, {"operation": "UPDATE"}), "parameters": input_parameters_empty}
+	results := violation with input as inp
+	count(results) == 0
+}
+
+input_review := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers,
+		"volumes": input_volumes,
+	},
+}}
+
+input_review_many := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {
+		"containers": input_containers_many,
+		"volumes": input_volumes_many,
+	},
+}}
+
+input_review_no_volumes := {"object": {
+	"metadata": {"name": "nginx"},
+	"spec": {"containers": input_containers_no_volumes},
+}}
+
+input_containers := [{
+	"name": "nginx",
+	"image": "nginx",
+	"volumeMounts": [{
+		"mountPath": "/cache",
+		"name": "cache-volume",
+	}],
+}]
+
+input_containers_no_volumes := [{
+	"name": "nginx",
+	"image": "nginx",
+}]
+
+input_containers_many := [
+	{
+		"name": "nginx",
+		"image": "nginx",
+		"volumeMounts": [{
+			"mountPath": "/cache",
+			"name": "cache-volume",
+		}],
+	},
+	{
+		"name": "nginx2",
+		"image": "nginx",
+		"volumeMounts": [{
+			"mountPath": "/cache",
+			"name": "cache-volume2",
+		}],
+	},
+]
+
+input_volumes := [{
+	"name": "cache-volume",
+	"hostPath": {"path": "/tmp"},
+}]
+
+input_volumes_many := [
+	{
+		"name": "cache-volume",
+		"hostPath": {"path": "/tmp"},
+	},
+	{
+		"name": "cache-volume2",
+		"emptyDir": {},
+	},
+]
+
+input_parameters_empty := {"volumes": []}
+
+input_parameters_wildcard := {"volumes": ["*"]}
+
+input_parameters_in_list := {"volumes": [
+	"hostPath",
+	"emptyDir",
+]}
+
+input_parameters_mixed := {"volumes": [
+	"configMap",
+	"emptyDir",
+]}
+
+input_parameters_not_in_list := {"volumes": [
+	"configMap",
+	"secret",
+]}

--- a/src/v1/rego/lib_exclude_update/lib_exclude_update.rego
+++ b/src/v1/rego/lib_exclude_update/lib_exclude_update.rego
@@ -1,0 +1,5 @@
+package lib.exclude_update
+
+import rego.v1
+
+is_update(review) if review.operation == "UPDATE"

--- a/src/v1/rego/lib_exclude_update/lib_exclude_update_test.rego
+++ b/src/v1/rego/lib_exclude_update/lib_exclude_update_test.rego
@@ -1,0 +1,15 @@
+package lib.exclude_update
+
+import rego.v1
+
+test_update if {
+	is_update({"operation": "UPDATE"})
+}
+
+test_create if {
+	not is_update({"operation": "CREATE"})
+}
+
+test_empty if {
+	not is_update({"operation": ""})
+}

--- a/src/v1/rego/lib_exempt_container/lib_exempt_container.rego
+++ b/src/v1/rego/lib_exempt_container/lib_exempt_container.rego
@@ -1,0 +1,19 @@
+package lib.exempt_container
+
+import rego.v1
+
+is_exempt(container) if {
+	some exemption in input.parameters.exemptImages
+	_matches_exemption(container.image, exemption)
+}
+
+_matches_exemption(img, exemption) if {
+	not endswith(exemption, "*")
+	exemption == img
+}
+
+_matches_exemption(img, exemption) if {
+	endswith(exemption, "*")
+	prefix := trim_suffix(exemption, "*")
+	startswith(img, prefix)
+}

--- a/src/v1/rego/lib_exempt_container/lib_exempt_container_test.rego
+++ b/src/v1/rego/lib_exempt_container/lib_exempt_container_test.rego
@@ -1,0 +1,35 @@
+package lib.exempt_container
+
+import rego.v1
+
+test_exact_match_success if {
+	is_exempt({"image": "one-two"}) with input.parameters.exemptImages as ["one-two"]
+}
+
+test_exact_match_fail if {
+	not is_exempt({"image": "one-two-three"}) with input.parameters.exemptImages as ["one-two"]
+}
+
+test_prefix_success if {
+	is_exempt({"image": "one-two-three"}) with input.parameters.exemptImages as ["one-two-*"]
+}
+
+test_prefix_fail if {
+	not is_exempt({"image": "one-two-three"}) with input.parameters.exemptImages as ["four-two-*"]
+}
+
+test_one_match if {
+	is_exempt({"image": "one-two"}) with input.parameters.exemptImages as ["three-four", "one-two"]
+}
+
+test_empty_exemption if {
+	not is_exempt({"image": "one-two"}) with input.parameters.exemptImages as []
+}
+
+test_empty_image if {
+	not is_exempt({"image": ""}) with input.parameters.exemptImages as ["three-four", "one-two"]
+}
+
+test_no_image if {
+	not is_exempt({}) with input.parameters.exemptImages as ["three-four", "one-two"]
+}

--- a/test.sh
+++ b/test.sh
@@ -2,15 +2,27 @@
 
 set -eu
 
-# Ensure OPA strict mode compliance
-# https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode
-opa check --strict src
-
 for folder in src/*/*
 do
+  if [[ "${folder}" == src/v1* ]] ; then
+    continue
+  fi
+
+  # Ensure OPA strict mode compliance
+  # https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode
+  opa check --v0-compatible --strict ${folder}
+
   # TODO: enforce coverage
   # needs https://github.com/open-policy-agent/opa/issues/2562 to see what was not covered
   # needs https://github.com/open-policy-agent/opa/issues/2139 to see verbose output when using coverage
+  echo "opa test --v0-compatible ${folder}/*.rego"
+  opa test --v0-compatible ${folder}/*.rego
+done
+
+for folder in src/v1/*/*
+do
+  opa check --strict ${folder}
+
   echo "opa test ${folder}/*.rego"
   opa test ${folder}/*.rego
 done


### PR DESCRIPTION
This is rewrite of the entire Rego library for Rego v1 compliance, and the introduction of Regal to identify issues and enforce good coding standards.

To not be too disruptive, all policies were first copied to a `v1` directory under `src`, and no modifications to existing policies have been made. The Regal configuration is also set to ignore anything but the new v1 directory.

The result is about 1200 lines less Rego in the v1 directory compared to the previous versions.

There's still a bunch of practicalities to deal with here, I'm sure. Like how to integrate this in the project CI, publishing, and so on. The templates are currently just copied from the "old" directories, but should probably not follow the same versioning, and might need something to identify them as Rego v1 policies. And so on, and so forth :)

But I figured a PR would be the best way to start that discussion, and for me to get some directions for what to work on now.

The test.sh file have been updated to run the unit tests against the v1 policies too, and they're all passing. I have not yet played with the Gator CLI tests though, so that might be a good thing to look into as well.