### PR TITLE
@W-19827921 Byoc spark loader

### DIFF
--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/artifacthub-pkg.yml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+version: 1.0.0
+name: sparkpodlabeling
+displayName: Spark Pod Labeling
+createdAt: "2025-10-07T20:33:19Z"
+description: Enforces security and labeling requirements for Spark pods created by Spark service accounts. Validates that Spark pods have required labels (spark-job-id, spark-role), use allowed service accounts, run only approved container images, and follow security best practices by prohibiting privileged containers and host path volumes.
+digest: 577fb7131b4f2c0a003c3a00fbcb76a0283cef8f315b28063c6f321f11b00ffc
+license: Apache-2.0
+homeURL: https://open-policy-agent.github.io/gatekeeper-library/website/sparkpodlabeling
+keywords:
+    - gatekeeper
+    - open-policy-agent
+    - policies
+readme: |-
+    # Spark Pod Labeling
+    Enforces security and labeling requirements for Spark pods created by Spark service accounts. Validates that Spark pods have required labels (spark-job-id, spark-role), use allowed service accounts, run only approved container images, and follow security best practices by prohibiting privileged containers and host path volumes.
+install: |-
+    ### Usage
+    ```shell
+    kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/artifacthub/library/general/sparkpodlabeling/1.0.0/template.yaml
+    ```
+provider:
+    name: Gatekeeper Library

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/kustomization.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/constraint.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/constraint.yaml
@@ -1,0 +1,20 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: SparkPodLabeling
+metadata:
+  name: spark-pod-labeling
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    allowedServiceAccounts:
+      - "spark-driver-sa"
+      - "spark-executor-sa"
+    requiredLabels:
+      - "spark-job-id"
+      - "spark-role"
+      - "app"
+    allowedImagePatterns:
+      - "spark/"
+      - "apache/spark"

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_disallowed_image.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_disallowed_image.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-disallowed-image
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "nginx:latest"  # Not allowed for Spark pods

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_empty_job_id.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_empty_job_id.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-empty-job-id
+  labels:
+    spark-job-id: ""
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_executor_wrong_sa.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_executor_wrong_sa.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-executor-wrong-sa
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "executor"
+    app: "spark-app"
+spec:
+  serviceAccountName: "wrong-sa"  # Not in allowed list
+  containers:
+    - name: spark-executor
+      image: "spark/spark:3.4.0"

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_host_path_volume.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_host_path_volume.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-host-path
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+  volumes:
+    - name: host-vol
+      hostPath:
+        path: "/tmp"  # Not allowed for Spark pods

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_invalid_role.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_invalid_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-invalid-role
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "invalid-role"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_missing_label.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_missing_label.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-missing-label
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    # Missing required "app" label
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_missing_role.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_missing_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-missing-role
+  labels:
+    spark-job-id: "job-123"
+    app: "spark-app"
+    # Missing spark-role label
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_multiple_violations.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_multiple_violations.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-multiple-violations
+  labels:
+    spark-job-id: ""  # Empty job ID
+    spark-role: "invalid-role"  # Invalid role
+    # Missing required "app" label
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "nginx:latest"  # Disallowed image
+      securityContext:
+        privileged: true  # Privileged container
+  volumes:
+    - name: host-vol
+      hostPath:
+        path: "/tmp"  # Host path volume

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_non_spark_sa.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_non_spark_sa.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: regular-pod
+  labels:
+    app: "nginx"
+spec:
+  serviceAccountName: "regular-sa"  # Not a Spark service account
+  containers:
+    - name: nginx
+      image: "nginx:latest"

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_privileged_container.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_privileged_container.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-privileged
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+      securityContext:
+        privileged: true  # Not allowed for Spark pods

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_valid_driver.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_valid_driver.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-driver-pod
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+      command: ["spark-submit"]
+      args: ["--class", "MySparkApp", "myapp.jar"]

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_valid_executor.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_valid_executor.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-executor-pod
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "executor"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-executor-sa"
+  containers:
+    - name: spark-executor
+      image: "apache/spark:3.4.0"
+      command: ["spark-executor"]

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_wrong_service_account.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/samples/spark-pod-labeling/example_wrong_service_account.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-wrong-sa
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "wrong-sa"  # Not in allowed list
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/suite.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/suite.yaml
@@ -1,0 +1,79 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: sparkpodlabeling
+tests:
+- name: spark-pod-labeling
+  template: template.yaml
+  constraint: samples/spark-pod-labeling/constraint.yaml
+  cases:
+  - name: valid-spark-driver
+    object: samples/spark-pod-labeling/example_valid_driver.yaml
+    assertions:
+    - violations: no
+  - name: valid-spark-executor
+    object: samples/spark-pod-labeling/example_valid_executor.yaml
+    assertions:
+    - violations: no
+  - name: missing-required-label
+    object: samples/spark-pod-labeling/example_missing_label.yaml
+    assertions:
+    - violations: yes
+      message: "Spark pod missing required label: app"
+  - name: empty-spark-job-id
+    object: samples/spark-pod-labeling/example_empty_job_id.yaml
+    assertions:
+    - violations: yes
+      message: "spark-job-id label cannot be empty"
+  - name: missing-spark-role
+    object: samples/spark-pod-labeling/example_missing_role.yaml
+    assertions:
+    - violations: yes
+      message: "spark-role label is required (driver or executor)"
+  - name: invalid-spark-role
+    object: samples/spark-pod-labeling/example_invalid_role.yaml
+    assertions:
+    - violations: yes
+      message: "Invalid spark-role: invalid-role. Must be 'driver' or 'executor'"
+  - name: disallowed-image
+    object: samples/spark-pod-labeling/example_disallowed_image.yaml
+    assertions:
+    - violations: yes
+      message: "Image not allowed for Spark pods: nginx:latest"
+  - name: privileged-container
+    object: samples/spark-pod-labeling/example_privileged_container.yaml
+    assertions:
+    - violations: yes
+      message: "Privileged containers not allowed for Spark pods"
+  - name: host-path-volume
+    object: samples/spark-pod-labeling/example_host_path_volume.yaml
+    assertions:
+    - violations: yes
+      message: "Host path volumes not allowed for Spark pods"
+  - name: wrong-service-account
+    object: samples/spark-pod-labeling/example_wrong_service_account.yaml
+    assertions:
+    - violations: yes
+      message: "SECURITY: Pod service account 'wrong-sa' must match allowed service accounts"
+  - name: executor-wrong-service-account
+    object: samples/spark-pod-labeling/example_executor_wrong_sa.yaml
+    assertions:
+    - violations: yes
+      message: "SECURITY: Executor pod must use allowed service account. Found: wrong-sa"
+  - name: non-spark-service-account
+    object: samples/spark-pod-labeling/example_non_spark_sa.yaml
+    assertions:
+    - violations: no
+  - name: multiple-violations
+    object: samples/spark-pod-labeling/example_multiple_violations.yaml
+    assertions:
+    - violations: yes
+      message: "Spark pod missing required label: app"
+    - violations: yes
+      message: "spark-job-id label cannot be empty"
+    - violations: yes
+      message: "Invalid spark-role: invalid-role. Must be 'driver' or 'executor'"
+    - violations: yes
+      message: "Image not allowed for Spark pods: nginx:latest"
+    - violations: yes
+      message: "Privileged containers not allowed for Spark pods"

--- a/artifacthub/library/general/sparkpodlabeling/1.0.0/template.yaml
+++ b/artifacthub/library/general/sparkpodlabeling/1.0.0/template.yaml
@@ -1,0 +1,122 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: sparkpodlabeling
+  annotations:
+    metadata.gatekeeper.sh/title: "Spark Pod Labeling"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Enforces security and labeling requirements for Spark pods created by Spark service accounts.
+      Validates that Spark pods have required labels (spark-job-id, spark-role), use allowed
+      service accounts, run only approved container images, and follow security best practices
+      by prohibiting privileged containers and host path volumes.
+spec:
+  crd:
+    spec:
+      names:
+        kind: SparkPodLabeling
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedServiceAccounts:
+              type: array
+              items:
+                type: string
+            requiredLabels:
+              type: array
+              items:
+                type: string
+            allowedImagePatterns:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+            package sparkpodlabeling
+
+            # Check if this is a Spark service account
+            is_spark_service_account {
+                some i
+                input.review.object.spec.serviceAccountName == input.parameters.allowedServiceAccounts[i]
+            }
+
+            # Violation: Spark service account creating pod without required labels
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some j
+                required := input.parameters.requiredLabels[j]
+                not input.review.object.metadata.labels[required]
+                msg := sprintf("Spark pod missing required label: %v", [required])
+            }
+
+            # Violation: Spark service account creating pod with empty spark-job-id
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                job_id := input.review.object.metadata.labels["spark-job-id"]
+                job_id == ""
+                msg := "spark-job-id label cannot be empty"
+            }
+
+            # Violation: Spark service account creating pod without spark-role
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                role := input.review.object.metadata.labels["spark-role"]
+                not role
+                msg := "spark-role label is required (driver or executor)"
+            }
+
+            # Violation: Invalid spark-role value
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                role := input.review.object.metadata.labels["spark-role"]
+                not role == "driver"
+                not role == "executor"
+                msg := sprintf("Invalid spark-role: %v. Must be 'driver' or 'executor'", [role])
+            }
+
+            # Violation: Spark service account using non-Spark images
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some k
+                image := input.review.object.spec.containers[k].image
+                allowed_patterns := input.parameters.allowedImagePatterns
+                count([p | some l; p := allowed_patterns[l]; contains(image, p)]) == 0
+                msg := sprintf("Image not allowed for Spark pods: %v", [image])
+            }
+
+            # Violation: Spark service account creating pods with privileged containers
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some m
+                input.review.object.spec.containers[m].securityContext.privileged == true
+                msg := "Privileged containers not allowed for Spark pods"
+            }
+
+            # Violation: Spark service account mounting host paths
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some n
+                input.review.object.spec.volumes[n].hostPath
+                msg := "Host path volumes not allowed for Spark pods"
+            }
+
+            # Violation: Executors must use same service account as driver
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                role := input.review.object.metadata.labels["spark-role"]
+                role == "executor"
+                executor_sa := input.review.object.spec.serviceAccountName
+                count([sa | some o; sa := input.parameters.allowedServiceAccounts[o]; sa == executor_sa]) == 0
+                msg := sprintf("SECURITY: Executor pod must use allowed service account. Found: %v", [executor_sa])
+            }
+
+            # Violation: Drivers creating pods with different service account
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                pod_sa := input.review.object.spec.serviceAccountName
+                count([sa | some p; sa := input.parameters.allowedServiceAccounts[p]; sa == pod_sa]) == 0
+                msg := sprintf("SECURITY: Pod service account '%v' must match allowed service accounts", [pod_sa])
+            }
+            

--- a/library/general/sparkpodlabeling/kustomization.yaml
+++ b/library/general/sparkpodlabeling/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/constraint.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/constraint.yaml
@@ -1,0 +1,20 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: SparkPodLabeling
+metadata:
+  name: spark-pod-labeling
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    allowedServiceAccounts:
+      - "spark-driver-sa"
+      - "spark-executor-sa"
+    requiredLabels:
+      - "spark-job-id"
+      - "spark-role"
+      - "app"
+    allowedImagePatterns:
+      - "spark/"
+      - "apache/spark"

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_disallowed_image.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_disallowed_image.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-disallowed-image
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "nginx:latest"  # Not allowed for Spark pods

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_empty_job_id.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_empty_job_id.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-empty-job-id
+  labels:
+    spark-job-id: ""
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_executor_wrong_sa.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_executor_wrong_sa.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-executor-wrong-sa
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "executor"
+    app: "spark-app"
+spec:
+  serviceAccountName: "wrong-sa"  # Not in allowed list
+  containers:
+    - name: spark-executor
+      image: "spark/spark:3.4.0"

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_host_path_volume.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_host_path_volume.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-host-path
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+  volumes:
+    - name: host-vol
+      hostPath:
+        path: "/tmp"  # Not allowed for Spark pods

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_invalid_role.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_invalid_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-invalid-role
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "invalid-role"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_missing_label.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_missing_label.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-missing-label
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    # Missing required "app" label
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_missing_role.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_missing_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-missing-role
+  labels:
+    spark-job-id: "job-123"
+    app: "spark-app"
+    # Missing spark-role label
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_multiple_violations.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_multiple_violations.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-multiple-violations
+  labels:
+    spark-job-id: ""  # Empty job ID
+    spark-role: "invalid-role"  # Invalid role
+    # Missing required "app" label
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "nginx:latest"  # Disallowed image
+      securityContext:
+        privileged: true  # Privileged container
+  volumes:
+    - name: host-vol
+      hostPath:
+        path: "/tmp"  # Host path volume

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_non_spark_sa.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_non_spark_sa.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: regular-pod
+  labels:
+    app: "nginx"
+spec:
+  serviceAccountName: "regular-sa"  # Not a Spark service account
+  containers:
+    - name: nginx
+      image: "nginx:latest"

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_privileged_container.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_privileged_container.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-privileged
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+      securityContext:
+        privileged: true  # Not allowed for Spark pods

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_valid_driver.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_valid_driver.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-driver-pod
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+      command: ["spark-submit"]
+      args: ["--class", "MySparkApp", "myapp.jar"]

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_valid_executor.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_valid_executor.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-executor-pod
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "executor"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-executor-sa"
+  containers:
+    - name: spark-executor
+      image: "apache/spark:3.4.0"
+      command: ["spark-executor"]

--- a/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_wrong_service_account.yaml
+++ b/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_wrong_service_account.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-wrong-sa
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "wrong-sa"  # Not in allowed list
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"

--- a/library/general/sparkpodlabeling/suite.yaml
+++ b/library/general/sparkpodlabeling/suite.yaml
@@ -1,0 +1,79 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: sparkpodlabeling
+tests:
+- name: spark-pod-labeling
+  template: template.yaml
+  constraint: samples/spark-pod-labeling/constraint.yaml
+  cases:
+  - name: valid-spark-driver
+    object: samples/spark-pod-labeling/example_valid_driver.yaml
+    assertions:
+    - violations: no
+  - name: valid-spark-executor
+    object: samples/spark-pod-labeling/example_valid_executor.yaml
+    assertions:
+    - violations: no
+  - name: missing-required-label
+    object: samples/spark-pod-labeling/example_missing_label.yaml
+    assertions:
+    - violations: yes
+      message: "Spark pod missing required label: app"
+  - name: empty-spark-job-id
+    object: samples/spark-pod-labeling/example_empty_job_id.yaml
+    assertions:
+    - violations: yes
+      message: "spark-job-id label cannot be empty"
+  - name: missing-spark-role
+    object: samples/spark-pod-labeling/example_missing_role.yaml
+    assertions:
+    - violations: yes
+      message: "spark-role label is required (driver or executor)"
+  - name: invalid-spark-role
+    object: samples/spark-pod-labeling/example_invalid_role.yaml
+    assertions:
+    - violations: yes
+      message: "Invalid spark-role: invalid-role. Must be 'driver' or 'executor'"
+  - name: disallowed-image
+    object: samples/spark-pod-labeling/example_disallowed_image.yaml
+    assertions:
+    - violations: yes
+      message: "Image not allowed for Spark pods: nginx:latest"
+  - name: privileged-container
+    object: samples/spark-pod-labeling/example_privileged_container.yaml
+    assertions:
+    - violations: yes
+      message: "Privileged containers not allowed for Spark pods"
+  - name: host-path-volume
+    object: samples/spark-pod-labeling/example_host_path_volume.yaml
+    assertions:
+    - violations: yes
+      message: "Host path volumes not allowed for Spark pods"
+  - name: wrong-service-account
+    object: samples/spark-pod-labeling/example_wrong_service_account.yaml
+    assertions:
+    - violations: yes
+      message: "SECURITY: Pod service account 'wrong-sa' must match allowed service accounts"
+  - name: executor-wrong-service-account
+    object: samples/spark-pod-labeling/example_executor_wrong_sa.yaml
+    assertions:
+    - violations: yes
+      message: "SECURITY: Executor pod must use allowed service account. Found: wrong-sa"
+  - name: non-spark-service-account
+    object: samples/spark-pod-labeling/example_non_spark_sa.yaml
+    assertions:
+    - violations: no
+  - name: multiple-violations
+    object: samples/spark-pod-labeling/example_multiple_violations.yaml
+    assertions:
+    - violations: yes
+      message: "Spark pod missing required label: app"
+    - violations: yes
+      message: "spark-job-id label cannot be empty"
+    - violations: yes
+      message: "Invalid spark-role: invalid-role. Must be 'driver' or 'executor'"
+    - violations: yes
+      message: "Image not allowed for Spark pods: nginx:latest"
+    - violations: yes
+      message: "Privileged containers not allowed for Spark pods"

--- a/library/general/sparkpodlabeling/template.yaml
+++ b/library/general/sparkpodlabeling/template.yaml
@@ -1,0 +1,122 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: sparkpodlabeling
+  annotations:
+    metadata.gatekeeper.sh/title: "Spark Pod Labeling"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Enforces security and labeling requirements for Spark pods created by Spark service accounts.
+      Validates that Spark pods have required labels (spark-job-id, spark-role), use allowed
+      service accounts, run only approved container images, and follow security best practices
+      by prohibiting privileged containers and host path volumes.
+spec:
+  crd:
+    spec:
+      names:
+        kind: SparkPodLabeling
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedServiceAccounts:
+              type: array
+              items:
+                type: string
+            requiredLabels:
+              type: array
+              items:
+                type: string
+            allowedImagePatterns:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+            package sparkpodlabeling
+
+            # Check if this is a Spark service account
+            is_spark_service_account {
+                some i
+                input.review.object.spec.serviceAccountName == input.parameters.allowedServiceAccounts[i]
+            }
+
+            # Violation: Spark service account creating pod without required labels
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some j
+                required := input.parameters.requiredLabels[j]
+                not input.review.object.metadata.labels[required]
+                msg := sprintf("Spark pod missing required label: %v", [required])
+            }
+
+            # Violation: Spark service account creating pod with empty spark-job-id
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                job_id := input.review.object.metadata.labels["spark-job-id"]
+                job_id == ""
+                msg := "spark-job-id label cannot be empty"
+            }
+
+            # Violation: Spark service account creating pod without spark-role
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                role := input.review.object.metadata.labels["spark-role"]
+                not role
+                msg := "spark-role label is required (driver or executor)"
+            }
+
+            # Violation: Invalid spark-role value
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                role := input.review.object.metadata.labels["spark-role"]
+                not role == "driver"
+                not role == "executor"
+                msg := sprintf("Invalid spark-role: %v. Must be 'driver' or 'executor'", [role])
+            }
+
+            # Violation: Spark service account using non-Spark images
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some k
+                image := input.review.object.spec.containers[k].image
+                allowed_patterns := input.parameters.allowedImagePatterns
+                count([p | some l; p := allowed_patterns[l]; contains(image, p)]) == 0
+                msg := sprintf("Image not allowed for Spark pods: %v", [image])
+            }
+
+            # Violation: Spark service account creating pods with privileged containers
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some m
+                input.review.object.spec.containers[m].securityContext.privileged == true
+                msg := "Privileged containers not allowed for Spark pods"
+            }
+
+            # Violation: Spark service account mounting host paths
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some n
+                input.review.object.spec.volumes[n].hostPath
+                msg := "Host path volumes not allowed for Spark pods"
+            }
+
+            # Violation: Executors must use same service account as driver
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                role := input.review.object.metadata.labels["spark-role"]
+                role == "executor"
+                executor_sa := input.review.object.spec.serviceAccountName
+                count([sa | some o; sa := input.parameters.allowedServiceAccounts[o]; sa == executor_sa]) == 0
+                msg := sprintf("SECURITY: Executor pod must use allowed service account. Found: %v", [executor_sa])
+            }
+
+            # Violation: Drivers creating pods with different service account
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                pod_sa := input.review.object.spec.serviceAccountName
+                count([sa | some p; sa := input.parameters.allowedServiceAccounts[p]; sa == pod_sa]) == 0
+                msg := sprintf("SECURITY: Pod service account '%v' must match allowed service accounts", [pod_sa])
+            }
+            

--- a/src/general/sparkpodlabeling/constraint.tmpl
+++ b/src/general/sparkpodlabeling/constraint.tmpl
@@ -1,0 +1,37 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: sparkpodlabeling
+  annotations:
+    metadata.gatekeeper.sh/title: "Spark Pod Labeling"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Enforces security and labeling requirements for Spark pods created by Spark service accounts.
+      Validates that Spark pods have required labels (spark-job-id, spark-role), use allowed
+      service accounts, run only approved container images, and follow security best practices
+      by prohibiting privileged containers and host path volumes.
+spec:
+  crd:
+    spec:
+      names:
+        kind: SparkPodLabeling
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedServiceAccounts:
+              type: array
+              items:
+                type: string
+            requiredLabels:
+              type: array
+              items:
+                type: string
+            allowedImagePatterns:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ file.Read "src/general/sparkpodlabeling/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/general/sparkpodlabeling/src.rego
+++ b/src/general/sparkpodlabeling/src.rego
@@ -1,0 +1,86 @@
+    package sparkpodlabeling
+
+    # Check if this is a Spark service account
+    is_spark_service_account {
+        some i
+        input.review.object.spec.serviceAccountName == input.parameters.allowedServiceAccounts[i]
+    }
+
+    # Violation: Spark service account creating pod without required labels
+    violation[{"msg": msg}] {
+        is_spark_service_account
+        some j
+        required := input.parameters.requiredLabels[j]
+        not input.review.object.metadata.labels[required]
+        msg := sprintf("Spark pod missing required label: %v", [required])
+    }
+
+    # Violation: Spark service account creating pod with empty spark-job-id
+    violation[{"msg": msg}] {
+        is_spark_service_account
+        job_id := input.review.object.metadata.labels["spark-job-id"]
+        job_id == ""
+        msg := "spark-job-id label cannot be empty"
+    }
+
+    # Violation: Spark service account creating pod without spark-role
+    violation[{"msg": msg}] {
+        is_spark_service_account
+        role := input.review.object.metadata.labels["spark-role"]
+        not role
+        msg := "spark-role label is required (driver or executor)"
+    }
+
+    # Violation: Invalid spark-role value
+    violation[{"msg": msg}] {
+        is_spark_service_account
+        role := input.review.object.metadata.labels["spark-role"]
+        not role == "driver"
+        not role == "executor"
+        msg := sprintf("Invalid spark-role: %v. Must be 'driver' or 'executor'", [role])
+    }
+
+    # Violation: Spark service account using non-Spark images
+    violation[{"msg": msg}] {
+        is_spark_service_account
+        some k
+        image := input.review.object.spec.containers[k].image
+        allowed_patterns := input.parameters.allowedImagePatterns
+        count([p | some l; p := allowed_patterns[l]; contains(image, p)]) == 0
+        msg := sprintf("Image not allowed for Spark pods: %v", [image])
+    }
+
+    # Violation: Spark service account creating pods with privileged containers
+    violation[{"msg": msg}] {
+        is_spark_service_account
+        some m
+        input.review.object.spec.containers[m].securityContext.privileged == true
+        msg := "Privileged containers not allowed for Spark pods"
+    }
+
+    # Violation: Spark service account mounting host paths
+    violation[{"msg": msg}] {
+        is_spark_service_account
+        some n
+        input.review.object.spec.volumes[n].hostPath
+        msg := "Host path volumes not allowed for Spark pods"
+    }
+
+    # Violation: Executors must use same service account as driver
+    violation[{"msg": msg}] {
+        is_spark_service_account
+        role := input.review.object.metadata.labels["spark-role"]
+        role == "executor"
+        executor_sa := input.review.object.spec.serviceAccountName
+        count([sa | some o; sa := input.parameters.allowedServiceAccounts[o]; sa == executor_sa]) == 0
+        msg := sprintf("SECURITY: Executor pod must use allowed service account. Found: %v", [executor_sa])
+    }
+
+    # Violation: Drivers creating pods with different service account
+    violation[{"msg": msg}] {
+        is_spark_service_account
+        pod_sa := input.review.object.spec.serviceAccountName
+        count([sa | some p; sa := input.parameters.allowedServiceAccounts[p]; sa == pod_sa]) == 0
+        msg := sprintf("SECURITY: Pod service account '%v' must match allowed service accounts", [pod_sa])
+    }
+    

--- a/src/general/sparkpodlabeling/src_test.rego
+++ b/src/general/sparkpodlabeling/src_test.rego
@@ -1,0 +1,367 @@
+package sparkpodlabeling
+
+# Test valid Spark driver pod with all required labels and proper service account
+test_valid_spark_driver {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-driver-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "driver",
+                "app": "spark-app"
+            },
+            "containers": [{"image": "spark/spark:3.4.0"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa", "spark-executor-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/", "apache/spark"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 0
+}
+
+# Test valid Spark executor pod with all required labels and proper service account
+test_valid_spark_executor {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-executor-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "executor",
+                "app": "spark-app"
+            },
+            "containers": [{"image": "spark/spark:3.4.0"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa", "spark-executor-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/", "apache/spark"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 0
+}
+
+# Test missing required label
+test_missing_required_label {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-driver-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "driver"
+                # Missing "app" label
+            },
+            "containers": [{"image": "spark/spark:3.4.0"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 1
+    results[0].msg == "Spark pod missing required label: app"
+}
+
+# Test empty spark-job-id
+test_empty_spark_job_id {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-driver-sa",
+            "labels": {
+                "spark-job-id": "",
+                "spark-role": "driver",
+                "app": "spark-app"
+            },
+            "containers": [{"image": "spark/spark:3.4.0"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 1
+    results[0].msg == "spark-job-id label cannot be empty"
+}
+
+# Test missing spark-role
+test_missing_spark_role {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-driver-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "app": "spark-app"
+                # Missing spark-role
+            },
+            "containers": [{"image": "spark/spark:3.4.0"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 1
+    results[0].msg == "spark-role label is required (driver or executor)"
+}
+
+# Test invalid spark-role
+test_invalid_spark_role {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-driver-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "invalid-role",
+                "app": "spark-app"
+            },
+            "containers": [{"image": "spark/spark:3.4.0"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 1
+    results[0].msg == "Invalid spark-role: invalid-role. Must be 'driver' or 'executor'"
+}
+
+# Test disallowed image
+test_disallowed_image {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-driver-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "driver",
+                "app": "spark-app"
+            },
+            "containers": [{"image": "nginx:latest"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/", "apache/spark"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 1
+    results[0].msg == "Image not allowed for Spark pods: nginx:latest"
+}
+
+# Test privileged container
+test_privileged_container {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-driver-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "driver",
+                "app": "spark-app"
+            },
+            "containers": [{
+                "image": "spark/spark:3.4.0",
+                "securityContext": {"privileged": true}
+            }]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 1
+    results[0].msg == "Privileged containers not allowed for Spark pods"
+}
+
+# Test host path volume
+test_host_path_volume {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-driver-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "driver",
+                "app": "spark-app"
+            },
+            "containers": [{"image": "spark/spark:3.4.0"}],
+            "volumes": [{"name": "host-vol", "hostPath": {"path": "/tmp"}}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 1
+    results[0].msg == "Host path volumes not allowed for Spark pods"
+}
+
+# Test executor with wrong service account
+test_executor_wrong_service_account {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "wrong-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "executor",
+                "app": "spark-app"
+            },
+            "containers": [{"image": "spark/spark:3.4.0"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa", "spark-executor-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 1
+    results[0].msg == "SECURITY: Executor pod must use allowed service account. Found: wrong-sa"
+}
+
+# Test driver with wrong service account
+test_driver_wrong_service_account {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "wrong-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "driver",
+                "app": "spark-app"
+            },
+            "containers": [{"image": "spark/spark:3.4.0"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa", "spark-executor-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 1
+    results[0].msg == "SECURITY: Pod service account 'wrong-sa' must match allowed service accounts"
+}
+
+# Test non-Spark service account (should pass)
+test_non_spark_service_account {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "regular-sa",
+            "labels": {
+                "app": "nginx"
+            },
+            "containers": [{"image": "nginx:latest"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa", "spark-executor-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 0
+}
+
+# Test multiple violations
+test_multiple_violations {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "wrong-sa",
+            "labels": {
+                "spark-job-id": "",
+                "spark-role": "invalid-role"
+                # Missing required "app" label
+            },
+            "containers": [{
+                "image": "nginx:latest",
+                "securityContext": {"privileged": true}
+            }],
+            "volumes": [{"name": "host-vol", "hostPath": {"path": "/tmp"}}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/"]
+        }
+    }
+    results := violation with input as inp
+    count(results) >= 5  # Should have multiple violations
+}
+
+# Test valid image patterns
+test_valid_image_patterns {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-driver-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "driver",
+                "app": "spark-app"
+            },
+            "containers": [{"image": "apache/spark:3.4.0"}]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/", "apache/spark"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 0
+}
+
+# Test multiple containers with mixed images
+test_multiple_containers_mixed_images {
+    inp := {
+        "review": spark_pod_review({
+            "serviceAccountName": "spark-driver-sa",
+            "labels": {
+                "spark-job-id": "job-123",
+                "spark-role": "driver",
+                "app": "spark-app"
+            },
+            "containers": [
+                {"image": "spark/spark:3.4.0"},
+                {"image": "nginx:latest"}  # This should fail
+            ]
+        }),
+        "parameters": {
+            "allowedServiceAccounts": ["spark-driver-sa"],
+            "requiredLabels": ["spark-job-id", "spark-role", "app"],
+            "allowedImagePatterns": ["spark/", "apache/spark"]
+        }
+    }
+    results := violation with input as inp
+    count(results) == 1
+    results[0].msg == "Image not allowed for Spark pods: nginx:latest"
+}
+
+# Helper function to create Spark pod review
+spark_pod_review(pod_spec) = output {
+    output = {
+        "object": {
+            "metadata": {
+                "name": "spark-pod",
+                "labels": pod_spec.labels
+            },
+            "spec": {
+                "serviceAccountName": pod_spec.serviceAccountName,
+                "containers": pod_spec.containers,
+                "volumes": pod_spec.volumes
+            }
+        }
+    }
+}

--- a/website/docs/validation/sparkpodlabeling.md
+++ b/website/docs/validation/sparkpodlabeling.md
@@ -1,0 +1,547 @@
+---
+id: sparkpodlabeling
+title: Spark Pod Labeling
+---
+
+# Spark Pod Labeling
+
+## Description
+Enforces security and labeling requirements for Spark pods created by Spark service accounts. Validates that Spark pods have required labels (spark-job-id, spark-role), use allowed service accounts, run only approved container images, and follow security best practices by prohibiting privileged containers and host path volumes.
+
+## Template
+```yaml
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: sparkpodlabeling
+  annotations:
+    metadata.gatekeeper.sh/title: "Spark Pod Labeling"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Enforces security and labeling requirements for Spark pods created by Spark service accounts.
+      Validates that Spark pods have required labels (spark-job-id, spark-role), use allowed
+      service accounts, run only approved container images, and follow security best practices
+      by prohibiting privileged containers and host path volumes.
+spec:
+  crd:
+    spec:
+      names:
+        kind: SparkPodLabeling
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedServiceAccounts:
+              type: array
+              items:
+                type: string
+            requiredLabels:
+              type: array
+              items:
+                type: string
+            allowedImagePatterns:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+            package sparkpodlabeling
+
+            # Check if this is a Spark service account
+            is_spark_service_account {
+                some i
+                input.review.object.spec.serviceAccountName == input.parameters.allowedServiceAccounts[i]
+            }
+
+            # Violation: Spark service account creating pod without required labels
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some j
+                required := input.parameters.requiredLabels[j]
+                not input.review.object.metadata.labels[required]
+                msg := sprintf("Spark pod missing required label: %v", [required])
+            }
+
+            # Violation: Spark service account creating pod with empty spark-job-id
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                job_id := input.review.object.metadata.labels["spark-job-id"]
+                job_id == ""
+                msg := "spark-job-id label cannot be empty"
+            }
+
+            # Violation: Spark service account creating pod without spark-role
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                role := input.review.object.metadata.labels["spark-role"]
+                not role
+                msg := "spark-role label is required (driver or executor)"
+            }
+
+            # Violation: Invalid spark-role value
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                role := input.review.object.metadata.labels["spark-role"]
+                not role == "driver"
+                not role == "executor"
+                msg := sprintf("Invalid spark-role: %v. Must be 'driver' or 'executor'", [role])
+            }
+
+            # Violation: Spark service account using non-Spark images
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some k
+                image := input.review.object.spec.containers[k].image
+                allowed_patterns := input.parameters.allowedImagePatterns
+                count([p | some l; p := allowed_patterns[l]; contains(image, p)]) == 0
+                msg := sprintf("Image not allowed for Spark pods: %v", [image])
+            }
+
+            # Violation: Spark service account creating pods with privileged containers
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some m
+                input.review.object.spec.containers[m].securityContext.privileged == true
+                msg := "Privileged containers not allowed for Spark pods"
+            }
+
+            # Violation: Spark service account mounting host paths
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                some n
+                input.review.object.spec.volumes[n].hostPath
+                msg := "Host path volumes not allowed for Spark pods"
+            }
+
+            # Violation: Executors must use same service account as driver
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                role := input.review.object.metadata.labels["spark-role"]
+                role == "executor"
+                executor_sa := input.review.object.spec.serviceAccountName
+                count([sa | some o; sa := input.parameters.allowedServiceAccounts[o]; sa == executor_sa]) == 0
+                msg := sprintf("SECURITY: Executor pod must use allowed service account. Found: %v", [executor_sa])
+            }
+
+            # Violation: Drivers creating pods with different service account
+            violation[{"msg": msg}] {
+                is_spark_service_account
+                pod_sa := input.review.object.spec.serviceAccountName
+                count([sa | some p; sa := input.parameters.allowedServiceAccounts[p]; sa == pod_sa]) == 0
+                msg := sprintf("SECURITY: Pod service account '%v' must match allowed service accounts", [pod_sa])
+            }
+            
+
+```
+
+### Usage
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/template.yaml
+```
+## Examples
+<details>
+<summary>spark-pod-labeling</summary>
+
+<details>
+<summary>constraint</summary>
+
+```yaml
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: SparkPodLabeling
+metadata:
+  name: spark-pod-labeling
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    allowedServiceAccounts:
+      - "spark-driver-sa"
+      - "spark-executor-sa"
+    requiredLabels:
+      - "spark-job-id"
+      - "spark-role"
+      - "app"
+    allowedImagePatterns:
+      - "spark/"
+      - "apache/spark"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/constraint.yaml
+```
+
+</details>
+
+<details>
+<summary>valid-spark-driver</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-driver-pod
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+      command: ["spark-submit"]
+      args: ["--class", "MySparkApp", "myapp.jar"]
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_valid_driver.yaml
+```
+
+</details>
+<details>
+<summary>valid-spark-executor</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-executor-pod
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "executor"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-executor-sa"
+  containers:
+    - name: spark-executor
+      image: "apache/spark:3.4.0"
+      command: ["spark-executor"]
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_valid_executor.yaml
+```
+
+</details>
+<details>
+<summary>missing-required-label</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-missing-label
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    # Missing required "app" label
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_missing_label.yaml
+```
+
+</details>
+<details>
+<summary>empty-spark-job-id</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-empty-job-id
+  labels:
+    spark-job-id: ""
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_empty_job_id.yaml
+```
+
+</details>
+<details>
+<summary>missing-spark-role</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-missing-role
+  labels:
+    spark-job-id: "job-123"
+    app: "spark-app"
+    # Missing spark-role label
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_missing_role.yaml
+```
+
+</details>
+<details>
+<summary>invalid-spark-role</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-invalid-role
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "invalid-role"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_invalid_role.yaml
+```
+
+</details>
+<details>
+<summary>disallowed-image</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-disallowed-image
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "nginx:latest"  # Not allowed for Spark pods
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_disallowed_image.yaml
+```
+
+</details>
+<details>
+<summary>privileged-container</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-privileged
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+      securityContext:
+        privileged: true  # Not allowed for Spark pods
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_privileged_container.yaml
+```
+
+</details>
+<details>
+<summary>host-path-volume</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-host-path
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+  volumes:
+    - name: host-vol
+      hostPath:
+        path: "/tmp"  # Not allowed for Spark pods
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_host_path_volume.yaml
+```
+
+</details>
+<details>
+<summary>wrong-service-account</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-wrong-sa
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "driver"
+    app: "spark-app"
+spec:
+  serviceAccountName: "wrong-sa"  # Not in allowed list
+  containers:
+    - name: spark-driver
+      image: "spark/spark:3.4.0"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_wrong_service_account.yaml
+```
+
+</details>
+<details>
+<summary>executor-wrong-service-account</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-executor-wrong-sa
+  labels:
+    spark-job-id: "job-123"
+    spark-role: "executor"
+    app: "spark-app"
+spec:
+  serviceAccountName: "wrong-sa"  # Not in allowed list
+  containers:
+    - name: spark-executor
+      image: "spark/spark:3.4.0"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_executor_wrong_sa.yaml
+```
+
+</details>
+<details>
+<summary>non-spark-service-account</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: regular-pod
+  labels:
+    app: "nginx"
+spec:
+  serviceAccountName: "regular-sa"  # Not a Spark service account
+  containers:
+    - name: nginx
+      image: "nginx:latest"
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_non_spark_sa.yaml
+```
+
+</details>
+<details>
+<summary>multiple-violations</summary>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spark-pod-multiple-violations
+  labels:
+    spark-job-id: ""  # Empty job ID
+    spark-role: "invalid-role"  # Invalid role
+    # Missing required "app" label
+spec:
+  serviceAccountName: "spark-driver-sa"
+  containers:
+    - name: spark-driver
+      image: "nginx:latest"  # Disallowed image
+      securityContext:
+        privileged: true  # Privileged container
+  volumes:
+    - name: host-vol
+      hostPath:
+        path: "/tmp"  # Host path volume
+
+```
+
+Usage
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/sparkpodlabeling/samples/spark-pod-labeling/example_multiple_violations.yaml
+```
+
+</details>
+
+
+</details>

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -44,6 +44,7 @@ module.exports = {
             'validation/requiredannotations',
             'validation/requiredlabels',
             'validation/requiredprobes',
+            'validation/sparkpodlabeling',
             'validation/storageclass',
             'validation/uniqueingresshost',
             'validation/uniqueserviceselector',


### PR DESCRIPTION
**What this PR does / why we need it**:

Enforces security and labeling requirements for Spark pods created by Spark service accounts. Validates that Spark pods have required labels (spark-job-id, spark-role), use allowed service accounts, run only approved container images, and follow security best practices by prohibiting privileged containers and host path volumes.

**Which issue(s) does this PR fix** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Library policies?**
Please refer to [How to contribute to the library](https://open-policy-agent.github.io/gatekeeper-library/website/#how-to-contribute-to-the-library) to add new policies or update existing policies.

**Are you updating an existing policy?**
Please run `make generate generate-website-docs generate-artifacthub-artifacts` to generate the templates and docs.
-->

**Special notes for your reviewer**:
