### PR TITLE
Fix PDB label selectors

### DIFF
--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/artifacthub-pkg.yml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/artifacthub-pkg.yml
@@ -1,0 +1,25 @@
+version: 1.0.5
+name: k8spoddisruptionbudget
+displayName: Pod Disruption Budget
+createdAt: "2026-06-23T11:44:53Z"
+description: |-
+    Disallow the following scenarios when deploying PodDisruptionBudgets or resources that implement the replica subresource (e.g. Deployment, ReplicationController, ReplicaSet, StatefulSet): 1. Deployment of PodDisruptionBudgets with .spec.maxUnavailable == 0 2. Deployment of PodDisruptionBudgets with .spec.minAvailable == .spec.replicas of the resource with replica subresource This will prevent PodDisruptionBudgets from blocking voluntary disruptions such as node draining.
+    https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+digest: 3a184a16d293c7c23740cce1101f28b03c9edf0d4af6d91195f4ad96062e4061
+license: Apache-2.0
+homeURL: https://open-policy-agent.github.io/gatekeeper-library/website/poddisruptionbudget
+keywords:
+    - gatekeeper
+    - open-policy-agent
+    - policies
+readme: |-
+    # Pod Disruption Budget
+    Disallow the following scenarios when deploying PodDisruptionBudgets or resources that implement the replica subresource (e.g. Deployment, ReplicationController, ReplicaSet, StatefulSet): 1. Deployment of PodDisruptionBudgets with .spec.maxUnavailable == 0 2. Deployment of PodDisruptionBudgets with .spec.minAvailable == .spec.replicas of the resource with replica subresource This will prevent PodDisruptionBudgets from blocking voluntary disruptions such as node draining.
+    https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+install: |-
+    ### Usage
+    ```shell
+    kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/artifacthub/library/general/poddisruptionbudget/1.0.5/template.yaml
+    ```
+provider:
+    name: Gatekeeper Library

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/kustomization.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/constraint.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/constraint.yaml
@@ -1,0 +1,13 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPodDisruptionBudget
+metadata:
+  name: pod-distruption-budget
+spec:
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet"]
+      - apiGroups: ["policy"]
+        kinds: ["PodDisruptionBudget"]
+      - apiGroups: [""]
+        kinds: ["ReplicationController"]

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_allowed_deployment1.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_allowed_deployment1.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-allowed-1
+  namespace: default
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+      example: allowed-deployment-1
+  template:
+    metadata:
+      labels:
+        app: nginx
+        example: allowed-deployment-1
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_allowed_deployment2.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_allowed_deployment2.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-allowed-2
+  namespace: default
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+      example: allowed-deployment-2
+  template:
+    metadata:
+      labels:
+        app: nginx
+        example: allowed-deployment-2
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_allowed_deployment3.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_allowed_deployment3.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-allowed-3
+  namespace: default
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+      example: allowed-deployment-3
+  template:
+    metadata:
+      labels:
+        app: nginx
+        example: allowed-deployment-3
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_allowed_deployment4.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_allowed_deployment4.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-allowed-4
+  namespace: default
+  labels:
+    app: non-matching-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: non-matching-nginx
+      example: allowed-deployment-4
+  template:
+    metadata:
+      labels:
+        app: non-matching-nginx
+        example: allowed-deployment-4
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_allowed_pdb.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_allowed_pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: nginx-pdb-allowed
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      foo: bar

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_disallowed_deployment.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_disallowed_deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-disallowed
+  namespace: default
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+      example: disallowed-deployment
+  template:
+    metadata:
+      labels:
+        app: nginx
+        example: disallowed-deployment
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_disallowed_pdb.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_disallowed_pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: nginx-pdb-disallowed
+  namespace: default
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      foo: bar

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_inventory_allowed1.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_inventory_allowed1.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: inventory-nginx-pdb-allowed-1
+  namespace: default
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: nginx
+      example: allowed-deployment-1

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_inventory_allowed2.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_inventory_allowed2.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: inventory-nginx-pdb-allowed-2
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+      example: allowed-deployment-2

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_inventory_allowed3.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_inventory_allowed3.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: inventory-nginx-pdb-allowed-3
+  namespace: default
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: nginx

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_inventory_allowed4.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_inventory_allowed4.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: inventory-mongo-pdb-allowed-3
+  namespace: default
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: mongo
+      example: non-matching-deployment-3

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_inventory_disallowed.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/samples/poddisruptionbudget/example_inventory_disallowed.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: inventory-nginx-pdb-disallowed
+  namespace: default
+spec:
+  minAvailable: 3
+  selector:
+    matchLabels:
+      app: nginx
+      example: disallowed-deployment

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/suite.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/suite.yaml
@@ -1,0 +1,47 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: poddisruptionbudget
+tests:
+- name: pod-disruption-budget
+  template: template.yaml
+  constraint: samples/poddisruptionbudget/constraint.yaml
+  cases:
+  - name: example-allowed-pdb
+    object: samples/poddisruptionbudget/example_allowed_pdb.yaml
+    assertions:
+    - violations: no
+  - name: example-disallowed-pdb
+    object: samples/poddisruptionbudget/example_disallowed_pdb.yaml
+    assertions:
+    - violations: yes
+  - name: example-allowed-min-available
+    object: samples/poddisruptionbudget/example_allowed_deployment1.yaml
+    inventory:
+    - samples/poddisruptionbudget/example_inventory_allowed1.yaml
+    assertions:
+    - violations: no
+  - name: example-allowed-max-unavailable
+    object: samples/poddisruptionbudget/example_allowed_deployment2.yaml
+    inventory:
+    - samples/poddisruptionbudget/example_inventory_allowed2.yaml
+    assertions:
+    - violations: no
+  - name: example-allowed-subset-selector
+    object: samples/poddisruptionbudget/example_allowed_deployment3.yaml
+    inventory:
+    - samples/poddisruptionbudget/example_inventory_allowed3.yaml
+    assertions:
+    - violations: no
+  - name: example-allowed-nomatch-selector
+    object: samples/poddisruptionbudget/example_allowed_deployment4.yaml
+    inventory:
+    - samples/poddisruptionbudget/example_inventory_allowed4.yaml
+    assertions:
+    - violations: no
+  - name: example-disallowed-min-available
+    object: samples/poddisruptionbudget/example_disallowed_deployment.yaml
+    inventory:
+    - samples/poddisruptionbudget/example_inventory_disallowed.yaml
+    assertions:
+    - violations: yes

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/sync.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/sync.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.gatekeeper.sh/v1alpha1
+kind: Config
+metadata:
+  name: config
+  namespace: "gatekeeper-system"
+spec:
+  sync:
+    syncOnly:
+      - group: "policy"
+        version: "v1"
+        kind: "PodDisruptionBudget"

--- a/artifacthub/library/general/poddisruptionbudget/1.0.5/template.yaml
+++ b/artifacthub/library/general/poddisruptionbudget/1.0.5/template.yaml
@@ -61,7 +61,7 @@ spec:
         violation[{"msg": msg}] {
           obj := input.review.object
           pdb := data.inventory.namespace[obj.metadata.namespace]["policy/v1"].PodDisruptionBudget[_]
-          
+
           matchLabels := { [label, value] | some label; value := pdb.spec.selector.matchLabels[label] }
           labels := { [label, value] | some label; value := obj.spec.template.metadata.labels[label] }
           count(matchLabels - labels) == 0

--- a/src/general/poddisruptionbudget/constraint.tmpl
+++ b/src/general/poddisruptionbudget/constraint.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: k8spoddisruptionbudget
   annotations:
     metadata.gatekeeper.sh/title: "Pod Disruption Budget"
-    metadata.gatekeeper.sh/version: 1.0.4
+    metadata.gatekeeper.sh/version: 1.0.5
     metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [

--- a/src/general/poddisruptionbudget/src.rego
+++ b/src/general/poddisruptionbudget/src.rego
@@ -16,7 +16,7 @@ violation[{"msg": msg}] {
   pdb := data.inventory.namespace[obj.metadata.namespace]["policy/v1"].PodDisruptionBudget[_]
 
   matchLabels := { [label, value] | some label; value := pdb.spec.selector.matchLabels[label] }
-  labels := { [label, value] | some label; value := obj.spec.selector.matchLabels[label] }
+  labels := { [label, value] | some label; value := obj.spec.template.metadata.labels[label] }
   count(matchLabels - labels) == 0
 
   not valid_pdb_max_unavailable(pdb)
@@ -31,7 +31,7 @@ violation[{"msg": msg}] {
   pdb := data.inventory.namespace[obj.metadata.namespace]["policy/v1"].PodDisruptionBudget[_]
   
   matchLabels := { [label, value] | some label; value := pdb.spec.selector.matchLabels[label] }
-  labels := { [label, value] | some label; value := obj.spec.selector.matchLabels[label] }
+  labels := { [label, value] | some label; value := obj.spec.template.metadata.labels[label] }
   count(matchLabels - labels) == 0
 
   not valid_pdb_min_available(obj, pdb)

--- a/src/general/poddisruptionbudget/src_test.rego
+++ b/src/general/poddisruptionbudget/src_test.rego
@@ -7,6 +7,8 @@ match_labels := {"matchLabels": {
   "key2": "val2",
 }}
 
+labels := object.union(match_labels["matchLabels"], {"key3": "val3"})
+
 test_input_pdb_0_max_unavailable {
   inp := {"review": input_pdb_max_unavailable(0)}
   results := violation with input as inp
@@ -47,6 +49,13 @@ test_input_deployment_pdb_1_max_unavailable {
   count(results) == 0
 }
 
+test_input_deployment_pdb_matches_template_labels_not_selector {
+  inp := {"review": input_deployment_with_selector(1, match_labels["matchLabels"])}
+  inv := inv_pdb_min_available_with_selector(1, {"matchLabels": {"key3": "val3"}})
+  results := violation with input as inp with data.inventory as inv
+  count(results) == 1
+}
+
 pdb_min_available(min_available) = output {
   output := {
     "apiVersion": "policy/v1",
@@ -57,6 +66,21 @@ pdb_min_available(min_available) = output {
     },
     "spec": {
       "selector": match_labels,
+      "minAvailable": min_available,
+    },
+  }
+}
+
+pdb_min_available_with_selector(min_available, selector) = output {
+  output := {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "name": "pdb-1",
+      "namespace": "namespace-1",
+    },
+    "spec": {
+      "selector": selector,
       "minAvailable": min_available,
     },
   }
@@ -77,6 +101,28 @@ pdb_max_unavailable(max_unavailable) = output {
   }
 }
 
+deployment_with_selector(replicas, selector) = output {
+  output := {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "name": "deployment-1",
+      "namespace": "namespace-1",
+    },
+    "spec": {
+      "replicas": replicas,
+      "selector": {
+        "matchLabels": selector,
+      },
+      "template": {
+        "metadata": {
+          "labels": labels,
+        }
+      }
+    },
+  }
+}
+
 deployment(replicas) = output {
   output := {
     "apiVersion": "apps/v1",
@@ -87,8 +133,19 @@ deployment(replicas) = output {
     },
     "spec": {
       "replicas": replicas,
-      "selector": match_labels,
+      "template": {
+        "metadata": {
+          "labels": labels,
+        }
+      }
     },
+  }
+}
+
+input_deployment_with_selector(replicas, selector) = output {
+  output := {
+    "kind": {"kind": "Deployment"},
+    "object": deployment_with_selector(replicas, selector),
   }
 }
 
@@ -112,6 +169,11 @@ inventory(obj) = output {
 
 inv_pdb_min_available(min_available) = output {
   pdb = pdb_min_available(min_available)
+  output := inventory(pdb)
+}
+
+inv_pdb_min_available_with_selector(min_available, selector) = output {
+  pdb = pdb_min_available_with_selector(min_available, selector)
   output := inventory(pdb)
 }
 

--- a/website/docs/validation/poddisruptionbudget.md
+++ b/website/docs/validation/poddisruptionbudget.md
@@ -17,7 +17,7 @@ metadata:
   name: k8spoddisruptionbudget
   annotations:
     metadata.gatekeeper.sh/title: "Pod Disruption Budget"
-    metadata.gatekeeper.sh/version: 1.0.4
+    metadata.gatekeeper.sh/version: 1.0.5
     metadata.gatekeeper.sh/requires-sync-data: |
       "[
         [
@@ -61,7 +61,7 @@ spec:
           pdb := data.inventory.namespace[obj.metadata.namespace]["policy/v1"].PodDisruptionBudget[_]
 
           matchLabels := { [label, value] | some label; value := pdb.spec.selector.matchLabels[label] }
-          labels := { [label, value] | some label; value := obj.spec.selector.matchLabels[label] }
+          labels := { [label, value] | some label; value := obj.spec.template.metadata.labels[label] }
           count(matchLabels - labels) == 0
 
           not valid_pdb_max_unavailable(pdb)
@@ -76,7 +76,7 @@ spec:
           pdb := data.inventory.namespace[obj.metadata.namespace]["policy/v1"].PodDisruptionBudget[_]
           
           matchLabels := { [label, value] | some label; value := pdb.spec.selector.matchLabels[label] }
-          labels := { [label, value] | some label; value := obj.spec.selector.matchLabels[label] }
+          labels := { [label, value] | some label; value := obj.spec.template.metadata.labels[label] }
           count(matchLabels - labels) == 0
 
           not valid_pdb_min_available(obj, pdb)


### PR DESCRIPTION
**What this PR does / why we need it**:
The actual matching between PDB and deployment is based on the pod template labels (`spec.template.metadata.labels`) rather than on the configured label selector (`.spec.slector.matchLabels`). The template can have more labels than the matchLabel selects on and PDB would still apply in such a case.

**Which issue(s) does this PR fix**:
fixes #755

<!--
**Are you making changes to Gatekeeper Library policies?**
Please refer to [How to contribute to the library](https://open-policy-agent.github.io/gatekeeper-library/website/#how-to-contribute-to-the-library) to add new policies or update existing policies.

**Are you updating an existing policy?**
Please run `make generate generate-website-docs generate-artifacthub-artifacts` to generate the templates and docs.
-->


**Special notes for your reviewer**:
Disclaimer: This is my first contribution to upstream gatekeeper library. 