### PR TITLE
fix: bump Go version in generate-catalog workflow to 1.25

### DIFF
--- a/.github/workflows/generate-catalog.yaml
+++ b/.github/workflows/generate-catalog.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           check-latest: true
 
       - name: Build gator


### PR DESCRIPTION
## Problem

The `generate_catalog` workflow fails on all PRs with:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

This is because gatekeeper master's `go.mod` now requires `go 1.25.0`, but the workflow installs Go 1.24.

## Fix

Bump `go-version` from `"1.24"` to `"1.25"` in `.github/workflows/generate-catalog.yaml`.

## Impact

This is a one-line change that unblocks all PRs. No functional changes.