### PR TITLE
feat: add AI workload governance policies (audit controls, approved registry, network egress)

### DIFF
--- a/library/general/aiapprovedmodelregistry/kustomization.yaml
+++ b/library/general/aiapprovedmodelregistry/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/aiapprovedmodelregistry/samples/ai-model-approved-registry/constraint.yaml
+++ b/library/general/aiapprovedmodelregistry/samples/ai-model-approved-registry/constraint.yaml
@@ -1,0 +1,17 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAIApprovedModelRegistry
+metadata:
+  name: ai-model-approved-registry
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    labelSelector:
+      matchLabels:
+        workload-type: ai-model
+  parameters:
+    approvedRegistries:
+      - "model-registry.example.com/"
+      - "ghcr.io/myorg/models/"
+    requireDigestPin: true

--- a/library/general/aiapprovedmodelregistry/samples/ai-model-approved-registry/example_allowed.yaml
+++ b/library/general/aiapprovedmodelregistry/samples/ai-model-approved-registry/example_allowed.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-approved
+  labels:
+    workload-type: ai-model
+spec:
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1@sha256:abc123def456789abcdef
+      resources:
+        limits:
+          cpu: "4"
+          memory: "16Gi"

--- a/library/general/aiapprovedmodelregistry/samples/ai-model-approved-registry/example_disallowed_init_registry.yaml
+++ b/library/general/aiapprovedmodelregistry/samples/ai-model-approved-registry/example_disallowed_init_registry.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-init-unapproved
+  labels:
+    workload-type: ai-model
+spec:
+  initContainers:
+    - name: model-downloader
+      image: docker.io/someuser/downloader:latest
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1@sha256:abc123def456789abcdef
+      resources:
+        limits:
+          cpu: "4"
+          memory: "16Gi"

--- a/library/general/aiapprovedmodelregistry/samples/ai-model-approved-registry/example_disallowed_registry.yaml
+++ b/library/general/aiapprovedmodelregistry/samples/ai-model-approved-registry/example_disallowed_registry.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-unapproved-registry
+  labels:
+    workload-type: ai-model
+spec:
+  containers:
+    - name: model-server
+      image: docker.io/someuser/mymodel:latest
+      resources:
+        limits:
+          cpu: "4"
+          memory: "16Gi"

--- a/library/general/aiapprovedmodelregistry/samples/ai-model-approved-registry/example_disallowed_unpinned.yaml
+++ b/library/general/aiapprovedmodelregistry/samples/ai-model-approved-registry/example_disallowed_unpinned.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-unpinned-tag
+  labels:
+    workload-type: ai-model
+spec:
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1
+      resources:
+        limits:
+          cpu: "4"
+          memory: "16Gi"

--- a/library/general/aiapprovedmodelregistry/suite.yaml
+++ b/library/general/aiapprovedmodelregistry/suite.yaml
@@ -21,3 +21,8 @@ tests:
     assertions:
     - violations: yes
       message: "digest-pinned"
+  - name: init-container-unapproved-registry
+    object: samples/ai-model-approved-registry/example_disallowed_init_registry.yaml
+    assertions:
+    - violations: yes
+      message: "not from an approved model registry"

--- a/library/general/aiapprovedmodelregistry/suite.yaml
+++ b/library/general/aiapprovedmodelregistry/suite.yaml
@@ -1,0 +1,23 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: aiapprovedmodelregistry
+tests:
+- name: ai-model-approved-registry
+  template: template.yaml
+  constraint: samples/ai-model-approved-registry/constraint.yaml
+  cases:
+  - name: example-allowed
+    object: samples/ai-model-approved-registry/example_allowed.yaml
+    assertions:
+    - violations: no
+  - name: unapproved-registry
+    object: samples/ai-model-approved-registry/example_disallowed_registry.yaml
+    assertions:
+    - violations: yes
+      message: "not from an approved model registry"
+  - name: unpinned-digest
+    object: samples/ai-model-approved-registry/example_disallowed_unpinned.yaml
+    assertions:
+    - violations: yes
+      message: "digest-pinned"

--- a/library/general/aiapprovedmodelregistry/template.yaml
+++ b/library/general/aiapprovedmodelregistry/template.yaml
@@ -38,12 +38,20 @@ spec:
       - engine: K8sNativeValidation
         source:
           variables:
+          - name: containers
+            expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.containers) ? variables.anyObject.spec.containers : []'
+          - name: initContainers
+            expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.initContainers) ? variables.anyObject.spec.initContainers : []'
+          - name: ephemeralContainers
+            expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.ephemeralContainers) ? variables.anyObject.spec.ephemeralContainers : []'
+          - name: allContainers
+            expression: 'variables.containers + variables.initContainers + variables.ephemeralContainers'
           - name: approvedRegistries
             expression: 'has(variables.params.approvedRegistries) ? variables.params.approvedRegistries : []'
           validations:
-          - expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.approvedRegistries.size() == 0 || variables.anyObject.spec.containers.all(c, variables.approvedRegistries.exists(r, c.image.startsWith(r)))'
+          - expression: 'variables.approvedRegistries.size() == 0 || variables.allContainers.all(c, variables.approvedRegistries.exists(r, c.image.startsWith(r)))'
             messageExpression: '"Container image is not from an approved model registry. Approved prefixes: " + variables.approvedRegistries.join(", ")'
-          - expression: '!has(variables.params.requireDigestPin) || variables.params.requireDigestPin != true || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, c.image.contains("@sha256:"))'
+          - expression: '!has(variables.params.requireDigestPin) || variables.params.requireDigestPin != true || variables.allContainers.all(c, c.image.contains("@sha256:"))'
             message: "AI workload container image must be digest-pinned (append @sha256:<digest>)"
       - engine: Rego
         source:

--- a/library/general/aiapprovedmodelregistry/template.yaml
+++ b/library/general/aiapprovedmodelregistry/template.yaml
@@ -37,9 +37,12 @@ spec:
       code:
       - engine: K8sNativeValidation
         source:
+          variables:
+          - name: approvedRegistries
+            expression: 'has(variables.params.approvedRegistries) ? variables.params.approvedRegistries : []'
           validations:
-          - expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, variables.params.approvedRegistries.exists(r, c.image.startsWith(r)))'
-            messageExpression: '"Container image is not from an approved model registry. Approved prefixes: " + variables.params.approvedRegistries.join(", ")'
+          - expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.approvedRegistries.size() == 0 || variables.anyObject.spec.containers.all(c, variables.approvedRegistries.exists(r, c.image.startsWith(r)))'
+            messageExpression: '"Container image is not from an approved model registry. Approved prefixes: " + variables.approvedRegistries.join(", ")'
           - expression: '!has(variables.params.requireDigestPin) || variables.params.requireDigestPin != true || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, c.image.contains("@sha256:"))'
             message: "AI workload container image must be digest-pinned (append @sha256:<digest>)"
       - engine: Rego

--- a/library/general/aiapprovedmodelregistry/template.yaml
+++ b/library/general/aiapprovedmodelregistry/template.yaml
@@ -1,0 +1,89 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8saiapprovedmodelregistry
+  annotations:
+    metadata.gatekeeper.sh/title: "AI Approved Model Registry"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Requires AI workload container images to originate from operator-approved
+      model registries. Optionally enforces digest pinning (@sha256:) to prevent
+      floating tags and supply-chain substitution attacks.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAIApprovedModelRegistry
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            approvedRegistries:
+              description: >-
+                List of approved model registry prefixes. Container images must
+                begin with one of these strings. Add a trailing '/' to prevent
+                prefix-spoofing (e.g. "model-registry.example.com/" not
+                "model-registry.example.com").
+              type: array
+              items:
+                type: string
+            requireDigestPin:
+              description: >-
+                If true, all container images must be pinned with a @sha256:
+                digest to prevent floating-tag substitution.
+              type: boolean
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+          validations:
+          - expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, variables.params.approvedRegistries.exists(r, c.image.startsWith(r)))'
+            messageExpression: '"Container image is not from an approved model registry. Approved prefixes: " + variables.params.approvedRegistries.join(", ")'
+          - expression: '!has(variables.params.requireDigestPin) || variables.params.requireDigestPin != true || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, c.image.contains("@sha256:"))'
+            message: "AI workload container image must be digest-pinned (append @sha256:<digest>)"
+      - engine: Rego
+        source:
+          rego: |
+            package k8saiapprovedmodelregistry
+
+            # Require container images to start with an approved model registry prefix.
+            violation[{"msg": msg}] {
+              container := input.review.object.spec.containers[_]
+              not strings.any_prefix_match(container.image, input.parameters.approvedRegistries)
+              msg := sprintf("container <%v> image <%v> is not from an approved model registry; allowed prefixes: %v", [container.name, container.image, input.parameters.approvedRegistries])
+            }
+
+            violation[{"msg": msg}] {
+              container := input.review.object.spec.initContainers[_]
+              not strings.any_prefix_match(container.image, input.parameters.approvedRegistries)
+              msg := sprintf("initContainer <%v> image <%v> is not from an approved model registry; allowed prefixes: %v", [container.name, container.image, input.parameters.approvedRegistries])
+            }
+
+            violation[{"msg": msg}] {
+              container := input.review.object.spec.ephemeralContainers[_]
+              not strings.any_prefix_match(container.image, input.parameters.approvedRegistries)
+              msg := sprintf("ephemeralContainer <%v> image <%v> is not from an approved model registry; allowed prefixes: %v", [container.name, container.image, input.parameters.approvedRegistries])
+            }
+
+            # Optionally require images to be digest-pinned with @sha256:.
+            violation[{"msg": msg}] {
+              input.parameters.requireDigestPin == true
+              container := input.review.object.spec.containers[_]
+              not contains(container.image, "@sha256:")
+              msg := sprintf("container <%v> image <%v> must be digest-pinned (append @sha256:<digest>)", [container.name, container.image])
+            }
+
+            violation[{"msg": msg}] {
+              input.parameters.requireDigestPin == true
+              container := input.review.object.spec.initContainers[_]
+              not contains(container.image, "@sha256:")
+              msg := sprintf("initContainer <%v> image <%v> must be digest-pinned (append @sha256:<digest>)", [container.name, container.image])
+            }
+
+            violation[{"msg": msg}] {
+              input.parameters.requireDigestPin == true
+              container := input.review.object.spec.ephemeralContainers[_]
+              not contains(container.image, "@sha256:")
+              msg := sprintf("ephemeralContainer <%v> image <%v> must be digest-pinned (append @sha256:<digest>)", [container.name, container.image])
+            }

--- a/library/general/ainetworkegress/kustomization.yaml
+++ b/library/general/ainetworkegress/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/ainetworkegress/samples/ai-workload-network-controls/constraint.yaml
+++ b/library/general/ainetworkegress/samples/ai-workload-network-controls/constraint.yaml
@@ -1,0 +1,17 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAINetworkEgress
+metadata:
+  name: ai-workload-network-controls
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    labelSelector:
+      matchLabels:
+        workload-type: ai-model
+  parameters:
+    blockHostNetwork: true
+    requiredEgressLabels:
+      - key: "network-policy/ai-egress"
+        value: "enforced"

--- a/library/general/ainetworkegress/samples/ai-workload-network-controls/example_allowed.yaml
+++ b/library/general/ainetworkegress/samples/ai-workload-network-controls/example_allowed.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-network-compliant
+  labels:
+    workload-type: ai-model
+    network-policy/ai-egress: "enforced"
+spec:
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1@sha256:abc123def456789
+      resources:
+        limits:
+          cpu: "4"
+          memory: "16Gi"

--- a/library/general/ainetworkegress/samples/ai-workload-network-controls/example_disallowed_host_network.yaml
+++ b/library/general/ainetworkegress/samples/ai-workload-network-controls/example_disallowed_host_network.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-host-network
+  labels:
+    workload-type: ai-model
+    network-policy/ai-egress: "enforced"
+spec:
+  hostNetwork: true
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1
+      resources:
+        limits:
+          cpu: "4"
+          memory: "16Gi"

--- a/library/general/ainetworkegress/samples/ai-workload-network-controls/example_disallowed_no_egress_label.yaml
+++ b/library/general/ainetworkegress/samples/ai-workload-network-controls/example_disallowed_no_egress_label.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-no-egress-label
+  labels:
+    workload-type: ai-model
+spec:
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1
+      resources:
+        limits:
+          cpu: "4"
+          memory: "16Gi"

--- a/library/general/ainetworkegress/samples/ai-workload-network-controls/example_disallowed_wrong_label_value.yaml
+++ b/library/general/ainetworkegress/samples/ai-workload-network-controls/example_disallowed_wrong_label_value.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-wrong-egress-value
+  labels:
+    workload-type: ai-model
+    network-policy/ai-egress: "disabled"
+spec:
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1
+      resources:
+        limits:
+          cpu: "4"
+          memory: "16Gi"

--- a/library/general/ainetworkegress/suite.yaml
+++ b/library/general/ainetworkegress/suite.yaml
@@ -21,3 +21,8 @@ tests:
     assertions:
     - violations: yes
       message: "egress label"
+  - name: wrong-egress-label-value
+    object: samples/ai-workload-network-controls/example_disallowed_wrong_label_value.yaml
+    assertions:
+    - violations: yes
+      message: "egress label"

--- a/library/general/ainetworkegress/suite.yaml
+++ b/library/general/ainetworkegress/suite.yaml
@@ -1,0 +1,23 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: ainetworkegress
+tests:
+- name: ai-workload-network-controls
+  template: template.yaml
+  constraint: samples/ai-workload-network-controls/constraint.yaml
+  cases:
+  - name: example-allowed
+    object: samples/ai-workload-network-controls/example_allowed.yaml
+    assertions:
+    - violations: no
+  - name: host-network-disallowed
+    object: samples/ai-workload-network-controls/example_disallowed_host_network.yaml
+    assertions:
+    - violations: yes
+      message: "hostNetwork"
+  - name: missing-egress-label
+    object: samples/ai-workload-network-controls/example_disallowed_no_egress_label.yaml
+    assertions:
+    - violations: yes
+      message: "egress label"

--- a/library/general/ainetworkegress/template.yaml
+++ b/library/general/ainetworkegress/template.yaml
@@ -1,0 +1,86 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sainetworkegress
+  annotations:
+    metadata.gatekeeper.sh/title: "AI Workload Network Egress Controls"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Enforces network egress controls on AI workload pods: optionally blocks
+      spec.hostNetwork=true (which bypasses NetworkPolicy), and requires pods
+      to carry labels that declare their NetworkPolicy binding, ensuring a
+      matching NetworkPolicy selector exists before the pod is admitted.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAINetworkEgress
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            blockHostNetwork:
+              description: >-
+                If true, reject pods with spec.hostNetwork=true. hostNetwork
+                gives the pod direct access to the node network and bypasses
+                all NetworkPolicy egress rules.
+              type: boolean
+            requiredEgressLabels:
+              description: >-
+                Labels that must be present on AI workload pods to declare their
+                NetworkPolicy binding. Use these labels as selectors in the
+                corresponding NetworkPolicy to ensure egress is controlled.
+                Specify key and optional value; leave value empty to require
+                the label key with any value.
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: The label key.
+                  value:
+                    type: string
+                    description: Required label value. Empty means any value is accepted.
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+          validations:
+          - expression: '!has(variables.params.blockHostNetwork) || variables.params.blockHostNetwork != true || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.hostNetwork) || !variables.anyObject.spec.hostNetwork'
+            message: "AI workload pod must not use spec.hostNetwork=true; it bypasses NetworkPolicy egress controls"
+          - expression: '!has(variables.anyObject.metadata) || variables.params.requiredEgressLabels.all(lbl, has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)'
+            messageExpression: '"AI workload pod is missing required network egress label(s): " + variables.params.requiredEgressLabels.filter(lbl, !(has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)).map(lbl, lbl.key).join(", ")'
+          - expression: '!has(variables.anyObject.metadata) || variables.params.requiredEgressLabels.all(lbl, !has(lbl.value) || lbl.value == "" || (has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels && variables.anyObject.metadata.labels[lbl.key] == lbl.value))'
+            message: "Network egress label value does not match the required value"
+      - engine: Rego
+        source:
+          rego: |
+            package k8sainetworkegress
+
+            # Block hostNetwork on AI workload pods when configured.
+            # hostNetwork=true bypasses all NetworkPolicy egress controls.
+            violation[{"msg": msg}] {
+              input.parameters.blockHostNetwork == true
+              input.review.object.spec.hostNetwork == true
+              msg := "AI workload pod must not use spec.hostNetwork=true; it bypasses NetworkPolicy egress controls"
+            }
+
+            # Require pods to carry labels that declare their NetworkPolicy binding.
+            # This ensures a matching NetworkPolicy selector exists before the pod is admitted.
+            violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+              provided := {k | input.review.object.metadata.labels[k]}
+              required := {lbl.key | lbl := input.parameters.requiredEgressLabels[_]}
+              missing := required - provided
+              count(missing) > 0
+              msg := sprintf("AI workload pod is missing required network egress label(s): %v", [missing])
+            }
+
+            violation[{"msg": msg}] {
+              lbl := input.parameters.requiredEgressLabels[_]
+              lbl.value != ""
+              value := input.review.object.metadata.labels[lbl.key]
+              lbl.value != value
+              msg := sprintf("Network egress label <%v> must have value <%v>, got <%v>", [lbl.key, lbl.value, value])
+            }

--- a/library/general/ainetworkegress/template.yaml
+++ b/library/general/ainetworkegress/template.yaml
@@ -47,12 +47,17 @@ spec:
       code:
       - engine: K8sNativeValidation
         source:
+          variables:
+          - name: blockHostNetwork
+            expression: 'has(variables.params.blockHostNetwork) ? variables.params.blockHostNetwork : false'
+          - name: requiredEgressLabels
+            expression: 'has(variables.params.requiredEgressLabels) ? variables.params.requiredEgressLabels : []'
           validations:
-          - expression: '!has(variables.params.blockHostNetwork) || variables.params.blockHostNetwork != true || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.hostNetwork) || !variables.anyObject.spec.hostNetwork'
+          - expression: '!variables.blockHostNetwork || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.hostNetwork) || !variables.anyObject.spec.hostNetwork'
             message: "AI workload pod must not use spec.hostNetwork=true; it bypasses NetworkPolicy egress controls"
-          - expression: '!has(variables.anyObject.metadata) || variables.params.requiredEgressLabels.all(lbl, has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)'
-            messageExpression: '"AI workload pod is missing required network egress label(s): " + variables.params.requiredEgressLabels.filter(lbl, !(has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)).map(lbl, lbl.key).join(", ")'
-          - expression: '!has(variables.anyObject.metadata) || variables.params.requiredEgressLabels.all(lbl, !has(lbl.value) || lbl.value == "" || (has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels && variables.anyObject.metadata.labels[lbl.key] == lbl.value))'
+          - expression: '!has(variables.anyObject.metadata) || variables.requiredEgressLabels.all(lbl, has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)'
+            messageExpression: '"AI workload pod is missing required network egress label(s): " + variables.requiredEgressLabels.filter(lbl, !(has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)).map(lbl, lbl.key).join(", ")'
+          - expression: '!has(variables.anyObject.metadata) || variables.requiredEgressLabels.all(lbl, !has(lbl.value) || lbl.value == "" || (has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels && variables.anyObject.metadata.labels[lbl.key] == lbl.value))'
             message: "Network egress label value does not match the required value"
       - engine: Rego
         source:

--- a/library/general/airequiredcontrols/kustomization.yaml
+++ b/library/general/airequiredcontrols/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/constraint.yaml
+++ b/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/constraint.yaml
@@ -1,0 +1,20 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAIRequiredControls
+metadata:
+  name: ai-model-must-audit-and-use-secrets
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    labelSelector:
+      matchLabels:
+        workload-type: ai-model
+  parameters:
+    requiredAnnotations:
+      - key: "ai-controls/audit-logging"
+        value: "enabled"
+    credentialEnvPatterns:
+      - ".*_API_KEY$"
+      - ".*_TOKEN$"
+      - ".*_SECRET$"

--- a/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_allowed.yaml
+++ b/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_allowed.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-compliant
+  labels:
+    workload-type: ai-model
+  annotations:
+    ai-controls/audit-logging: "enabled"
+spec:
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1@sha256:abc123def456
+      env:
+        - name: MODEL_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: model-credentials
+              key: api-key
+      resources:
+        limits:
+          cpu: "2"
+          memory: "8Gi"

--- a/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_disallowed_ephemeral_plain_credential.yaml
+++ b/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_disallowed_ephemeral_plain_credential.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-ephemeral-plain-cred
+  labels:
+    workload-type: ai-model
+  annotations:
+    ai-controls/audit-logging: "enabled"
+spec:
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1
+      resources:
+        limits:
+          cpu: "2"
+          memory: "8Gi"
+  ephemeralContainers:
+    - name: debug-shell
+      image: model-registry.example.com/debug:v1
+      env:
+        - name: ADMIN_SECRET
+          value: "plaintext-admin-secret-xyz"

--- a/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_disallowed_init_plain_credential.yaml
+++ b/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_disallowed_init_plain_credential.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-init-plain-cred
+  labels:
+    workload-type: ai-model
+  annotations:
+    ai-controls/audit-logging: "enabled"
+spec:
+  initContainers:
+    - name: model-downloader
+      image: model-registry.example.com/downloader:v1
+      env:
+        - name: STORAGE_API_KEY
+          value: "plaintext-storage-key-abc123"
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1
+      resources:
+        limits:
+          cpu: "2"
+          memory: "8Gi"

--- a/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_disallowed_no_annotation.yaml
+++ b/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_disallowed_no_annotation.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-no-audit
+  labels:
+    workload-type: ai-model
+spec:
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1
+      resources:
+        limits:
+          cpu: "2"
+          memory: "8Gi"

--- a/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_disallowed_plain_credential.yaml
+++ b/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_disallowed_plain_credential.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-plain-cred
+  labels:
+    workload-type: ai-model
+  annotations:
+    ai-controls/audit-logging: "enabled"
+spec:
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1
+      env:
+        - name: OPENAI_API_KEY
+          value: "sk-plaintextcredential1234"
+      resources:
+        limits:
+          cpu: "2"
+          memory: "8Gi"

--- a/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_disallowed_wrong_annotation_value.yaml
+++ b/library/general/airequiredcontrols/samples/ai-model-must-audit-and-use-secrets/example_disallowed_wrong_annotation_value.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-model-audit-disabled
+  labels:
+    workload-type: ai-model
+  annotations:
+    ai-controls/audit-logging: "disabled"
+spec:
+  containers:
+    - name: model-server
+      image: model-registry.example.com/llama3:v2.1
+      resources:
+        limits:
+          cpu: "2"
+          memory: "8Gi"

--- a/library/general/airequiredcontrols/suite.yaml
+++ b/library/general/airequiredcontrols/suite.yaml
@@ -16,6 +16,11 @@ tests:
     assertions:
     - violations: yes
       message: "missing required annotation"
+  - name: wrong-annotation-value
+    object: samples/ai-model-must-audit-and-use-secrets/example_disallowed_wrong_annotation_value.yaml
+    assertions:
+    - violations: yes
+      message: "annotation"
   - name: plain-text-credential
     object: samples/ai-model-must-audit-and-use-secrets/example_disallowed_plain_credential.yaml
     assertions:

--- a/library/general/airequiredcontrols/suite.yaml
+++ b/library/general/airequiredcontrols/suite.yaml
@@ -26,3 +26,13 @@ tests:
     assertions:
     - violations: yes
       message: "plain-text"
+  - name: plain-text-credential-init-container
+    object: samples/ai-model-must-audit-and-use-secrets/example_disallowed_init_plain_credential.yaml
+    assertions:
+    - violations: yes
+      message: "plain-text"
+  - name: plain-text-credential-ephemeral-container
+    object: samples/ai-model-must-audit-and-use-secrets/example_disallowed_ephemeral_plain_credential.yaml
+    assertions:
+    - violations: yes
+      message: "plain-text"

--- a/library/general/airequiredcontrols/suite.yaml
+++ b/library/general/airequiredcontrols/suite.yaml
@@ -1,0 +1,23 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: airequiredcontrols
+tests:
+- name: ai-model-must-audit-and-use-secrets
+  template: template.yaml
+  constraint: samples/ai-model-must-audit-and-use-secrets/constraint.yaml
+  cases:
+  - name: example-allowed
+    object: samples/ai-model-must-audit-and-use-secrets/example_allowed.yaml
+    assertions:
+    - violations: no
+  - name: missing-annotation
+    object: samples/ai-model-must-audit-and-use-secrets/example_disallowed_no_annotation.yaml
+    assertions:
+    - violations: yes
+      message: "missing required annotation"
+  - name: plain-text-credential
+    object: samples/ai-model-must-audit-and-use-secrets/example_disallowed_plain_credential.yaml
+    assertions:
+    - violations: yes
+      message: "plain-text"

--- a/library/general/airequiredcontrols/template.yaml
+++ b/library/general/airequiredcontrols/template.yaml
@@ -46,12 +46,17 @@ spec:
       code:
       - engine: K8sNativeValidation
         source:
+          variables:
+          - name: requiredAnnotations
+            expression: 'has(variables.params.requiredAnnotations) ? variables.params.requiredAnnotations : []'
+          - name: credentialEnvPatterns
+            expression: 'has(variables.params.credentialEnvPatterns) ? variables.params.credentialEnvPatterns : []'
           validations:
-          - expression: '!has(variables.anyObject.metadata) || variables.params.requiredAnnotations.all(req, has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)'
-            messageExpression: '"AI workload is missing required annotation(s): " + variables.params.requiredAnnotations.filter(req, !(has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)).map(req, req.key).join(", ")'
-          - expression: '!has(variables.anyObject.metadata) || variables.params.requiredAnnotations.all(req, !has(req.value) || req.value == "" || !has(variables.anyObject.metadata.annotations) || !(req.key in variables.anyObject.metadata.annotations) || variables.anyObject.metadata.annotations[req.key] == req.value)'
+          - expression: '!has(variables.anyObject.metadata) || variables.requiredAnnotations.all(req, has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)'
+            messageExpression: '"AI workload is missing required annotation(s): " + variables.requiredAnnotations.filter(req, !(has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)).map(req, req.key).join(", ")'
+          - expression: '!has(variables.anyObject.metadata) || variables.requiredAnnotations.all(req, !has(req.value) || req.value == "" || !has(variables.anyObject.metadata.annotations) || !(req.key in variables.anyObject.metadata.annotations) || variables.anyObject.metadata.annotations[req.key] == req.value)'
             message: "AI workload annotation value does not match the required value"
-          - expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, !has(c.env) || c.env.all(e, !(variables.params.credentialEnvPatterns.exists(p, e.name.matches(p))) || !has(e.value) || e.value == ""))'
+          - expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, !has(c.env) || c.env.all(e, !(variables.credentialEnvPatterns.exists(p, e.name.matches(p))) || !has(e.value) || e.value == ""))'
             message: "AI workload container has a plain-text credential env var; use secretKeyRef instead"
       - engine: Rego
         source:

--- a/library/general/airequiredcontrols/template.yaml
+++ b/library/general/airequiredcontrols/template.yaml
@@ -47,6 +47,14 @@ spec:
       - engine: K8sNativeValidation
         source:
           variables:
+          - name: containers
+            expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.containers) ? variables.anyObject.spec.containers : []'
+          - name: initContainers
+            expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.initContainers) ? variables.anyObject.spec.initContainers : []'
+          - name: ephemeralContainers
+            expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.ephemeralContainers) ? variables.anyObject.spec.ephemeralContainers : []'
+          - name: allContainers
+            expression: 'variables.containers + variables.initContainers + variables.ephemeralContainers'
           - name: requiredAnnotations
             expression: 'has(variables.params.requiredAnnotations) ? variables.params.requiredAnnotations : []'
           - name: credentialEnvPatterns
@@ -56,7 +64,7 @@ spec:
             messageExpression: '"AI workload is missing required annotation(s): " + variables.requiredAnnotations.filter(req, !(has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)).map(req, req.key).join(", ")'
           - expression: '!has(variables.anyObject.metadata) || variables.requiredAnnotations.all(req, !has(req.value) || req.value == "" || !has(variables.anyObject.metadata.annotations) || !(req.key in variables.anyObject.metadata.annotations) || variables.anyObject.metadata.annotations[req.key] == req.value)'
             message: "AI workload annotation value does not match the required value"
-          - expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, !has(c.env) || c.env.all(e, !(variables.credentialEnvPatterns.exists(p, e.name.matches(p))) || !has(e.value) || e.value == ""))'
+          - expression: 'variables.allContainers.all(c, !has(c.env) || c.env.all(e, !(variables.credentialEnvPatterns.exists(p, e.name.matches(p))) || !has(e.value) || e.value == ""))'
             message: "AI workload container has a plain-text credential env var; use secretKeyRef instead"
       - engine: Rego
         source:

--- a/library/general/airequiredcontrols/template.yaml
+++ b/library/general/airequiredcontrols/template.yaml
@@ -1,0 +1,104 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sairequiredcontrols
+  annotations:
+    metadata.gatekeeper.sh/title: "AI Workload Required Controls"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Enforces security controls on AI model workload pods: requires specified
+      annotations (e.g. audit-logging enabled) and prevents plain-text credentials
+      in environment variables by requiring secretKeyRef for names matching
+      configurable patterns.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAIRequiredControls
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            requiredAnnotations:
+              description: >-
+                Annotations that must be present on AI workload pods.
+                Specify key and optional value; omit or leave value empty to
+                require the annotation key with any value.
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: The annotation key.
+                  value:
+                    type: string
+                    description: Required annotation value. Empty means any value is accepted.
+            credentialEnvPatterns:
+              description: >-
+                RE2 regex patterns for env var names that must use secretKeyRef.
+                Example patterns: ".*_KEY$", ".*_TOKEN$", ".*_SECRET$".
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+          validations:
+          - expression: '!has(variables.anyObject.metadata) || variables.params.requiredAnnotations.all(req, has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)'
+            messageExpression: '"AI workload is missing required annotation(s): " + variables.params.requiredAnnotations.filter(req, !(has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)).map(req, req.key).join(", ")'
+          - expression: '!has(variables.anyObject.metadata) || variables.params.requiredAnnotations.all(req, !has(req.value) || req.value == "" || !has(variables.anyObject.metadata.annotations) || !(req.key in variables.anyObject.metadata.annotations) || variables.anyObject.metadata.annotations[req.key] == req.value)'
+            message: "AI workload annotation value does not match the required value"
+          - expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, !has(c.env) || c.env.all(e, !(variables.params.credentialEnvPatterns.exists(p, e.name.matches(p))) || !has(e.value) || e.value == ""))'
+            message: "AI workload container has a plain-text credential env var; use secretKeyRef instead"
+      - engine: Rego
+        source:
+          rego: |
+            package k8sairequiredcontrols
+
+            # Verify required annotations are present with the expected values.
+            violation[{"msg": msg, "details": {"missing_annotations": missing}}] {
+              provided := {k | input.review.object.metadata.annotations[k]}
+              required := {req.key | req := input.parameters.requiredAnnotations[_]}
+              missing := required - provided
+              count(missing) > 0
+              msg := sprintf("AI workload is missing required annotation(s): %v", [missing])
+            }
+
+            violation[{"msg": msg}] {
+              ann := input.parameters.requiredAnnotations[_]
+              ann.value != ""
+              value := input.review.object.metadata.annotations[ann.key]
+              ann.value != value
+              msg := sprintf("Annotation <%v> must have value <%v>, got <%v>", [ann.key, ann.value, value])
+            }
+
+            # Verify credential env vars use secretKeyRef and not a plain-text value.
+            violation[{"msg": msg}] {
+              container := input.review.object.spec.containers[_]
+              env := container.env[_]
+              pattern := input.parameters.credentialEnvPatterns[_]
+              regex.match(pattern, env.name)
+              is_string(env.value)
+              msg := sprintf("container <%v> env var <%v> matches credential pattern <%v> but uses a plain-text value; use secretKeyRef instead", [container.name, env.name, pattern])
+            }
+
+            violation[{"msg": msg}] {
+              container := input.review.object.spec.initContainers[_]
+              env := container.env[_]
+              pattern := input.parameters.credentialEnvPatterns[_]
+              regex.match(pattern, env.name)
+              is_string(env.value)
+              msg := sprintf("initContainer <%v> env var <%v> matches credential pattern <%v> but uses a plain-text value; use secretKeyRef instead", [container.name, env.name, pattern])
+            }
+
+            violation[{"msg": msg}] {
+              container := input.review.object.spec.ephemeralContainers[_]
+              env := container.env[_]
+              pattern := input.parameters.credentialEnvPatterns[_]
+              regex.match(pattern, env.name)
+              is_string(env.value)
+              msg := sprintf("ephemeralContainer <%v> env var <%v> matches credential pattern <%v> but uses a plain-text value; use secretKeyRef instead", [container.name, env.name, pattern])
+            }

--- a/src/general/aiapprovedmodelregistry/constraint.tmpl
+++ b/src/general/aiapprovedmodelregistry/constraint.tmpl
@@ -1,0 +1,44 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8saiapprovedmodelregistry
+  annotations:
+    metadata.gatekeeper.sh/title: "AI Approved Model Registry"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Requires AI workload container images to originate from operator-approved
+      model registries. Optionally enforces digest pinning (@sha256:) to prevent
+      floating tags and supply-chain substitution attacks.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAIApprovedModelRegistry
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            approvedRegistries:
+              description: >-
+                List of approved model registry prefixes. Container images must
+                begin with one of these strings. Add a trailing '/' to prevent
+                prefix-spoofing (e.g. "model-registry.example.com/" not
+                "model-registry.example.com").
+              type: array
+              items:
+                type: string
+            requireDigestPin:
+              description: >-
+                If true, all container images must be pinned with a @sha256:
+                digest to prevent floating-tag substitution.
+              type: boolean
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/general/aiapprovedmodelregistry/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/general/aiapprovedmodelregistry/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}

--- a/src/general/aiapprovedmodelregistry/src.cel
+++ b/src/general/aiapprovedmodelregistry/src.cel
@@ -1,8 +1,16 @@
 variables:
+- name: containers
+  expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.containers) ? variables.anyObject.spec.containers : []'
+- name: initContainers
+  expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.initContainers) ? variables.anyObject.spec.initContainers : []'
+- name: ephemeralContainers
+  expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.ephemeralContainers) ? variables.anyObject.spec.ephemeralContainers : []'
+- name: allContainers
+  expression: 'variables.containers + variables.initContainers + variables.ephemeralContainers'
 - name: approvedRegistries
   expression: 'has(variables.params.approvedRegistries) ? variables.params.approvedRegistries : []'
 validations:
-- expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.approvedRegistries.size() == 0 || variables.anyObject.spec.containers.all(c, variables.approvedRegistries.exists(r, c.image.startsWith(r)))'
+- expression: 'variables.approvedRegistries.size() == 0 || variables.allContainers.all(c, variables.approvedRegistries.exists(r, c.image.startsWith(r)))'
   messageExpression: '"Container image is not from an approved model registry. Approved prefixes: " + variables.approvedRegistries.join(", ")'
-- expression: '!has(variables.params.requireDigestPin) || variables.params.requireDigestPin != true || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, c.image.contains("@sha256:"))'
+- expression: '!has(variables.params.requireDigestPin) || variables.params.requireDigestPin != true || variables.allContainers.all(c, c.image.contains("@sha256:"))'
   message: "AI workload container image must be digest-pinned (append @sha256:<digest>)"

--- a/src/general/aiapprovedmodelregistry/src.cel
+++ b/src/general/aiapprovedmodelregistry/src.cel
@@ -1,5 +1,8 @@
+variables:
+- name: approvedRegistries
+  expression: 'has(variables.params.approvedRegistries) ? variables.params.approvedRegistries : []'
 validations:
-- expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, variables.params.approvedRegistries.exists(r, c.image.startsWith(r)))'
-  messageExpression: '"Container image is not from an approved model registry. Approved prefixes: " + variables.params.approvedRegistries.join(", ")'
+- expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.approvedRegistries.size() == 0 || variables.anyObject.spec.containers.all(c, variables.approvedRegistries.exists(r, c.image.startsWith(r)))'
+  messageExpression: '"Container image is not from an approved model registry. Approved prefixes: " + variables.approvedRegistries.join(", ")'
 - expression: '!has(variables.params.requireDigestPin) || variables.params.requireDigestPin != true || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, c.image.contains("@sha256:"))'
   message: "AI workload container image must be digest-pinned (append @sha256:<digest>)"

--- a/src/general/aiapprovedmodelregistry/src.cel
+++ b/src/general/aiapprovedmodelregistry/src.cel
@@ -1,0 +1,5 @@
+validations:
+- expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, variables.params.approvedRegistries.exists(r, c.image.startsWith(r)))'
+  messageExpression: '"Container image is not from an approved model registry. Approved prefixes: " + variables.params.approvedRegistries.join(", ")'
+- expression: '!has(variables.params.requireDigestPin) || variables.params.requireDigestPin != true || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, c.image.contains("@sha256:"))'
+  message: "AI workload container image must be digest-pinned (append @sha256:<digest>)"

--- a/src/general/aiapprovedmodelregistry/src.rego
+++ b/src/general/aiapprovedmodelregistry/src.rego
@@ -1,0 +1,42 @@
+package k8saiapprovedmodelregistry
+
+# Require container images to start with an approved model registry prefix.
+violation[{"msg": msg}] {
+  container := input.review.object.spec.containers[_]
+  not strings.any_prefix_match(container.image, input.parameters.approvedRegistries)
+  msg := sprintf("container <%v> image <%v> is not from an approved model registry; allowed prefixes: %v", [container.name, container.image, input.parameters.approvedRegistries])
+}
+
+violation[{"msg": msg}] {
+  container := input.review.object.spec.initContainers[_]
+  not strings.any_prefix_match(container.image, input.parameters.approvedRegistries)
+  msg := sprintf("initContainer <%v> image <%v> is not from an approved model registry; allowed prefixes: %v", [container.name, container.image, input.parameters.approvedRegistries])
+}
+
+violation[{"msg": msg}] {
+  container := input.review.object.spec.ephemeralContainers[_]
+  not strings.any_prefix_match(container.image, input.parameters.approvedRegistries)
+  msg := sprintf("ephemeralContainer <%v> image <%v> is not from an approved model registry; allowed prefixes: %v", [container.name, container.image, input.parameters.approvedRegistries])
+}
+
+# Optionally require images to be digest-pinned with @sha256:.
+violation[{"msg": msg}] {
+  input.parameters.requireDigestPin == true
+  container := input.review.object.spec.containers[_]
+  not contains(container.image, "@sha256:")
+  msg := sprintf("container <%v> image <%v> must be digest-pinned (append @sha256:<digest>)", [container.name, container.image])
+}
+
+violation[{"msg": msg}] {
+  input.parameters.requireDigestPin == true
+  container := input.review.object.spec.initContainers[_]
+  not contains(container.image, "@sha256:")
+  msg := sprintf("initContainer <%v> image <%v> must be digest-pinned (append @sha256:<digest>)", [container.name, container.image])
+}
+
+violation[{"msg": msg}] {
+  input.parameters.requireDigestPin == true
+  container := input.review.object.spec.ephemeralContainers[_]
+  not contains(container.image, "@sha256:")
+  msg := sprintf("ephemeralContainer <%v> image <%v> must be digest-pinned (append @sha256:<digest>)", [container.name, container.image])
+}

--- a/src/general/aiapprovedmodelregistry/src_test.rego
+++ b/src/general/aiapprovedmodelregistry/src_test.rego
@@ -1,0 +1,143 @@
+package k8saiapprovedmodelregistry
+
+# --- Approved registry tests ---
+
+test_approved_registry_allowed {
+  inp := {
+    "review": input_review_approved,
+    "parameters": {
+      "approvedRegistries": ["model-registry.example.com/", "ghcr.io/myorg/"],
+      "requireDigestPin": false,
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+test_unapproved_registry_denied {
+  inp := {
+    "review": input_review_unapproved,
+    "parameters": {
+      "approvedRegistries": ["model-registry.example.com/"],
+      "requireDigestPin": false,
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+test_mixed_containers_one_denied {
+  inp := {
+    "review": input_review_mixed,
+    "parameters": {
+      "approvedRegistries": ["model-registry.example.com/"],
+      "requireDigestPin": false,
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+test_init_container_unapproved_denied {
+  inp := {
+    "review": input_review_init_unapproved,
+    "parameters": {
+      "approvedRegistries": ["model-registry.example.com/"],
+      "requireDigestPin": false,
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+# --- Digest pin tests ---
+
+test_digest_pinned_allowed {
+  inp := {
+    "review": input_review_digest_pinned,
+    "parameters": {
+      "approvedRegistries": ["model-registry.example.com/"],
+      "requireDigestPin": true,
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+test_digest_not_pinned_denied {
+  inp := {
+    "review": input_review_approved,
+    "parameters": {
+      "approvedRegistries": ["model-registry.example.com/"],
+      "requireDigestPin": true,
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+test_digest_pin_disabled_no_violation {
+  inp := {
+    "review": input_review_approved,
+    "parameters": {
+      "approvedRegistries": ["model-registry.example.com/"],
+      "requireDigestPin": false,
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+# --- Input fixtures ---
+
+input_review_approved = {
+  "object": {
+    "metadata": {"name": "ai-model-pod"},
+    "spec": {
+      "containers": [{"name": "model-server", "image": "model-registry.example.com/llama3:v2.1"}],
+    },
+  },
+}
+
+input_review_unapproved = {
+  "object": {
+    "metadata": {"name": "ai-model-pod"},
+    "spec": {
+      "containers": [{"name": "model-server", "image": "docker.io/library/ubuntu:latest"}],
+    },
+  },
+}
+
+input_review_mixed = {
+  "object": {
+    "metadata": {"name": "ai-model-pod"},
+    "spec": {
+      "containers": [
+        {"name": "model-server", "image": "model-registry.example.com/llama3:v2.1"},
+        {"name": "sidecar", "image": "docker.io/library/nginx:latest"},
+      ],
+    },
+  },
+}
+
+input_review_init_unapproved = {
+  "object": {
+    "metadata": {"name": "ai-model-pod"},
+    "spec": {
+      "containers": [{"name": "model-server", "image": "model-registry.example.com/llama3:v2.1"}],
+      "initContainers": [{"name": "downloader", "image": "docker.io/library/alpine:3"}],
+    },
+  },
+}
+
+input_review_digest_pinned = {
+  "object": {
+    "metadata": {"name": "ai-model-pod"},
+    "spec": {
+      "containers": [{
+        "name": "model-server",
+        "image": "model-registry.example.com/llama3:v2.1@sha256:abc123def456789",
+      }],
+    },
+  },
+}

--- a/src/general/ainetworkegress/constraint.tmpl
+++ b/src/general/ainetworkegress/constraint.tmpl
@@ -1,0 +1,54 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sainetworkegress
+  annotations:
+    metadata.gatekeeper.sh/title: "AI Workload Network Egress Controls"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Enforces network egress controls on AI workload pods: optionally blocks
+      spec.hostNetwork=true (which bypasses NetworkPolicy), and requires pods
+      to carry labels that declare their NetworkPolicy binding, ensuring a
+      matching NetworkPolicy selector exists before the pod is admitted.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAINetworkEgress
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            blockHostNetwork:
+              description: >-
+                If true, reject pods with spec.hostNetwork=true. hostNetwork
+                gives the pod direct access to the node network and bypasses
+                all NetworkPolicy egress rules.
+              type: boolean
+            requiredEgressLabels:
+              description: >-
+                Labels that must be present on AI workload pods to declare their
+                NetworkPolicy binding. Use these labels as selectors in the
+                corresponding NetworkPolicy to ensure egress is controlled.
+                Specify key and optional value; leave value empty to require
+                the label key with any value.
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: The label key.
+                  value:
+                    type: string
+                    description: Required label value. Empty means any value is accepted.
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/general/ainetworkegress/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/general/ainetworkegress/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}

--- a/src/general/ainetworkegress/src.cel
+++ b/src/general/ainetworkegress/src.cel
@@ -1,0 +1,7 @@
+validations:
+- expression: '!has(variables.params.blockHostNetwork) || variables.params.blockHostNetwork != true || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.hostNetwork) || !variables.anyObject.spec.hostNetwork'
+  message: "AI workload pod must not use spec.hostNetwork=true; it bypasses NetworkPolicy egress controls"
+- expression: '!has(variables.anyObject.metadata) || variables.params.requiredEgressLabels.all(lbl, has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)'
+  messageExpression: '"AI workload pod is missing required network egress label(s): " + variables.params.requiredEgressLabels.filter(lbl, !(has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)).map(lbl, lbl.key).join(", ")'
+- expression: '!has(variables.anyObject.metadata) || variables.params.requiredEgressLabels.all(lbl, !has(lbl.value) || lbl.value == "" || (has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels && variables.anyObject.metadata.labels[lbl.key] == lbl.value))'
+  message: "Network egress label value does not match the required value"

--- a/src/general/ainetworkegress/src.cel
+++ b/src/general/ainetworkegress/src.cel
@@ -1,7 +1,12 @@
+variables:
+- name: blockHostNetwork
+  expression: 'has(variables.params.blockHostNetwork) ? variables.params.blockHostNetwork : false'
+- name: requiredEgressLabels
+  expression: 'has(variables.params.requiredEgressLabels) ? variables.params.requiredEgressLabels : []'
 validations:
-- expression: '!has(variables.params.blockHostNetwork) || variables.params.blockHostNetwork != true || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.hostNetwork) || !variables.anyObject.spec.hostNetwork'
+- expression: '!variables.blockHostNetwork || !has(variables.anyObject.spec) || !has(variables.anyObject.spec.hostNetwork) || !variables.anyObject.spec.hostNetwork'
   message: "AI workload pod must not use spec.hostNetwork=true; it bypasses NetworkPolicy egress controls"
-- expression: '!has(variables.anyObject.metadata) || variables.params.requiredEgressLabels.all(lbl, has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)'
-  messageExpression: '"AI workload pod is missing required network egress label(s): " + variables.params.requiredEgressLabels.filter(lbl, !(has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)).map(lbl, lbl.key).join(", ")'
-- expression: '!has(variables.anyObject.metadata) || variables.params.requiredEgressLabels.all(lbl, !has(lbl.value) || lbl.value == "" || (has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels && variables.anyObject.metadata.labels[lbl.key] == lbl.value))'
+- expression: '!has(variables.anyObject.metadata) || variables.requiredEgressLabels.all(lbl, has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)'
+  messageExpression: '"AI workload pod is missing required network egress label(s): " + variables.requiredEgressLabels.filter(lbl, !(has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels)).map(lbl, lbl.key).join(", ")'
+- expression: '!has(variables.anyObject.metadata) || variables.requiredEgressLabels.all(lbl, !has(lbl.value) || lbl.value == "" || (has(variables.anyObject.metadata.labels) && lbl.key in variables.anyObject.metadata.labels && variables.anyObject.metadata.labels[lbl.key] == lbl.value))'
   message: "Network egress label value does not match the required value"

--- a/src/general/ainetworkegress/src.rego
+++ b/src/general/ainetworkegress/src.rego
@@ -1,0 +1,27 @@
+package k8sainetworkegress
+
+# Block hostNetwork on AI workload pods when configured.
+# hostNetwork=true bypasses all NetworkPolicy egress controls.
+violation[{"msg": msg}] {
+  input.parameters.blockHostNetwork == true
+  input.review.object.spec.hostNetwork == true
+  msg := "AI workload pod must not use spec.hostNetwork=true; it bypasses NetworkPolicy egress controls"
+}
+
+# Require pods to carry labels that declare their NetworkPolicy binding.
+# This ensures a matching NetworkPolicy selector exists before the pod is admitted.
+violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+  provided := {k | input.review.object.metadata.labels[k]}
+  required := {lbl.key | lbl := input.parameters.requiredEgressLabels[_]}
+  missing := required - provided
+  count(missing) > 0
+  msg := sprintf("AI workload pod is missing required network egress label(s): %v", [missing])
+}
+
+violation[{"msg": msg}] {
+  lbl := input.parameters.requiredEgressLabels[_]
+  lbl.value != ""
+  value := input.review.object.metadata.labels[lbl.key]
+  lbl.value != value
+  msg := sprintf("Network egress label <%v> must have value <%v>, got <%v>", [lbl.key, lbl.value, value])
+}

--- a/src/general/ainetworkegress/src_test.rego
+++ b/src/general/ainetworkegress/src_test.rego
@@ -1,0 +1,184 @@
+package k8sainetworkegress
+
+# --- hostNetwork tests ---
+
+test_host_network_true_denied {
+  inp := {
+    "review": input_review_host_network_true,
+    "parameters": {
+      "blockHostNetwork": true,
+      "requiredEgressLabels": [],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+test_host_network_false_allowed {
+  inp := {
+    "review": input_review_host_network_false,
+    "parameters": {
+      "blockHostNetwork": true,
+      "requiredEgressLabels": [],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+test_host_network_block_disabled_no_violation {
+  inp := {
+    "review": input_review_host_network_true,
+    "parameters": {
+      "blockHostNetwork": false,
+      "requiredEgressLabels": [],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+# --- Egress label tests ---
+
+test_missing_egress_label_denied {
+  inp := {
+    "review": input_review_no_labels,
+    "parameters": {
+      "blockHostNetwork": false,
+      "requiredEgressLabels": [{"key": "network-policy/ai-egress", "value": "enforced"}],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+test_egress_label_wrong_value_denied {
+  inp := {
+    "review": input_review_wrong_label_value,
+    "parameters": {
+      "blockHostNetwork": false,
+      "requiredEgressLabels": [{"key": "network-policy/ai-egress", "value": "enforced"}],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+test_egress_label_correct_allowed {
+  inp := {
+    "review": input_review_correct_label,
+    "parameters": {
+      "blockHostNetwork": false,
+      "requiredEgressLabels": [{"key": "network-policy/ai-egress", "value": "enforced"}],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+test_egress_label_key_only_allowed {
+  inp := {
+    "review": input_review_correct_label,
+    "parameters": {
+      "blockHostNetwork": false,
+      "requiredEgressLabels": [{"key": "network-policy/ai-egress", "value": ""}],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+test_empty_required_labels_no_violation {
+  inp := {
+    "review": input_review_no_labels,
+    "parameters": {
+      "blockHostNetwork": false,
+      "requiredEgressLabels": [],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+test_full_compliance_no_violations {
+  inp := {
+    "review": input_review_fully_compliant,
+    "parameters": {
+      "blockHostNetwork": true,
+      "requiredEgressLabels": [{"key": "network-policy/ai-egress", "value": "enforced"}],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+# --- Input fixtures ---
+
+input_review_host_network_true = {
+  "object": {
+    "metadata": {"name": "ai-model-pod", "labels": {"workload-type": "ai-model"}},
+    "spec": {
+      "hostNetwork": true,
+      "containers": [{"name": "model-server", "image": "registry.example.com/model:v1"}],
+    },
+  },
+}
+
+input_review_host_network_false = {
+  "object": {
+    "metadata": {"name": "ai-model-pod"},
+    "spec": {
+      "hostNetwork": false,
+      "containers": [{"name": "model-server", "image": "registry.example.com/model:v1"}],
+    },
+  },
+}
+
+input_review_no_labels = {
+  "object": {
+    "metadata": {"name": "ai-model-pod"},
+    "spec": {
+      "containers": [{"name": "model-server", "image": "registry.example.com/model:v1"}],
+    },
+  },
+}
+
+input_review_wrong_label_value = {
+  "object": {
+    "metadata": {
+      "name": "ai-model-pod",
+      "labels": {"network-policy/ai-egress": "disabled"},
+    },
+    "spec": {
+      "containers": [{"name": "model-server", "image": "registry.example.com/model:v1"}],
+    },
+  },
+}
+
+input_review_correct_label = {
+  "object": {
+    "metadata": {
+      "name": "ai-model-pod",
+      "labels": {"network-policy/ai-egress": "enforced"},
+    },
+    "spec": {
+      "containers": [{"name": "model-server", "image": "registry.example.com/model:v1"}],
+    },
+  },
+}
+
+input_review_fully_compliant = {
+  "object": {
+    "metadata": {
+      "name": "ai-model-pod",
+      "labels": {
+        "workload-type": "ai-model",
+        "network-policy/ai-egress": "enforced",
+      },
+    },
+    "spec": {
+      "hostNetwork": false,
+      "containers": [{"name": "model-server", "image": "registry.example.com/model:v1"}],
+    },
+  },
+}

--- a/src/general/airequiredcontrols/constraint.tmpl
+++ b/src/general/airequiredcontrols/constraint.tmpl
@@ -1,0 +1,53 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sairequiredcontrols
+  annotations:
+    metadata.gatekeeper.sh/title: "AI Workload Required Controls"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Enforces security controls on AI model workload pods: requires specified
+      annotations (e.g. audit-logging enabled) and prevents plain-text credentials
+      in environment variables by requiring secretKeyRef for names matching
+      configurable patterns.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAIRequiredControls
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            requiredAnnotations:
+              description: >-
+                Annotations that must be present on AI workload pods.
+                Specify key and optional value; omit or leave value empty to
+                require the annotation key with any value.
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: The annotation key.
+                  value:
+                    type: string
+                    description: Required annotation value. Empty means any value is accepted.
+            credentialEnvPatterns:
+              description: >-
+                RE2 regex patterns for env var names that must use secretKeyRef.
+                Example patterns: ".*_KEY$", ".*_TOKEN$", ".*_SECRET$".
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+      - engine: K8sNativeValidation
+        source:
+{{ file.Read "src/general/airequiredcontrols/src.cel" | strings.Indent 10 | strings.TrimSuffix "\n" }}
+      - engine: Rego
+        source:
+          rego: |
+{{ file.Read "src/general/airequiredcontrols/src.rego" | strings.Indent 12 | strings.TrimSuffix "\n" }}

--- a/src/general/airequiredcontrols/src.cel
+++ b/src/general/airequiredcontrols/src.cel
@@ -1,4 +1,12 @@
 variables:
+- name: containers
+  expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.containers) ? variables.anyObject.spec.containers : []'
+- name: initContainers
+  expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.initContainers) ? variables.anyObject.spec.initContainers : []'
+- name: ephemeralContainers
+  expression: 'has(variables.anyObject.spec) && has(variables.anyObject.spec.ephemeralContainers) ? variables.anyObject.spec.ephemeralContainers : []'
+- name: allContainers
+  expression: 'variables.containers + variables.initContainers + variables.ephemeralContainers'
 - name: requiredAnnotations
   expression: 'has(variables.params.requiredAnnotations) ? variables.params.requiredAnnotations : []'
 - name: credentialEnvPatterns
@@ -8,5 +16,5 @@ validations:
   messageExpression: '"AI workload is missing required annotation(s): " + variables.requiredAnnotations.filter(req, !(has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)).map(req, req.key).join(", ")'
 - expression: '!has(variables.anyObject.metadata) || variables.requiredAnnotations.all(req, !has(req.value) || req.value == "" || !has(variables.anyObject.metadata.annotations) || !(req.key in variables.anyObject.metadata.annotations) || variables.anyObject.metadata.annotations[req.key] == req.value)'
   message: "AI workload annotation value does not match the required value"
-- expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, !has(c.env) || c.env.all(e, !(variables.credentialEnvPatterns.exists(p, e.name.matches(p))) || !has(e.value) || e.value == ""))'
+- expression: 'variables.allContainers.all(c, !has(c.env) || c.env.all(e, !(variables.credentialEnvPatterns.exists(p, e.name.matches(p))) || !has(e.value) || e.value == ""))'
   message: "AI workload container has a plain-text credential env var; use secretKeyRef instead"

--- a/src/general/airequiredcontrols/src.cel
+++ b/src/general/airequiredcontrols/src.cel
@@ -1,7 +1,12 @@
+variables:
+- name: requiredAnnotations
+  expression: 'has(variables.params.requiredAnnotations) ? variables.params.requiredAnnotations : []'
+- name: credentialEnvPatterns
+  expression: 'has(variables.params.credentialEnvPatterns) ? variables.params.credentialEnvPatterns : []'
 validations:
-- expression: '!has(variables.anyObject.metadata) || variables.params.requiredAnnotations.all(req, has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)'
-  messageExpression: '"AI workload is missing required annotation(s): " + variables.params.requiredAnnotations.filter(req, !(has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)).map(req, req.key).join(", ")'
-- expression: '!has(variables.anyObject.metadata) || variables.params.requiredAnnotations.all(req, !has(req.value) || req.value == "" || !has(variables.anyObject.metadata.annotations) || !(req.key in variables.anyObject.metadata.annotations) || variables.anyObject.metadata.annotations[req.key] == req.value)'
+- expression: '!has(variables.anyObject.metadata) || variables.requiredAnnotations.all(req, has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)'
+  messageExpression: '"AI workload is missing required annotation(s): " + variables.requiredAnnotations.filter(req, !(has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)).map(req, req.key).join(", ")'
+- expression: '!has(variables.anyObject.metadata) || variables.requiredAnnotations.all(req, !has(req.value) || req.value == "" || !has(variables.anyObject.metadata.annotations) || !(req.key in variables.anyObject.metadata.annotations) || variables.anyObject.metadata.annotations[req.key] == req.value)'
   message: "AI workload annotation value does not match the required value"
-- expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, !has(c.env) || c.env.all(e, !(variables.params.credentialEnvPatterns.exists(p, e.name.matches(p))) || !has(e.value) || e.value == ""))'
+- expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, !has(c.env) || c.env.all(e, !(variables.credentialEnvPatterns.exists(p, e.name.matches(p))) || !has(e.value) || e.value == ""))'
   message: "AI workload container has a plain-text credential env var; use secretKeyRef instead"

--- a/src/general/airequiredcontrols/src.cel
+++ b/src/general/airequiredcontrols/src.cel
@@ -1,0 +1,7 @@
+validations:
+- expression: '!has(variables.anyObject.metadata) || variables.params.requiredAnnotations.all(req, has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)'
+  messageExpression: '"AI workload is missing required annotation(s): " + variables.params.requiredAnnotations.filter(req, !(has(variables.anyObject.metadata.annotations) && req.key in variables.anyObject.metadata.annotations)).map(req, req.key).join(", ")'
+- expression: '!has(variables.anyObject.metadata) || variables.params.requiredAnnotations.all(req, !has(req.value) || req.value == "" || !has(variables.anyObject.metadata.annotations) || !(req.key in variables.anyObject.metadata.annotations) || variables.anyObject.metadata.annotations[req.key] == req.value)'
+  message: "AI workload annotation value does not match the required value"
+- expression: '!has(variables.anyObject.spec) || !has(variables.anyObject.spec.containers) || variables.anyObject.spec.containers.all(c, !has(c.env) || c.env.all(e, !(variables.params.credentialEnvPatterns.exists(p, e.name.matches(p))) || !has(e.value) || e.value == ""))'
+  message: "AI workload container has a plain-text credential env var; use secretKeyRef instead"

--- a/src/general/airequiredcontrols/src.rego
+++ b/src/general/airequiredcontrols/src.rego
@@ -1,0 +1,46 @@
+package k8sairequiredcontrols
+
+# Verify required annotations are present with the expected values.
+violation[{"msg": msg, "details": {"missing_annotations": missing}}] {
+  provided := {k | input.review.object.metadata.annotations[k]}
+  required := {req.key | req := input.parameters.requiredAnnotations[_]}
+  missing := required - provided
+  count(missing) > 0
+  msg := sprintf("AI workload is missing required annotation(s): %v", [missing])
+}
+
+violation[{"msg": msg}] {
+  ann := input.parameters.requiredAnnotations[_]
+  ann.value != ""
+  value := input.review.object.metadata.annotations[ann.key]
+  ann.value != value
+  msg := sprintf("Annotation <%v> must have value <%v>, got <%v>", [ann.key, ann.value, value])
+}
+
+# Verify credential env vars use secretKeyRef and not a plain-text value.
+violation[{"msg": msg}] {
+  container := input.review.object.spec.containers[_]
+  env := container.env[_]
+  pattern := input.parameters.credentialEnvPatterns[_]
+  regex.match(pattern, env.name)
+  is_string(env.value)
+  msg := sprintf("container <%v> env var <%v> matches credential pattern <%v> but uses a plain-text value; use secretKeyRef instead", [container.name, env.name, pattern])
+}
+
+violation[{"msg": msg}] {
+  container := input.review.object.spec.initContainers[_]
+  env := container.env[_]
+  pattern := input.parameters.credentialEnvPatterns[_]
+  regex.match(pattern, env.name)
+  is_string(env.value)
+  msg := sprintf("initContainer <%v> env var <%v> matches credential pattern <%v> but uses a plain-text value; use secretKeyRef instead", [container.name, env.name, pattern])
+}
+
+violation[{"msg": msg}] {
+  container := input.review.object.spec.ephemeralContainers[_]
+  env := container.env[_]
+  pattern := input.parameters.credentialEnvPatterns[_]
+  regex.match(pattern, env.name)
+  is_string(env.value)
+  msg := sprintf("ephemeralContainer <%v> env var <%v> matches credential pattern <%v> but uses a plain-text value; use secretKeyRef instead", [container.name, env.name, pattern])
+}

--- a/src/general/airequiredcontrols/src_test.rego
+++ b/src/general/airequiredcontrols/src_test.rego
@@ -1,0 +1,226 @@
+package k8sairequiredcontrols
+
+# --- Annotation tests ---
+
+test_annotation_missing {
+  inp := {
+    "review": input_review_no_annotations,
+    "parameters": {
+      "requiredAnnotations": [{"key": "ai-controls/audit-logging", "value": "enabled"}],
+      "credentialEnvPatterns": [],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+test_annotation_wrong_value {
+  inp := {
+    "review": input_review_annotation_wrong_value,
+    "parameters": {
+      "requiredAnnotations": [{"key": "ai-controls/audit-logging", "value": "enabled"}],
+      "credentialEnvPatterns": [],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+test_annotation_correct_value_allowed {
+  inp := {
+    "review": input_review_with_annotation,
+    "parameters": {
+      "requiredAnnotations": [{"key": "ai-controls/audit-logging", "value": "enabled"}],
+      "credentialEnvPatterns": [],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+test_annotation_key_only_any_value_allowed {
+  inp := {
+    "review": input_review_with_annotation,
+    "parameters": {
+      "requiredAnnotations": [{"key": "ai-controls/audit-logging", "value": ""}],
+      "credentialEnvPatterns": [],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+test_no_required_annotations_no_violation {
+  inp := {
+    "review": input_review_no_annotations,
+    "parameters": {
+      "requiredAnnotations": [],
+      "credentialEnvPatterns": [],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+# --- Credential env var tests ---
+
+test_credential_plain_value_denied {
+  inp := {
+    "review": input_review_credential_plain,
+    "parameters": {
+      "requiredAnnotations": [],
+      "credentialEnvPatterns": [".*_KEY$", ".*_TOKEN$", ".*_SECRET$"],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+test_credential_secret_ref_allowed {
+  inp := {
+    "review": input_review_credential_secretref,
+    "parameters": {
+      "requiredAnnotations": [],
+      "credentialEnvPatterns": [".*_KEY$", ".*_TOKEN$", ".*_SECRET$"],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+test_credential_init_container_denied {
+  inp := {
+    "review": input_review_credential_init_plain,
+    "parameters": {
+      "requiredAnnotations": [],
+      "credentialEnvPatterns": [".*_KEY$"],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 1
+}
+
+test_no_credential_patterns_no_violation {
+  inp := {
+    "review": input_review_credential_plain,
+    "parameters": {
+      "requiredAnnotations": [],
+      "credentialEnvPatterns": [],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+test_full_compliance_no_violations {
+  inp := {
+    "review": input_review_fully_compliant,
+    "parameters": {
+      "requiredAnnotations": [{"key": "ai-controls/audit-logging", "value": "enabled"}],
+      "credentialEnvPatterns": [".*_KEY$", ".*_TOKEN$"],
+    },
+  }
+  results := violation with input as inp
+  count(results) == 0
+}
+
+# --- Input fixtures ---
+
+input_review_no_annotations = {
+  "object": {
+    "metadata": {
+      "name": "ai-model-pod",
+      "labels": {"workload-type": "ai-model"},
+    },
+    "spec": {
+      "containers": [{"name": "model-server", "image": "registry.example.com/model:v1"}],
+    },
+  },
+}
+
+input_review_annotation_wrong_value = {
+  "object": {
+    "metadata": {
+      "name": "ai-model-pod",
+      "annotations": {"ai-controls/audit-logging": "disabled"},
+    },
+    "spec": {
+      "containers": [{"name": "model-server", "image": "registry.example.com/model:v1"}],
+    },
+  },
+}
+
+input_review_with_annotation = {
+  "object": {
+    "metadata": {
+      "name": "ai-model-pod",
+      "annotations": {"ai-controls/audit-logging": "enabled"},
+    },
+    "spec": {
+      "containers": [{"name": "model-server", "image": "registry.example.com/model:v1"}],
+    },
+  },
+}
+
+input_review_credential_plain = {
+  "object": {
+    "metadata": {"name": "ai-model-pod"},
+    "spec": {
+      "containers": [{
+        "name": "model-server",
+        "image": "registry.example.com/model:v1",
+        "env": [{"name": "OPENAI_API_KEY", "value": "sk-plaintextabc123"}],
+      }],
+    },
+  },
+}
+
+input_review_credential_secretref = {
+  "object": {
+    "metadata": {"name": "ai-model-pod"},
+    "spec": {
+      "containers": [{
+        "name": "model-server",
+        "image": "registry.example.com/model:v1",
+        "env": [{
+          "name": "OPENAI_API_KEY",
+          "valueFrom": {"secretKeyRef": {"name": "openai-creds", "key": "api-key"}},
+        }],
+      }],
+    },
+  },
+}
+
+input_review_credential_init_plain = {
+  "object": {
+    "metadata": {"name": "ai-model-pod"},
+    "spec": {
+      "containers": [{"name": "model-server", "image": "registry.example.com/model:v1"}],
+      "initContainers": [{
+        "name": "init-loader",
+        "image": "registry.example.com/init:v1",
+        "env": [{"name": "LOADER_API_KEY", "value": "sk-plaintextinit"}],
+      }],
+    },
+  },
+}
+
+input_review_fully_compliant = {
+  "object": {
+    "metadata": {
+      "name": "ai-model-pod",
+      "annotations": {"ai-controls/audit-logging": "enabled"},
+      "labels": {"workload-type": "ai-model"},
+    },
+    "spec": {
+      "containers": [{
+        "name": "model-server",
+        "image": "registry.example.com/model:v1@sha256:abc123def456",
+        "env": [{
+          "name": "MODEL_API_KEY",
+          "valueFrom": {"secretKeyRef": {"name": "model-creds", "key": "api-key"}},
+        }],
+      }],
+    },
+  },
+}


### PR DESCRIPTION
## Summary

This PR adds three new general validation policies designed to govern AI model workloads running in Kubernetes. As AI services (LLM inference servers, embedding pipelines, model-serving deployments) become first-class Kubernetes workloads, teams need admission controls that go beyond generic pod policies. These three policies address the specific security posture of AI workloads.

### Policies

**`k8sairequiredcontrols`** — Enforces two controls on AI workload pods:
1. Requires specified annotations to be present (e.g. `ai-controls/audit-logging: enabled`) so operators can verify audit/observability is declared at admission time
2. Checks that environment variable names matching configurable regex patterns (e.g. `.*_API_KEY$`, `.*_TOKEN$`) use `secretKeyRef` rather than plain-text `value` fields — preventing model API credentials from being baked into pod specs

**`k8saiapprovedmodelregistry`** — Requires AI workload containers to pull images only from operator-approved model registry prefixes. Optionally enforces digest pinning (`@sha256:`) to prevent floating-tag substitution attacks on model images.

**`k8sainetworkegress`** — Enforces network egress hygiene on AI workload pods:
1. Optionally blocks `spec.hostNetwork=true`, which bypasses all `NetworkPolicy` egress rules
2. Requires pods to carry operator-specified labels (e.g. `network-policy/ai-egress: enforced`) that serve as `NetworkPolicy` selectors — ensuring a matching `NetworkPolicy` exists before the pod is admitted

### Implementation

Each policy ships with the full required structure:
- `src/general/<name>/` — `constraint.tmpl`, `src.rego`, `src.cel`, `src_test.rego`
- `library/general/<name>/` — `template.yaml`, `kustomization.yaml`, `suite.yaml`, `samples/`

All three policies implement **dual-engine support (Rego + CEL / K8sNativeValidation)** per the contributing guidelines.

**OPA unit tests: 26 total — all passing**
- `k8sairequiredcontrols`: 10 tests
- `k8saiapprovedmodelregistry`: 7 tests
- `k8sainetworkegress`: 9 tests

### Constraints use `labelSelector` for scoping

The sample constraints target pods with `workload-type: ai-model` via `match.labelSelector`. The Rego and CEL implementations themselves are label-agnostic — operators can scope to any label or namespace in their own constraints.

## Test plan

- [x] `opa test src/general/airequiredcontrols/ --verbose` — 10 PASS
- [x] `opa test src/general/aiapprovedmodelregistry/ --verbose` — 7 PASS
- [x] `opa test src/general/ainetworkegress/ --verbose` — 9 PASS
- [ ] `make generate` produces no diff in `library/*/template.yaml`
- [x] `make validate` passes
- [x] `make require-suites` passes
- [x] `make verify-gator-dockerized POLICY_ENGINE=rego` passes
- [x] `make verify-gator-dockerized POLICY_ENGINE=cel` passes