### PR TITLE
docs: adding JFrog OPA policy allowing evidence checking on images, policy …

### DIFF
--- a/library/general/jfrog-evidence/kustomization.yaml
+++ b/library/general/jfrog-evidence/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/jfrog-evidence/samples/jfrogcheckevidence/constraint.yaml
+++ b/library/general/jfrog-evidence/samples/jfrogcheckevidence/constraint.yaml
@@ -1,5 +1,5 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: jfrogcheckevidence
+kind: K8sJfrogCheckEvidence
 metadata:
   name: jfrog-check-evidence
 spec:

--- a/library/general/jfrog-evidence/samples/jfrogcheckevidence/constraint.yaml
+++ b/library/general/jfrog-evidence/samples/jfrogcheckevidence/constraint.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: jfrogcheckevidence
+metadata:
+  name: jfrog-check-evidence
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    checkedRegistries: ["my-jfrog-registry.jfrog.io"]
+    # add whitelist for repositories, uncomment to enable
+    # checkedRepositories: ["docker-local"]
+    checkedPredicateTypes: ["https://slsa.dev/provenance/v1"]

--- a/library/general/jfrog-evidence/samples/jfrogcheckevidence/example_allowed.yaml
+++ b/library/general/jfrog-evidence/samples/jfrogcheckevidence/example_allowed.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: your-jfrog-testing-pod
+spec:
+  containers:
+  - name: testing
+    image: my-jfrog-registry.jfrog.io/docker-local/your-valid-testing-image:1.0.0
+    imagePullPolicy: Always
+  imagePullSecrets: 
+  - name: jfrog-secret

--- a/library/general/jfrog-evidence/samples/jfrogcheckevidence/example_disallowed.yaml
+++ b/library/general/jfrog-evidence/samples/jfrogcheckevidence/example_disallowed.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: your-jfrog-testing-pod
+spec:
+  containers:
+  - name: testing
+    image: my-jfrog-registry.jfrog.io/docker-local/your-invalid-testing-image:1.0.0
+    imagePullPolicy: Always
+  imagePullSecrets: 
+  - name: jfrog-secret

--- a/library/general/jfrog-evidence/suite.yaml
+++ b/library/general/jfrog-evidence/suite.yaml
@@ -1,0 +1,18 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: replicalimits
+tests:
+- name: replica-limit
+  template: template.yaml
+  constraint: samples/jfrogcheckevidence/constraint.yaml
+  cases:
+  - name: example-allowed
+    object: samples/jfrogcheckevidence/example_allowed.yaml
+    assertions:
+    - violations: no
+  - name: example-disallowed
+    object: samples/jfrogcheckevidence/example_disallowed.yaml
+    assertions:
+    - violations: yes
+

--- a/library/general/jfrog-evidence/template.yaml
+++ b/library/general/jfrog-evidence/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
-  name: jfrogcheckevidence
+  name: k8sjfrogcheckevidence
   annotations:
     metadata.gatekeeper.sh/title: "Check JFrog Evidence"
     metadata.gatekeeper.sh/version: 1.0.0
@@ -12,89 +12,105 @@ spec:
   crd:
     spec:
       names:
-        kind: jfrogcheckevidence
+        kind: K8sJfrogCheckEvidence
       validation:
         openAPIV3Schema:
           type: object
           properties:
             checkedPredicateTypes:
               type: array
+              description: "The predicate types to check for evidence"
               items:
                 type: string
             checkedRegistries:
               type: array
+              description: "The registries for which to check for evidence"
               items:
                 type: string
             checkedRepositories: 
               type: array
+              description: "Optional, The repositories for which to check for evidence, remove parameter to check all repositories"
               items:
                 type: string
   targets:
-    - target: admission.k8s.gatekeeper.sh
-      code:
-      - engine: Rego
-        source: 
-          rego: |
-            package jfrogcheckevidence            
-            import data.lib.filter_images
-            import future.keywords.in
-            import future.keywords.contains
-            # get all images
-            all_images := [img | img = input.review.object.spec.containers[_].image]
-            target_images := [img | img = all_images[_]
-              filter_images.is_checked_registry(img)
-              filter_images.is_checked_repository(img)
-            ]
-            # get init images
-            init_images := [img | img = input.review.object.spec.initContainers[_].image]
-            target_init_images := [img | img = init_images[_]
-              filter_images.is_checked_registry(img)
-              filter_images.is_checked_repository(img)
-            ]
+    - target: admission.k8s.gatekeeper.sh      
+      rego: |
+        package k8sjfrogcheckevidence            
+        import data.lib.filter_images
+        import future.keywords.in
+        import future.keywords.contains
 
-            # append target_images, target_init_images
-            checked_images := array.concat(target_images, target_init_images)
-            # convert arreay input.parameters.checkedPredicateTypes to string
-            types := concat(",", input.parameters.checkedPredicateTypes)
-            typesArray := [types]
+        # fails if input.parameters.checkedRegistries is empty
+        violation[{"msg": msg}] {
+          not input.parameters.checkedRegistries
+          msg := "checkedRegistries parameter is empty"
+        }
 
-            checked_keys := array.concat(typesArray, checked_images)
-            violation[{"msg": msg}] {              
-              count(checked_images) > 0
-              response := external_data({"provider": "jfrog-evidence-opa-provider", "keys": checked_keys})
-              any_issues_found(response)
-              
-              msg := sprintf("TARGET IMAGES: %v, RESPONSE: %v", [checked_images, response])
-            }
+        # fails if input.parameters.checkedPredicateTypes is empty
+        violation[{"msg": msg}] {
+          not input.parameters.checkedPredicateTypes
+          msg := "checkedPredicateTypes parameter is empty"
+        }
 
-            any_issues_found(response) {
-              count(response.errors) > 0              
-            } else {
-              response.system_error != ""
-            } else {              
-              response_has_invalid(response)
-            }
+        # get all images
+        all_images := [img | img = input.review.object.spec.containers[_].image]
+        target_images := [img | img = all_images[_]
+          filter_images.is_checked_registry(img)
+          filter_images.is_checked_repository(img)
+        ]
+        # get init images
+        init_images := [img | img = input.review.object.spec.initContainers[_].image]
+        target_init_images := [img | img = init_images[_]
+          filter_images.is_checked_registry(img)
+          filter_images.is_checked_repository(img)
+        ]
+        
+        # append target_images, target_init_images        
+        checked_images := array.concat(target_images, target_init_images)
+        # convert arreay input.parameters.checkedPredicateTypes to string
+        types := concat(",", input.parameters.checkedPredicateTypes)
+        typesArray := [types]
 
-            response_has_invalid(response) {
-              some item in response.responses
-              count(item) == 2
-              item[1] == "_invalid"
-            }
-           
-            has_check_registry_images_parameter {
-              input.parameters.checkedRegistries != null
-            }
-          libs:
-            - |
-              package lib.filter_images    
-              import future.keywords.in
-              is_checked_registry(img) {
-                  checked_registries := object.get(object.get(input, "parameters", {}), "checkedRegistries", [])
-                  some registry in checked_registries
-                  startswith(img, registry)
-              }
-              is_checked_repository(img) {
-                  checked_repositories := object.get(object.get(input, "parameters", {}), "checkedRepositories", ["/"])
-                  some repository in checked_repositories      
-                  contains(img, repository)
-              }
+        checked_keys := array.concat(typesArray, checked_images)
+        violation[{"msg": msg}] {              
+          count(checked_images) > 0
+          response := external_data({"provider": "jfrog-evidence-opa-provider", "keys": checked_keys})
+          any_issues_found(response)
+                    
+          errors_count := count(response.errors)
+          system_error := response.system_error
+          invalid_images := [img | some item in response.responses
+                                  count(item) == 2
+                                  item[1] == "_invalid"
+                                  img := item[0]]
+          msg := sprintf("TARGET IMAGES: %v, ERROR_COUNT: %v, SYSTEM_ERROR: %v, INVALID_IMAGES: %v", [checked_images, errors_count, system_error, invalid_images])
+        }
+
+        any_issues_found(response) {
+          count(response.errors) > 0              
+        } else {
+          response.system_error != ""
+        } else {              
+          response_has_invalid(response)
+        }
+
+        response_has_invalid(response) {
+          some item in response.responses
+          count(item) == 2
+          item[1] == "_invalid"
+        }       
+        
+      libs:
+        - |
+          package lib.filter_images    
+          import future.keywords.in
+          is_checked_registry(img) {
+              checked_registries := object.get(object.get(input, "parameters", {}), "checkedRegistries", [])
+              some registry in checked_registries
+              startswith(img, registry)
+          }
+          is_checked_repository(img) {
+              checked_repositories := object.get(object.get(input, "parameters", {}), "checkedRepositories", ["/"])
+              some repository in checked_repositories      
+              contains(img, repository)
+          }

--- a/library/general/jfrog-evidence/template.yaml
+++ b/library/general/jfrog-evidence/template.yaml
@@ -1,0 +1,100 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: jfrogcheckevidence
+  annotations:
+    metadata.gatekeeper.sh/title: "Check JFrog Evidence"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Checks if the images in a pod comply with regulations or corporate policies by validating they have required verified evidence.
+      This policy is based on the JFrog OPA provider. To deploy JFrog OPA Provider, please visit: https://github.com/jfrog/jfrog-opa-policy
+spec:
+  crd:
+    spec:
+      names:
+        kind: jfrogcheckevidence
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            checkedPredicateTypes:
+              type: array
+              items:
+                type: string
+            checkedRegistries:
+              type: array
+              items:
+                type: string
+            checkedRepositories: 
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: Rego
+        source: 
+          rego: |
+            package jfrogcheckevidence            
+            import data.lib.filter_images
+            import future.keywords.in
+            import future.keywords.contains
+            # get all images
+            all_images := [img | img = input.review.object.spec.containers[_].image]
+            target_images := [img | img = all_images[_]
+              filter_images.is_checked_registry(img)
+              filter_images.is_checked_repository(img)
+            ]
+            # get init images
+            init_images := [img | img = input.review.object.spec.initContainers[_].image]
+            target_init_images := [img | img = init_images[_]
+              filter_images.is_checked_registry(img)
+              filter_images.is_checked_repository(img)
+            ]
+
+            # append target_images, target_init_images
+            checked_images := array.concat(target_images, target_init_images)
+            # convert arreay input.parameters.checkedPredicateTypes to string
+            types := concat(",", input.parameters.checkedPredicateTypes)
+            typesArray := [types]
+
+            checked_keys := array.concat(typesArray, checked_images)
+            violation[{"msg": msg}] {              
+              count(checked_images) > 0
+              response := external_data({"provider": "jfrog-evidence-opa-provider", "keys": checked_keys})
+              any_issues_found(response)
+              
+              msg := sprintf("TARGET IMAGES: %v, RESPONSE: %v", [checked_images, response])
+            }
+
+            any_issues_found(response) {
+              count(response.errors) > 0              
+            } else {
+              response.system_error != ""
+            } else {              
+              response_has_invalid(response)
+            }
+
+            response_has_invalid(response) {
+              some item in response.responses
+              count(item) == 2
+              item[1] == "_invalid"
+            }
+           
+            has_check_registry_images_parameter {
+              input.parameters.checkedRegistries != null
+            }
+          libs:
+            - |
+              package lib.filter_images    
+              import future.keywords.in
+              is_checked_registry(img) {
+                  checked_registries := object.get(object.get(input, "parameters", {}), "checkedRegistries", [])
+                  some registry in checked_registries
+                  startswith(img, registry)
+              }
+              is_checked_repository(img) {
+                  checked_repositories := object.get(object.get(input, "parameters", {}), "checkedRepositories", ["/"])
+                  some repository in checked_repositories      
+                  contains(img, repository)
+              }

--- a/src/general/jfrog-evidence/constraint.tmpl
+++ b/src/general/jfrog-evidence/constraint.tmpl
@@ -1,7 +1,7 @@
 apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
-  name: jfrogcheckevidence
+  name: k8sjfrogcheckevidence
   annotations:
     metadata.gatekeeper.sh/title: "Check JFrog Evidence"
     metadata.gatekeeper.sh/version: 1.0.0
@@ -12,7 +12,7 @@ spec:
   crd:
     spec:
       names:
-        kind: jfrogcheckevidence
+        kind: K8sJfrogCheckEvidence
       validation:
         openAPIV3Schema:
           type: object
@@ -31,8 +31,5 @@ spec:
                 type: string
   targets:
     - target: admission.k8s.gatekeeper.sh
-      code:
-      - engine: Rego
-        source: 
-          rego: |
+      rego: |
 {{ file.Read "src/general/jfrog-evidence/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/general/jfrog-evidence/constraint.tmpl
+++ b/src/general/jfrog-evidence/constraint.tmpl
@@ -1,0 +1,38 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: jfrogcheckevidence
+  annotations:
+    metadata.gatekeeper.sh/title: "Check JFrog Evidence"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Checks if the images in a pod comply with regulations or corporate policies by validating they have required verified evidence.
+      This policy is based on the JFrog OPA provider. To deploy JFrog OPA Provider, please visit: https://github.com/jfrog/jfrog-opa-policy
+spec:
+  crd:
+    spec:
+      names:
+        kind: jfrogcheckevidence
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            checkedPredicateTypes:
+              type: array
+              items:
+                type: string
+            checkedRegistries:
+              type: array
+              items:
+                type: string
+            checkedRepositories: 
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: Rego
+        source: 
+          rego: |
+{{ file.Read "src/general/jfrog-evidence/src.rego" | strings.Indent 8 | strings.TrimSuffix "\n" }}

--- a/src/general/jfrog-evidence/src.rego
+++ b/src/general/jfrog-evidence/src.rego
@@ -1,0 +1,63 @@
+package jfrogcheckevidence            
+import data.lib.filter_images
+import future.keywords.in
+import future.keywords.contains
+# get all images
+all_images := [img | img = input.review.object.spec.containers[_].image]
+target_images := [img | img = all_images[_]
+    filter_images.is_checked_registry(img)
+    filter_images.is_checked_repository(img)
+]
+# get init images
+init_images := [img | img = input.review.object.spec.initContainers[_].image]
+target_init_images := [img | img = init_images[_]
+    filter_images.is_checked_registry(img)
+    filter_images.is_checked_repository(img)
+]
+
+# append target_images, target_init_images
+checked_images := array.concat(target_images, target_init_images)
+# convert arreay input.parameters.checkedPredicateTypes to string
+types := concat(",", input.parameters.checkedPredicateTypes)
+typesArray := [types]
+
+checked_keys := array.concat(typesArray, checked_images)
+violation[{"msg": msg}] {              
+    count(checked_images) > 0
+    response := external_data({"provider": "jfrog-evidence-opa-provider", "keys": checked_keys})
+    any_issues_found(response)
+    
+    msg := sprintf("TARGET IMAGES: %v, RESPONSE: %v", [checked_images, response])
+}
+
+any_issues_found(response) {
+    count(response.errors) > 0              
+} else {
+    response.system_error != ""
+} else {              
+    response_has_invalid(response)
+}
+
+response_has_invalid(response) {
+    some item in response.responses
+    count(item) == 2
+    item[1] == "_invalid"
+}
+
+has_check_registry_images_parameter {
+    input.parameters.checkedRegistries != null
+}
+libs:
+- |
+    package lib.filter_images    
+    import future.keywords.in
+    is_checked_registry(img) {
+        checked_registries := object.get(object.get(input, "parameters", {}), "checkedRegistries", [])
+        some registry in checked_registries
+        startswith(img, registry)
+    }
+    is_checked_repository(img) {
+        checked_repositories := object.get(object.get(input, "parameters", {}), "checkedRepositories", ["/"])
+        some repository in checked_repositories      
+        contains(img, repository)
+    }

--- a/src/general/jfrog-evidence/src.rego
+++ b/src/general/jfrog-evidence/src.rego
@@ -1,7 +1,20 @@
-package jfrogcheckevidence            
+package k8sjfrogcheckevidence            
 import data.lib.filter_images
 import future.keywords.in
 import future.keywords.contains
+
+# fails if input.parameters.checkedRegistries is empty
+violation[{"msg": msg}] {
+    not input.parameters.checkedRegistries
+    msg := "checkedRegistries parameter is empty"
+}
+
+# fails if input.parameters.checkedPredicateTypes is empty
+violation[{"msg": msg}] {
+    not input.parameters.checkedPredicateTypes
+    msg := "checkedPredicateTypes parameter is empty"
+}
+
 # get all images
 all_images := [img | img = input.review.object.spec.containers[_].image]
 target_images := [img | img = all_images[_]
@@ -15,7 +28,7 @@ target_init_images := [img | img = init_images[_]
     filter_images.is_checked_repository(img)
 ]
 
-# append target_images, target_init_images
+# append target_images, target_init_images        
 checked_images := array.concat(target_images, target_init_images)
 # convert arreay input.parameters.checkedPredicateTypes to string
 types := concat(",", input.parameters.checkedPredicateTypes)
@@ -26,8 +39,14 @@ violation[{"msg": msg}] {
     count(checked_images) > 0
     response := external_data({"provider": "jfrog-evidence-opa-provider", "keys": checked_keys})
     any_issues_found(response)
-    
-    msg := sprintf("TARGET IMAGES: %v, RESPONSE: %v", [checked_images, response])
+            
+    errors_count := count(response.errors)
+    system_error := response.system_error
+    invalid_images := [img | some item in response.responses
+                            count(item) == 2
+                            item[1] == "_invalid"
+                            img := item[0]]
+    msg := sprintf("TARGET IMAGES: %v, ERROR_COUNT: %v, SYSTEM_ERROR: %v, INVALID_IMAGES: %v", [checked_images, errors_count, system_error, invalid_images])
 }
 
 any_issues_found(response) {
@@ -42,11 +61,8 @@ response_has_invalid(response) {
     some item in response.responses
     count(item) == 2
     item[1] == "_invalid"
-}
+}       
 
-has_check_registry_images_parameter {
-    input.parameters.checkedRegistries != null
-}
 libs:
 - |
     package lib.filter_images    


### PR DESCRIPTION
…is based on JFog OPA provider

This PR adds a policy allowing users to verify that all images used within a pod comply with the company's regulations requirements. 
All images' evidence that were stored in JFrog Artifactory are retrieved and verified according to the user's policy.
This policy requires the user to have JFrog artifactory, JFrog OPA provider installed (see under https://github.com/jfrog/jfrog-opa-policy)

**Special notes for your reviewer**:
Since external_data is in the heart of this policy, we are unable to add src_test.rego, additionally, as the policy is communicating with an installed provider and through it with a JFrog Artifactory platform, samples cannot be used without personalization of the image registry and location for allowing the test to run on the user's platform