### PR TITLE
ci: bumping lint to v2

### DIFF
--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         folder: [artifacthub, require-sync, validate, website]
     steps:
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: '1.20'
           cache: false
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.55.2
+          version: v2.0.2
           working-directory: scripts/${{ matrix.folder }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,50 +1,62 @@
+version: "2"
 run:
   timeout: 5m
-
-linters-settings:
-  gocritic:
-    enabled-tags:
-    - performance
-  gosec:
-    excludes:
-    - G108
-  importas:
-    no-unaliased: true
-    alias:
-      - pkg: "github.com/open-policy-agent/frameworks/constraint/pkg/client"
-        alias: constraintclient
-  lll:
-    line-length: 200
-
-  misspell:
-    locale: US
-  staticcheck:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.20"
-
+  go: "1.20"
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
     - errorlint
-    - exportloopref
     - forcetypeassert
-    - gci
-    - gocritic
     - goconst
+    - gocritic
     - godot
-    - gofmt
-    - gofumpt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - importas
     - ineffassign
     - misspell
     - revive # replacement for golint
     - staticcheck
-    - typecheck
     - unconvert
     - unused
     - whitespace
+  settings:
+    gocritic:
+      enabled-tags:
+        - performance
+    gosec:
+      excludes:
+        - G108
+    importas:
+      alias:
+        - pkg: github.com/open-policy-agent/frameworks/constraint/pkg/client
+          alias: constraintclient
+      no-unaliased: true
+    lll:
+      line-length: 200
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes CI error in lint here -https://github.com/open-policy-agent/gatekeeper-library/actions/runs/14315041850/job/40119131619?pr=643

**Which issue(s) does this PR fix** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Library policies?**
Please refer to [How to contribute to the library](https://open-policy-agent.github.io/gatekeeper-library/website/#how-to-contribute-to-the-library) to add new policies or update existing policies.

**Are you updating an existing policy?**
Please run `make generate generate-website-docs generate-artifacthub-artifacts` to generate the templates and docs.
-->

**Special notes for your reviewer**:
